### PR TITLE
AI-2888: Add GSD plan files for Days 1-2 launch sprint

### DIFF
--- a/.planning/phases/01-deploy-critical-fixes/01-01-PLAN.md
+++ b/.planning/phases/01-deploy-critical-fixes/01-01-PLAN.md
@@ -1,0 +1,28 @@
+# Fix Home.tsx Landing Page
+
+## Goal
+Replace the placeholder scaffold `Home.tsx` (spinning Loader2 + "Example Page" text) with a real landing page for Bottleneck Bots. Since `AppRouter.tsx` routes `/` to the existing `LandingPage` component (which is already a full marketing page with hero, features, pricing, trust badges, etc.), the fix is to **delete or gut `Home.tsx`** so it cannot confuse developers or be accidentally routed to, and ensure `LandingPage.tsx` is the sole landing experience.
+
+## Context
+- `client/src/pages/Home.tsx` is dead code -- `AppRouter.tsx` line 67-72 routes `/` to `<LandingPage>` (from `client/src/components/LandingPage.tsx`), not `Home`.
+- `Home.tsx` imports `useAuth` from `@/_core/hooks/useAuth` (the wrong path -- see C8 in UX audit).
+- `LandingPage.tsx` already has: hero section, feature highlights, pricing tiers, CTAs, trust badges, exit intent popup, cookie consent, live chat, countdown timer, conversion tracking.
+- The `Routes.tsx` dashboard router maps `/` to `DashboardHome` (shown only when inside `DashboardLayout`).
+
+## Tasks
+- [ ] Task 1 -- `client/src/pages/Home.tsx` -- Delete this file entirely. It is unreachable dead code that references a broken import path and serves no purpose. The landing page is `LandingPage.tsx`.
+- [ ] Task 2 -- `client/src/components/LandingPage.tsx` -- Verify the existing landing page includes all required sections: hero with value prop ("AI Agents for Your Agency"), features grid, pricing tiers matching STARTER/GROWTH/WHITELABEL, CTA buttons linking to `/signup`. Fix any missing sections.
+- [ ] Task 3 -- `client/src/components/LandingPage.tsx` -- Ensure the pricing section references the actual subscription tier names and limits from the Stripe/subscription system. Cross-reference with `client/src/components/subscription/UpgradeModal.tsx` for tier names and pricing.
+- [ ] Task 4 -- `client/src/components/AppRouter.tsx` -- Remove the `Home` lazy import (line 6 area if it exists) since `Home.tsx` is being deleted. Verify no other file imports `Home.tsx`.
+- [ ] Task 5 -- Global search for any remaining imports of `pages/Home` and remove them.
+
+## Verification
+- [ ] `grep -r "pages/Home" client/src/` returns zero results
+- [ ] App loads at `/` and shows the LandingPage with hero, features, pricing, CTAs
+- [ ] No console errors on the landing page
+- [ ] `pnpm check` passes (no broken imports)
+
+## Files to Modify
+- client/src/pages/Home.tsx (DELETE)
+- client/src/components/LandingPage.tsx (verify/enhance)
+- client/src/components/AppRouter.tsx (remove dead import if present)

--- a/.planning/phases/01-deploy-critical-fixes/01-02-PLAN.md
+++ b/.planning/phases/01-deploy-critical-fixes/01-02-PLAN.md
@@ -1,0 +1,56 @@
+# Fix Dual Routing Conflict and Login Navigation
+
+## Goal
+Resolve the conflicting dual routing system (`AppRouter.tsx` vs `Routes.tsx`), fix the Login page using `window.location.href` instead of SPA navigation, and standardize the `useAuth` import path across the entire app.
+
+## Context
+Two routing systems exist:
+- `client/src/components/AppRouter.tsx` -- handles public routes (`/`, `/login`, `/signup`, `/features`, `/dashboard`) with auth gating and lazy loading. Routes `/dashboard` to the `<Dashboard>` component.
+- `client/src/components/Routes.tsx` -- handles dashboard-internal routes (`/`, `/agent`, `/training`, etc.) wrapped in `DashboardLayout`. Routes `/` to `DashboardHome`.
+
+The relationship: `AppRouter` renders at the app root. When user hits `/dashboard`, AppRouter renders `<Dashboard>`. But `Routes.tsx` is used *inside* Dashboard to handle sub-routes. The conflict: both define a `/` route -- AppRouter's `/` shows LandingPage, Routes' `/` shows DashboardHome. This works because Routes is only mounted inside the `/dashboard` path context, BUT Wouter routes are absolute, not relative. So `Routes.tsx` defining `path="/"` actually matches the root `/`, not `/dashboard/`.
+
+Two `useAuth` hooks exist:
+- `client/src/_core/hooks/useAuth.ts` -- framework-level hook with redirect support, uses `trpc.useUtils()` for cache management.
+- `client/src/hooks/useAuth.ts` -- app-level hook with `login()`, `signup()`, `logout()` functions using REST API calls, toast notifications, and Wouter navigation.
+
+Login.tsx (line 11-14) uses `window.location.href` for navigation, causing full page reloads.
+
+## Tasks
+- [ ] Task 1 -- `client/src/components/Routes.tsx` -- Fix the route paths to be relative to the dashboard context. Since Wouter doesn't support nested routers natively, either:
+  - (a) Prefix all routes with `/dashboard` (e.g., `path="/dashboard"` instead of `path="/"`, `path="/dashboard/agent"` instead of `path="/agent"`), OR
+  - (b) Use Wouter's `Router` base prop to set the base path to `/dashboard`, OR
+  - (c) Consolidate into AppRouter with all routes defined there.
+  Recommended: Option (a) is simplest and most explicit.
+- [ ] Task 2 -- `client/src/components/DashboardLayout.tsx` -- Update sidebar `menuItems` paths to match the new dashboard-prefixed routes (e.g., `path: "/dashboard"` instead of `path: "/"`, `path: "/dashboard/agent"` instead of `path: "/agent"`).
+- [ ] Task 3 -- `client/src/components/AppRouter.tsx` -- Update the `/dashboard` route to use a wildcard match (`/dashboard/:rest*`) so it catches all dashboard sub-routes and renders `<Dashboard>` (which in turn renders Routes).
+- [ ] Task 4 -- `client/src/pages/Login.tsx` -- Replace the `navigateTo` function (lines 11-14) with Wouter's `useLocation` hook:
+  ```tsx
+  import { useLocation } from 'wouter';
+  // ...
+  const [, setLocation] = useLocation();
+  ```
+  Replace all `navigateTo('/path')` calls with `setLocation('/path')`. Remove the `window.history.pushState` + `window.location.href` hack.
+- [ ] Task 5 -- `client/src/pages/Login.tsx` -- Change `useAuth` import from `'@/hooks/useAuth'` to match the canonical path. Decide which hook is canonical:
+  - `@/hooks/useAuth` is the app-level one with `login()`, `signup()`, `logout()` -- this is what Login/Signup need.
+  - `@/_core/hooks/useAuth` is the framework-level one used by DashboardLayout.
+  Both are needed but serve different purposes. Standardize: keep both but ensure no file accidentally imports the wrong one. Login and Signup should use `@/hooks/useAuth`. DashboardLayout should use `@/_core/hooks/useAuth`.
+- [ ] Task 6 -- `client/src/pages/Signup.tsx` -- Verify it imports `useAuth` from `@/hooks/useAuth` (it already does per audit line 8). Ensure it also uses `setLocation` from Wouter, not `window.location`.
+- [ ] Task 7 -- `client/src/components/DashboardLayout.tsx` -- Verify the `location === item.path` comparison on line 246 works correctly with the new prefixed paths.
+
+## Verification
+- [ ] Navigate to `/` -- shows LandingPage (not DashboardHome)
+- [ ] Navigate to `/dashboard` while logged in -- shows DashboardHome inside DashboardLayout
+- [ ] Navigate to `/dashboard/agent` -- shows AgentDashboard inside DashboardLayout
+- [ ] Sidebar links navigate correctly without full page reloads
+- [ ] Login form submission navigates to dashboard via SPA (no full page reload)
+- [ ] "Sign up" link on Login page navigates to `/signup` via SPA
+- [ ] "Forgot password?" link navigates via SPA
+- [ ] `pnpm check` passes
+
+## Files to Modify
+- client/src/components/AppRouter.tsx
+- client/src/components/Routes.tsx
+- client/src/components/DashboardLayout.tsx
+- client/src/pages/Login.tsx
+- client/src/pages/Signup.tsx

--- a/.planning/phases/01-deploy-critical-fixes/01-03-PLAN.md
+++ b/.planning/phases/01-deploy-critical-fixes/01-03-PLAN.md
@@ -1,0 +1,38 @@
+# Fix Dashboard Hardcoded Tier and Stats
+
+## Goal
+Remove the hardcoded `userTier="WHITELABEL"` and `credits={1000}` props from AppRouter, and replace hardcoded zero values in DashboardHome with real data from the subscription and stats APIs.
+
+## Context
+- `AppRouter.tsx` line 108: `<Dashboard userTier="WHITELABEL" credits={1000} />` -- every user gets WHITELABEL tier with 1000 credits regardless of actual subscription.
+- `Dashboard.tsx` line 53-56: accepts `DashboardProps { userTier: string; credits: number; }` and passes them through to child components.
+- `DashboardHome.tsx` already fetches `trpc.subscription.getMySubscription` (line 16-18) and uses it for execution stats (line 74-77) and the SubscriptionUsageCard. However, three stat cards are hardcoded zeros:
+  - "Active Workflows" (line 88) -- hardcoded `0`
+  - "Team Members" (line 99) -- hardcoded `1`
+  - "Integrations" (line 110) -- hardcoded `0`
+- `workflowExecution.ts` `executeWorkflow()` function (lines 311-340) returns mock data with "PLACEHOLDER" comments.
+- `useBrowserAutomation.ts` passes `workflowId: 1` hardcoded (lines 52, 120).
+
+## Tasks
+- [ ] Task 1 -- `client/src/components/AppRouter.tsx` -- Remove the hardcoded props from the Dashboard component. Instead of `<Dashboard userTier="WHITELABEL" credits={1000} />`, render `<Dashboard />` with no props. The Dashboard component should fetch its own subscription data.
+- [ ] Task 2 -- `client/src/components/Dashboard.tsx` -- Remove the `DashboardProps` interface and the `userTier`/`credits` parameters. Instead, fetch subscription data internally using `trpc.subscription.getMySubscription.useQuery()`. Pass the fetched tier/credits to any child components that need them, or let child components fetch their own data (DashboardHome already does this).
+- [ ] Task 3 -- `client/src/pages/DashboardHome.tsx` -- Replace the three hardcoded stat cards (lines 82-113) with real data:
+  - "Active Workflows": Add a tRPC query `trpc.workflows.list.useQuery()` or similar and count active ones. If no such endpoint exists, add a `TODO` comment and show "Coming soon" instead of a misleading `0`.
+  - "Team Members": Query team members from the subscription data (`subscriptionQuery.data?.limits?.maxTeamMembers` or similar), or show `1` with the user's actual count if a team endpoint exists.
+  - "Integrations": Query connected integrations count, or show a "Connect" CTA button instead of a misleading `0`.
+- [ ] Task 4 -- `client/src/services/workflowExecution.ts` -- Replace the mock `executeWorkflow` function (lines 311-340) with a real tRPC call. It should call the backend `workflows.execute` mutation. If the backend endpoint isn't ready, throw an explicit error ("Workflow execution not yet available") instead of returning fake success data.
+- [ ] Task 5 -- `client/src/hooks/useBrowserAutomation.ts` -- Remove the hardcoded `workflowId: 1` on lines 52 and 120. Accept workflowId as a parameter to `executeStep` and `executePlan`, or derive it from the current context. If no workflow ID is available, throw an error rather than silently using ID 1.
+
+## Verification
+- [ ] Login as a new user -- Dashboard shows actual subscription tier (likely STARTER or free), not WHITELABEL
+- [ ] Credits shown match actual subscription credits
+- [ ] Dashboard stat cards show real data or appropriate "Coming soon" states
+- [ ] Workflow "Test Run" in WorkflowBuilder does NOT return fake success -- either calls real backend or shows clear "not available" state
+- [ ] `pnpm check` passes
+
+## Files to Modify
+- client/src/components/AppRouter.tsx
+- client/src/components/Dashboard.tsx
+- client/src/pages/DashboardHome.tsx
+- client/src/services/workflowExecution.ts
+- client/src/hooks/useBrowserAutomation.ts

--- a/.planning/phases/01-deploy-critical-fixes/01-04-PLAN.md
+++ b/.planning/phases/01-deploy-critical-fixes/01-04-PLAN.md
@@ -1,0 +1,63 @@
+# Fix Remaining Critical UX Bugs
+
+## Goal
+Fix all remaining CRITICAL and select HIGH-priority UX issues from the audit that are not covered by plans 01-01 through 01-03: Google Ads placeholder ID, dead Support link, simulated upload progress, and inline 404 fallback.
+
+## Context
+From UX audit `docs/UX-AUDIT-2026-03-16.md`:
+- **C6**: `client/src/lib/analytics.ts` line 78 -- Google Ads conversion ID is `AW-XXXXXXXXX` (placeholder).
+- **H3**: `client/src/components/DashboardLayout.tsx` line 57 -- Sidebar "Support" link routes to `/support` which has no route, showing unstyled 404.
+- **H8**: `client/src/components/Routes.tsx` lines 62-69 -- Inline 404 fallback is bare HTML instead of using the existing `NotFound.tsx` component.
+- **H10**: `client/src/pages/Training.tsx` lines 126-183 -- Upload progress is simulated with fixed increments (10%, 30%, 70%, 100%) instead of tracking real upload progress.
+- **H5**: `client/src/hooks/useAgentExecution.ts` lines 47-50 -- `setCurrentTask` is a dead no-op placeholder.
+- **H9**: `client/src/pages/BrowserSessions.tsx` lines 227-229 -- "New Session" button just shows a toast instead of navigating.
+
+## Tasks
+- [ ] Task 1 -- `client/src/lib/analytics.ts` line 78 -- Replace `AW-XXXXXXXXX` with an environment variable reference: `import.meta.env.VITE_GOOGLE_ADS_ID || 'AW-XXXXXXXXX'`. This way the placeholder only fires in dev and the real ID is set via Vercel env vars. Also add a guard: if the ID is still the placeholder, skip the conversion call entirely to avoid sending garbage data to Google.
+- [ ] Task 2 -- `client/src/components/DashboardLayout.tsx` line 57 -- Change the Support sidebar item from `path: "/support"` to either:
+  - (a) An external link to a support email/form: `path: "mailto:support@bottleneckbots.com"` or an external URL, OR
+  - (b) Route to `/settings` with a support tab, OR
+  - (c) Remove the Support link entirely and add it back when a support page exists.
+  Recommended: Option (c) -- remove it and add a comment `// TODO: Add support page`.
+- [ ] Task 3 -- `client/src/components/Routes.tsx` lines 62-69 -- Replace the inline 404 fallback with the existing `NotFound.tsx` component:
+  ```tsx
+  import NotFound from '@/pages/NotFound';
+  // ...
+  <Route component={NotFound} />
+  ```
+- [ ] Task 4 -- `client/src/pages/Training.tsx` -- Fix simulated upload progress. The current approach manually sets progress at 10%, 30%, 70%, 100%. Instead, since the upload goes through tRPC mutation (not a raw fetch), we can't get real byte-level progress. However, we should:
+  - Show an indeterminate progress state during the tRPC mutation (use `uploadMutation.isPending`).
+  - Remove the fake percentage-based progress bar.
+  - Replace with a spinner + "Uploading..." text during mutation, then "Processing..." while server-side RAG indexing runs.
+  - Only show the success toast on `onSuccess`.
+- [ ] Task 5 -- `client/src/hooks/useAgentExecution.ts` lines 47-50 -- Either implement `setCurrentTask` properly by wiring it to the agent store, or remove the dead function and update any callers. Check if anything calls `setCurrentTask`:
+  ```bash
+  grep -r "setCurrentTask" client/src/
+  ```
+  If nothing calls it, remove it. If something does, wire it to `useAgentStore`.
+- [ ] Task 6 -- `client/src/pages/BrowserSessions.tsx` lines 227-229 -- Replace the toast-only "New Session" handler with actual navigation to the agent page:
+  ```tsx
+  const handleNewSession = () => {
+    setLocation('/agent'); // or '/dashboard/agent' after routing fix
+  };
+  ```
+  Import `useLocation` from `wouter` if not already imported.
+- [ ] Task 7 -- `client/src/components/AppRouter.tsx` lines 116-129 -- Replace the inline 404 with `NotFound` component for consistency (same as Task 3 but for the public router).
+
+## Verification
+- [ ] Google Ads tracking does not fire with placeholder ID in production (check console for analytics logs)
+- [ ] Sidebar has no dead "Support" link (or it navigates to a real destination)
+- [ ] Hitting an unknown route inside the dashboard shows the styled NotFound page
+- [ ] Hitting an unknown public route shows the styled NotFound page
+- [ ] Training page upload shows appropriate loading state (no fake percentages)
+- [ ] BrowserSessions "New Session" button navigates to agent page
+- [ ] `pnpm check` passes
+
+## Files to Modify
+- client/src/lib/analytics.ts
+- client/src/components/DashboardLayout.tsx
+- client/src/components/Routes.tsx
+- client/src/components/AppRouter.tsx
+- client/src/pages/Training.tsx
+- client/src/hooks/useAgentExecution.ts
+- client/src/pages/BrowserSessions.tsx

--- a/.planning/phases/02-agent-training-ux/02-01-PLAN.md
+++ b/.planning/phases/02-agent-training-ux/02-01-PLAN.md
@@ -1,0 +1,79 @@
+# Agent Training Interface Enhancement
+
+## Goal
+Enhance the existing `Training.tsx` page from a document-upload-only page into a comprehensive agent training interface with tabs for Documents, Workflows, Skills, and Behavior configuration. Users should be able to define what their agent does (agency tasks: marketing campaigns, lead follow-up, GHL automations, content creation) and connect uploaded SOPs/docs to the agent's knowledge base.
+
+## Context
+- `client/src/pages/Training.tsx` currently has: file upload with drag-and-drop, URL ingestion, category/platform selectors, documents table with CRUD, stats cards. Uses `trpc.rag.listSources`, `trpc.rag.uploadDocument`, `trpc.rag.ingestUrl`, `trpc.rag.deleteSource`.
+- `server/services/knowledge.service.ts` handles knowledge management.
+- `server/services/rag.service.ts` handles RAG pipeline (document parsing, chunking, embedding, vector search).
+- `server/services/agentOrchestrator.service.ts` is the core agent execution loop.
+- `client/src/pages/AgentDashboard.tsx` imports `TaskTemplates` from `@/components/agent` -- task templates already exist in the agent UI.
+- `drizzle/schema.ts` has `automationTemplates` table with: id, name, description, steps (JSON), category, createdAt, updatedAt.
+- No workflow training schema exists yet -- only document-based training.
+
+## Tasks
+- [ ] Task 1 -- `client/src/pages/Training.tsx` -- Wrap existing content in a Tabs component (from `@/components/ui/tabs`). Create four tabs:
+  - **Documents** (default) -- current upload/URL ingestion/documents table content
+  - **Workflows** -- new workflow training form
+  - **Skills** -- agent capability toggles
+  - **Behavior** -- agent personality and escalation rules
+  Move all existing upload/document code into the "Documents" TabsContent.
+
+- [ ] Task 2 -- `client/src/pages/Training.tsx` -- Build the "Workflows" tab content:
+  - Form to define a workflow training sequence:
+    - Workflow name (Input)
+    - Description (Textarea)
+    - Platform target (Select: GHL, Email, SMS, Browser, API)
+    - Steps list (ordered, each step has: step number, action description (text), expected input, expected output, platform action type)
+    - Add step / remove step buttons
+  - Save button that stores workflow training config via a new tRPC mutation
+  - List of saved workflow trainings below the form
+
+- [ ] Task 3 -- `server/api/routers/rag.ts` (or new `server/api/routers/training.ts`) -- Add tRPC procedures for workflow training:
+  - `training.saveWorkflowConfig` -- saves a workflow training definition (name, description, platform, steps array)
+  - `training.listWorkflowConfigs` -- lists saved workflow configs for the current user
+  - `training.deleteWorkflowConfig` -- deletes a workflow config
+  Store in a new DB table or extend the existing `automationTemplates` table with a `type` column to distinguish templates from training configs.
+
+- [ ] Task 4 -- `client/src/pages/Training.tsx` -- Build the "Skills" tab content:
+  - Grid of toggle cards for agent capabilities:
+    - Browser Automation (BrowserBase/Stagehand)
+    - GoHighLevel API (contact management, workflows, campaigns)
+    - Email (send/receive/draft)
+    - SMS (send via GHL or Twilio)
+    - Voice Calling (via VAPI)
+    - File Creation (PDF reports, CSV exports)
+    - Web Research (scraping, data gathering)
+    - Content Creation (blog posts, social media)
+  - Each card: icon, name, description, toggle switch, optional permission level (read-only / read-write)
+  - Persist via tRPC mutation to user preferences or agent config
+
+- [ ] Task 5 -- `client/src/pages/Training.tsx` -- Build the "Behavior" tab content:
+  - Agent personality selector (Professional, Friendly, Technical, Custom)
+  - Custom instructions textarea (free-form instructions for the agent)
+  - Escalation rules:
+    - When to escalate to human (error threshold, sensitive actions, unknown tasks)
+    - Escalation method (email notification, Slack, in-app notification)
+  - Response style (Concise, Detailed, Step-by-step)
+  - Save button persisting to user/agent config
+
+- [ ] Task 6 -- `client/src/pages/Training.tsx` -- Update the stats cards at the top to reflect all training dimensions:
+  - Documents count (existing)
+  - Chunks count (existing)
+  - Replace hardcoded "RAG Enabled" with actual status check
+  - Replace hardcoded "Active Status" with workflow training count
+
+## Verification
+- [ ] Training page loads with 4 tabs: Documents, Workflows, Skills, Behavior
+- [ ] Documents tab retains all existing upload/ingestion/delete functionality
+- [ ] Workflows tab: can add workflow name + steps, save, see it listed
+- [ ] Skills tab: toggles render, can be toggled on/off
+- [ ] Behavior tab: personality/instructions can be set and saved
+- [ ] `pnpm check` passes
+
+## Files to Modify
+- client/src/pages/Training.tsx (major refactor into tabs)
+- server/api/routers/rag.ts OR new server/api/routers/training.ts (new endpoints)
+- server/routers.ts (register new router if created)
+- drizzle/schema.ts (extend automationTemplates or add training config table)

--- a/.planning/phases/02-agent-training-ux/02-02-PLAN.md
+++ b/.planning/phases/02-agent-training-ux/02-02-PLAN.md
@@ -1,0 +1,94 @@
+# Task Template System
+
+## Goal
+Create a pre-built task template system for common agency operations. Users can browse templates by category, preview details, fill in required inputs, and launch tasks from templates. Templates are stored in the database and seeded with initial agency-relevant options.
+
+## Context
+- `server/api/routers/templates.ts` already has a `templatesRouter` with `getAll` (public) and `execute` (protected) procedures.
+- `drizzle/schema.ts` has `automationTemplates` table: id, name, description, steps (JSON string), category (varchar 50), createdAt, updatedAt.
+- `client/src/pages/AgentDashboard.tsx` line 8: already imports `TaskTemplates` from `@/components/agent`.
+- `client/src/components/agent/` directory contains agent UI components including task template display.
+- The existing template schema is minimal -- needs extension for required inputs, estimated duration, credit cost, and platform requirements.
+
+## Tasks
+- [ ] Task 1 -- `drizzle/schema.ts` -- Extend the `automationTemplates` table with new columns:
+  ```
+  requiredInputs: text("required_inputs")    // JSON array of { name, type, label, placeholder, required }
+  estimatedDuration: integer("estimated_duration")  // seconds
+  creditCost: integer("credit_cost")          // estimated credits
+  platform: varchar("platform", { length: 50 })    // 'ghl', 'browser', 'email', 'api', 'multi'
+  icon: varchar("icon", { length: 50 })       // lucide icon name
+  isActive: boolean("is_active").default(true)
+  usageCount: integer("usage_count").default(0)
+  ```
+  Run `pnpm db:generate` after schema changes.
+
+- [ ] Task 2 -- Create seed script `server/seeds/seed-templates.ts` -- Seed the following templates:
+
+  **Marketing category:**
+  - "Social Media Post Scheduler" -- schedule posts across platforms
+  - "Ad Campaign Setup" -- create and configure ad campaigns in GHL
+  - "Content Calendar Generator" -- generate a month of content ideas
+
+  **Sales category:**
+  - "Lead Follow-Up Sequence" -- automated follow-up for new leads via GHL
+  - "Pipeline Report Generator" -- export pipeline data to CSV/PDF
+  - "Proposal Draft Generator" -- create proposal from template + lead data
+
+  **Operations category:**
+  - "Client Onboarding Workflow" -- add client to GHL, create pipeline, send welcome
+  - "Weekly Report Generator" -- compile weekly metrics report
+  - "Invoice Reminder Sequence" -- automated invoice follow-up
+
+  **GHL category:**
+  - "Add Contact to Pipeline" -- create GHL contact, add to pipeline stage
+  - "Launch Email Campaign" -- select contacts, create campaign, send via GHL
+  - "Bulk Tag Contacts" -- tag contacts by criteria in GHL
+  - "Export Pipeline Report" -- pull GHL pipeline data, generate CSV
+  - "Create GHL Workflow" -- build automation workflow in GHL
+
+  Each template includes: name, description, category, steps (JSON array of step objects), requiredInputs, estimatedDuration, creditCost, platform.
+
+- [ ] Task 3 -- `server/api/routers/templates.ts` -- Extend the router with:
+  - `getByCategory` -- filter templates by category
+  - `getById` -- get single template with full details
+  - `createFromTemplate` -- create a task instance pre-filled from template + user inputs
+  - `search` -- search templates by name/description
+  - `incrementUsage` -- increment usage count when a template is executed
+
+- [ ] Task 4 -- Create `client/src/pages/Templates.tsx` -- New page for browsing templates:
+  - Category filter bar (All, Marketing, Sales, Operations, GHL)
+  - Search input for filtering by name
+  - Grid of template cards showing: icon, name, description, category badge, estimated duration, credit cost
+  - Click card opens detail modal/sheet with:
+    - Full description
+    - Steps preview (ordered list)
+    - Required inputs form (dynamically generated from `requiredInputs`)
+    - "Run This Template" button
+    - Platform requirements indicator
+  - "Run This Template" calls `templates.createFromTemplate` with form values, then navigates to AgentDashboard to show execution
+
+- [ ] Task 5 -- `client/src/components/Routes.tsx` -- Add route for the Templates page: `path="/templates"` or `path="/dashboard/templates"` (depending on routing fix from 01-02).
+
+- [ ] Task 6 -- `client/src/components/DashboardLayout.tsx` -- Add "Templates" to the sidebar menu items:
+  ```tsx
+  { icon: LayoutTemplate, label: "Templates", path: "/templates" }
+  ```
+  Import `LayoutTemplate` from `lucide-react`.
+
+## Verification
+- [ ] Templates page renders with category filter and search
+- [ ] At least 14 seeded templates appear in the grid
+- [ ] Clicking a template shows detail modal with inputs form
+- [ ] Filling inputs and clicking "Run" creates a task (or shows appropriate feedback)
+- [ ] Sidebar shows Templates link and navigates correctly
+- [ ] `pnpm check` passes
+- [ ] `pnpm db:generate` generates migration for schema changes
+
+## Files to Modify
+- drizzle/schema.ts (extend automationTemplates)
+- server/seeds/seed-templates.ts (NEW -- seed script)
+- server/api/routers/templates.ts (extend router)
+- client/src/pages/Templates.tsx (NEW -- templates browser page)
+- client/src/components/Routes.tsx (add route)
+- client/src/components/DashboardLayout.tsx (add sidebar item)

--- a/.planning/phases/02-agent-training-ux/02-03-PLAN.md
+++ b/.planning/phases/02-agent-training-ux/02-03-PLAN.md
@@ -1,0 +1,95 @@
+# Agent Customization UI
+
+## Goal
+Let users configure their agent's personality, custom instructions, allowed tools/actions, and GHL permissions. Build on the existing `AgentDashboard.tsx` by adding an agent settings panel accessible from the dashboard.
+
+## Context
+- `client/src/pages/AgentDashboard.tsx` is the main agent interface. It imports from `@/components/agent` and `@/stores/agentStore`. Has tabbed interface (Task, Browser, Thinking), execution history sidebar, live browser view.
+- `server/services/agentPermissions.service.ts` exists -- handles agent permission gating (what actions agents can take).
+- `server/services/agentOrchestrator.service.ts` is the core agent loop -- it would consume agent config during execution.
+- `server/services/agentPrompts.ts` contains prompt templates for the agent.
+- `client/src/stores/agentStore.ts` manages agent UI state via Zustand.
+- No agent configuration UI currently exists -- the agent runs with default settings.
+
+## Tasks
+- [ ] Task 1 -- `drizzle/schema.ts` -- Add an `agentConfigs` table:
+  ```
+  agentConfigs = pgTable("agent_configs", {
+    id: serial("id").primaryKey(),
+    userId: integer("user_id").notNull().references(() => users.id),
+    name: varchar("name", { length: 100 }).default("My Agent"),
+    personality: varchar("personality", { length: 50 }).default("professional"),  // professional, friendly, technical, custom
+    customInstructions: text("custom_instructions"),
+    responseStyle: varchar("response_style", { length: 50 }).default("detailed"),  // concise, detailed, step-by-step
+    allowedTools: text("allowed_tools"),  // JSON array of tool names
+    ghlPermissions: text("ghl_permissions"),  // JSON: { contacts: 'read-write', workflows: 'read-only', ... }
+    escalationRules: text("escalation_rules"),  // JSON: { errorThreshold: 3, sensitiveActions: true, notifyMethod: 'email' }
+    maxConcurrentTasks: integer("max_concurrent_tasks").default(1),
+    isActive: boolean("is_active").default(true),
+    createdAt: timestamp("createdAt").defaultNow().notNull(),
+    updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+  })
+  ```
+  Run `pnpm db:generate` after.
+
+- [ ] Task 2 -- Create `server/api/routers/agentConfig.ts` -- New tRPC router:
+  - `agentConfig.get` -- get current user's agent config (or create default)
+  - `agentConfig.update` -- update agent config fields
+  - `agentConfig.resetToDefaults` -- reset to default config
+  Register in `server/routers.ts`.
+
+- [ ] Task 3 -- Create `client/src/components/agent/AgentSettingsPanel.tsx` -- Agent configuration panel with sections:
+
+  **General Settings:**
+  - Agent name (Input)
+  - Personality (Select: Professional, Friendly, Technical, Custom)
+  - Response style (Select: Concise, Detailed, Step-by-step)
+  - Custom instructions (Textarea -- shown when personality is "Custom" or always available as override)
+  - Max concurrent tasks (number input, 1-5)
+
+  **Tools & Permissions:**
+  - Grid of tool toggles with permission levels:
+    - Browser Automation: enabled/disabled
+    - GHL Contacts: off / read-only / read-write
+    - GHL Workflows: off / read-only / read-write
+    - GHL Campaigns: off / read-only / read-write
+    - GHL Pipelines: off / read-only / read-write
+    - Email: off / send-only / full
+    - SMS: off / send-only / full
+    - Voice Calling: enabled/disabled
+    - File Generation: enabled/disabled
+    - Web Research: enabled/disabled
+  Each tool shows an icon, name, description, and a segmented control for permission level.
+
+  **Escalation Rules:**
+  - Error threshold before escalation (number input, default 3)
+  - Escalate on sensitive actions (toggle -- e.g., deleting contacts, sending bulk messages)
+  - Notification method (Select: Email, In-app, Both)
+  - Auto-pause on repeated failures (toggle)
+
+  **Save/Reset buttons** at bottom.
+
+- [ ] Task 4 -- `client/src/pages/AgentDashboard.tsx` -- Add a Settings tab or gear icon button that opens the AgentSettingsPanel in a Sheet (slide-over panel) or as a new tab in the existing Tabs component.
+
+- [ ] Task 5 -- `server/services/agentOrchestrator.service.ts` -- Add a function `getAgentConfig(userId: number)` that fetches the agent config from DB and applies it during execution. The orchestrator should:
+  - Check `allowedTools` before using any tool
+  - Apply `customInstructions` to the system prompt
+  - Respect `ghlPermissions` when making GHL API calls
+  - Follow `escalationRules` when errors occur
+
+## Verification
+- [ ] Agent settings panel opens from AgentDashboard
+- [ ] Can set agent name, personality, instructions, response style
+- [ ] Can toggle tools on/off and set permission levels
+- [ ] Can configure escalation rules
+- [ ] Settings save successfully and persist across page reloads
+- [ ] `pnpm check` passes
+- [ ] `pnpm db:generate` generates migration
+
+## Files to Modify
+- drizzle/schema.ts (add agentConfigs table)
+- server/api/routers/agentConfig.ts (NEW)
+- server/routers.ts (register agentConfig router)
+- client/src/components/agent/AgentSettingsPanel.tsx (NEW)
+- client/src/pages/AgentDashboard.tsx (add settings access)
+- server/services/agentOrchestrator.service.ts (consume config)

--- a/.planning/phases/02-agent-training-ux/02-04-PLAN.md
+++ b/.planning/phases/02-agent-training-ux/02-04-PLAN.md
@@ -1,0 +1,74 @@
+# RAG-to-Execution Pipeline
+
+## Goal
+Connect the existing RAG training system (document upload, chunking, vector search) to the agent execution engine so that when a user trains their agent on SOPs and business documents, the agent can reference that knowledge during task execution. This closes the loop between "upload a doc" and "agent uses that doc."
+
+## Context
+- `server/services/rag.service.ts` handles the RAG pipeline: document parsing, text chunking, embedding generation, vector storage, and similarity search. Already has functions for ingesting documents and querying knowledge.
+- `server/services/knowledge.service.ts` manages the knowledge base -- CRUD for knowledge sources, chunk management, metadata.
+- `server/services/agentOrchestrator.service.ts` is the core agent loop that plans, decides, and executes steps. Currently does NOT query the RAG system during execution.
+- `server/services/agentPrompts.ts` contains prompt templates -- these need to be augmented with RAG context.
+- `drizzle/schema-rag.ts` defines the RAG schema (sources, chunks, embeddings).
+- `client/src/pages/Training.tsx` already has document upload working via `trpc.rag.uploadDocument`.
+- The agent orchestrator uses an LLM (Anthropic/Gemini) to plan and reason. RAG context should be injected into the planning prompt.
+
+## Tasks
+- [ ] Task 1 -- `server/services/agentOrchestrator.service.ts` -- Add RAG context retrieval to the agent planning phase. Before the agent generates a plan for a task:
+  1. Extract key terms from the user's task description
+  2. Call `ragService.searchKnowledge(query, userId, { limit: 5 })` to retrieve relevant document chunks
+  3. Inject retrieved chunks into the system prompt as "Business Knowledge Context"
+  4. Format: `## Relevant Business Knowledge\n\n${chunks.map(c => `### ${c.source}\n${c.content}`).join('\n\n')}`
+
+  Import the RAG service and call it in the `planTask()` or `executeTask()` method. The agent should see relevant SOP content when deciding how to execute a task.
+
+- [ ] Task 2 -- `server/services/agentPrompts.ts` -- Add a new prompt section template for RAG context injection:
+  ```typescript
+  export function buildRAGContextPrompt(chunks: Array<{ source: string; content: string; relevance: number }>): string {
+    if (!chunks.length) return '';
+    return `\n## Business Knowledge (from uploaded training documents)\n\n${
+      chunks.map((c, i) => `### Source: ${c.source}\n${c.content}`).join('\n\n---\n\n')
+    }\n\nUse the above knowledge to inform your approach. Follow any SOPs or processes described.`;
+  }
+  ```
+
+- [ ] Task 3 -- `server/services/rag.service.ts` -- Add a `searchByUserId` function (if not already present) that filters vector search results to only the current user's documents. Ensure tenant isolation so User A's documents don't leak into User B's agent context. Check if existing search already filters by userId -- if so, just verify.
+
+- [ ] Task 4 -- `server/api/routers/rag.ts` -- Add a `rag.testQuery` procedure that lets users test what knowledge the agent would retrieve for a given query. This gives users visibility into whether their uploaded docs are being used:
+  ```typescript
+  testQuery: protectedProcedure
+    .input(z.object({ query: z.string().min(1) }))
+    .query(async ({ input, ctx }) => {
+      const results = await ragService.searchKnowledge(input.query, ctx.user.id, { limit: 5 });
+      return { results };
+    })
+  ```
+
+- [ ] Task 5 -- `client/src/pages/Training.tsx` -- Add a "Test Knowledge" section (in the Documents tab or as a new tab):
+  - Input field: "Ask your knowledge base a question"
+  - Submit button
+  - Results display: show matched document chunks with source name, relevance score, and content preview
+  - Uses `trpc.rag.testQuery` to fetch results
+  This lets users verify their uploads are searchable before running agent tasks.
+
+- [ ] Task 6 -- `server/services/agentOrchestrator.service.ts` -- Add RAG context to the step-level execution as well (not just planning). When the agent is executing a step and encounters ambiguity or needs to make a decision, it should re-query the knowledge base with the specific step context. Add a `getStepContext(stepDescription: string, userId: number)` helper.
+
+- [ ] Task 7 -- Ensure the RAG retrieval is performant:
+  - Add a cache layer for frequently queried terms (use existing `server/services/cache.service.ts`)
+  - Limit context injection to max 2000 tokens of RAG content to avoid blowing up the prompt
+  - Add a `ragEnabled` flag in agent config (from 02-03) to let users disable RAG if needed
+
+## Verification
+- [ ] Upload a PDF SOP via Training page (e.g., "Client Onboarding SOP")
+- [ ] Use "Test Knowledge" to query "How do I onboard a new client?" -- relevant chunks returned
+- [ ] Start an agent task "Onboard new client John Smith" -- agent's thinking/planning shows it referenced the uploaded SOP
+- [ ] RAG results are scoped to the current user (tenant isolation)
+- [ ] Agent execution with no uploaded docs works normally (graceful empty RAG)
+- [ ] `pnpm check` passes
+
+## Files to Modify
+- server/services/agentOrchestrator.service.ts (add RAG context retrieval)
+- server/services/agentPrompts.ts (add RAG context prompt builder)
+- server/services/rag.service.ts (verify/add user-scoped search)
+- server/api/routers/rag.ts (add testQuery endpoint)
+- client/src/pages/Training.tsx (add test knowledge UI)
+- server/services/cache.service.ts (cache RAG queries)


### PR DESCRIPTION
## Summary
- Add GSD plan files for Day 1 (deploy + critical fixes) and Day 2 (agent training UX)
- Structured execution plans for the launch sprint

## Test plan
- [ ] Verify plan files are valid markdown
- [ ] Confirm phase structure matches ROADMAP.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)