### PR TITLE
AI-2881: Implement multi-location management

### DIFF
--- a/client/src/components/GHLConnectionCard.tsx
+++ b/client/src/components/GHLConnectionCard.tsx
@@ -4,9 +4,11 @@
  * Settings UI for GoHighLevel OAuth connection management.
  * - Connect/disconnect button
  * - Connection status badge
- * - Location selector dropdown
+ * - Location list with names (fetched from GHL API)
+ * - Active location indicator
+ * - Per-location config panel
  *
- * Linear: AI-2877
+ * Linear: AI-2877, AI-2881
  */
 
 import React from 'react';
@@ -31,36 +33,56 @@ import {
   RefreshCw,
   Unplug,
   Building2,
+  Star,
+  Settings,
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { LocationConfigPanel } from './ghl/LocationConfigPanel';
 
 export const GHLConnectionCard: React.FC = () => {
   const [disconnectLocationId, setDisconnectLocationId] = React.useState<string | null>(null);
+  const [configLocationId, setConfigLocationId] = React.useState<string | null>(null);
 
   // tRPC queries
   const { data: locations, refetch: refetchLocations } = trpc.ghl.listLocations.useQuery();
   const { data: configStatus } = trpc.ghl.configStatus.useQuery();
+  const utils = trpc.useUtils();
 
   // Disconnect mutation
   const disconnectMutation = trpc.ghl.disconnect.useMutation({
     onSuccess: (data) => {
       toast.success(data.message);
       setDisconnectLocationId(null);
+      setConfigLocationId(null);
       refetchLocations();
+      utils.ghl.getActiveLocation.invalidate();
     },
     onError: (error) => toast.error(`Failed to disconnect: ${error.message}`),
+  });
+
+  // Set active location mutation
+  const setActiveMutation = trpc.ghl.setActiveLocation.useMutation({
+    onSuccess: (data) => {
+      toast.success(`Set ${data.activeLocationId} as active location`);
+      refetchLocations();
+      utils.ghl.getActiveLocation.invalidate();
+    },
+    onError: (err) => toast.error(`Failed to set active: ${err.message}`),
   });
 
   const connectedLocations = locations || [];
   const isConfigured = configStatus?.configured ?? false;
 
   const handleConnect = () => {
-    // Redirect to GHL OAuth authorization endpoint
     window.location.href = '/api/ghl/oauth/authorize';
   };
 
   const handleDisconnect = (locationId: string) => {
     disconnectMutation.mutate({ locationId });
+  };
+
+  const handleSetActive = (locationId: string) => {
+    setActiveMutation.mutate({ locationId });
   };
 
   return (
@@ -109,42 +131,81 @@ export const GHLConnectionCard: React.FC = () => {
               {connectedLocations.map((loc) => (
                 <div
                   key={loc.locationId}
-                  className="flex items-center justify-between p-3 rounded-lg bg-slate-800/50 border border-slate-700"
+                  className={`flex items-center justify-between p-3 rounded-lg border ${
+                    loc.isActive
+                      ? 'bg-orange-500/5 border-orange-500/30'
+                      : 'bg-slate-800/50 border-slate-700'
+                  }`}
                 >
                   <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded bg-orange-500/20 flex items-center justify-center">
-                      <Building2 className="w-4 h-4 text-orange-400" />
+                    <div className={`w-8 h-8 rounded flex items-center justify-center ${
+                      loc.isActive ? 'bg-orange-500/20' : 'bg-slate-700/50'
+                    }`}>
+                      <Building2 className={`w-4 h-4 ${loc.isActive ? 'text-orange-400' : 'text-slate-400'}`} />
                     </div>
                     <div>
-                      <p className="text-sm font-medium text-white">
-                        Location: {loc.locationId}
+                      <p className="text-sm font-medium text-white flex items-center gap-2">
+                        {loc.name || `Location: ${loc.locationId}`}
+                        {loc.isActive && (
+                          <Badge className="bg-orange-500/20 text-orange-400 border-orange-500/30 text-[10px] px-1.5 py-0">
+                            <Star className="w-2.5 h-2.5 mr-0.5" />
+                            Active
+                          </Badge>
+                        )}
                       </p>
                       {loc.companyId && (
                         <p className="text-xs text-slate-400">Company: {loc.companyId}</p>
                       )}
-                      {loc.expiresAt && (
-                        <p className="text-xs text-slate-500">
-                          Token expires: {new Date(loc.expiresAt).toLocaleString()}
-                        </p>
-                      )}
+                      <p className="text-xs text-slate-500">ID: {loc.locationId}</p>
                     </div>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <Badge className="bg-green-500/20 text-green-400 border-green-500/30 text-xs">
-                      {loc.scopes.length} scope{loc.scopes.length !== 1 ? 's' : ''}
-                    </Badge>
+                  <div className="flex items-center gap-1.5">
+                    {loc.scopes.length > 0 && (
+                      <Badge className="bg-green-500/20 text-green-400 border-green-500/30 text-xs">
+                        {loc.scopes.length} scope{loc.scopes.length !== 1 ? 's' : ''}
+                      </Badge>
+                    )}
+                    {!loc.isActive && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-orange-400 hover:text-orange-300 hover:bg-orange-500/10 text-xs"
+                        onClick={() => handleSetActive(loc.locationId)}
+                        disabled={setActiveMutation.isPending}
+                      >
+                        <Star className="w-3.5 h-3.5 mr-1" />
+                        Set Active
+                      </Button>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-slate-400 hover:text-slate-300 hover:bg-slate-700/50"
+                      onClick={() =>
+                        setConfigLocationId(
+                          configLocationId === loc.locationId ? null : loc.locationId
+                        )
+                      }
+                    >
+                      <Settings className="w-3.5 h-3.5" />
+                    </Button>
                     <Button
                       variant="ghost"
                       size="sm"
                       className="text-red-400 hover:text-red-300 hover:bg-red-500/10"
                       onClick={() => setDisconnectLocationId(loc.locationId)}
                     >
-                      <Unplug className="w-4 h-4" />
+                      <Unplug className="w-3.5 h-3.5" />
                     </Button>
                   </div>
                 </div>
               ))}
             </div>
+          )}
+
+          {/* Per-location config panel (expandable) */}
+          {configLocationId && (
+            <LocationConfigPanel locationId={configLocationId} />
           )}
 
           {/* Connect button */}
@@ -168,7 +229,7 @@ export const GHLConnectionCard: React.FC = () => {
           <AlertDialogHeader>
             <AlertDialogTitle className="text-white">Disconnect GHL Location?</AlertDialogTitle>
             <AlertDialogDescription className="text-slate-400">
-              This will revoke access tokens and stop all automations for location{' '}
+              This will revoke access tokens, remove location configuration, and stop all automations for location{' '}
               <strong className="text-slate-300">{disconnectLocationId}</strong>.
               You can reconnect at any time.
             </AlertDialogDescription>

--- a/client/src/components/ghl/LocationConfigPanel.tsx
+++ b/client/src/components/ghl/LocationConfigPanel.tsx
@@ -1,0 +1,327 @@
+/**
+ * GHL Location Config Panel
+ *
+ * Per-location configuration UI for sync settings, tags, and preferences.
+ * Displayed within the Settings page when a location is selected.
+ *
+ * Linear: AI-2881
+ */
+
+import React from 'react';
+import { trpc } from '@/lib/trpc';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+import {
+  Settings,
+  RefreshCw,
+  Tag,
+  Clock,
+  Users,
+  Webhook,
+  Save,
+  Building2,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+interface LocationConfigPanelProps {
+  locationId: string;
+}
+
+export const LocationConfigPanel: React.FC<LocationConfigPanelProps> = ({ locationId }) => {
+  const { data: config, isLoading } = trpc.ghl.getLocationConfig.useQuery({ locationId });
+  const { data: locationDetails, isLoading: detailsLoading } = trpc.ghl.getLocationDetails.useQuery(
+    { locationId },
+    { retry: 1 }
+  );
+  const utils = trpc.useUtils();
+
+  const [localConfig, setLocalConfig] = React.useState<{
+    autoSyncContacts: boolean;
+    autoSyncOpportunities: boolean;
+    syncInterval: number;
+    defaultTags: string[];
+    contactImportEnabled: boolean;
+    webhookEnabled: boolean;
+  }>({
+    autoSyncContacts: false,
+    autoSyncOpportunities: false,
+    syncInterval: 30,
+    defaultTags: [],
+    contactImportEnabled: false,
+    webhookEnabled: false,
+  });
+
+  const [tagInput, setTagInput] = React.useState('');
+
+  // Sync local state from server config
+  React.useEffect(() => {
+    if (config?.syncConfig) {
+      const sc = config.syncConfig as Record<string, unknown>;
+      setLocalConfig({
+        autoSyncContacts: (sc.autoSyncContacts as boolean) ?? false,
+        autoSyncOpportunities: (sc.autoSyncOpportunities as boolean) ?? false,
+        syncInterval: (sc.syncInterval as number) ?? 30,
+        defaultTags: (sc.defaultTags as string[]) ?? [],
+        contactImportEnabled: (sc.contactImportEnabled as boolean) ?? false,
+        webhookEnabled: (sc.webhookEnabled as boolean) ?? false,
+      });
+    }
+  }, [config]);
+
+  const updateMutation = trpc.ghl.updateLocationConfig.useMutation({
+    onSuccess: () => {
+      toast.success('Location config saved');
+      utils.ghl.getLocationConfig.invalidate({ locationId });
+      utils.ghl.listLocations.invalidate();
+    },
+    onError: (err) => toast.error(`Failed to save: ${err.message}`),
+  });
+
+  const handleSave = () => {
+    updateMutation.mutate({
+      locationId,
+      syncConfig: localConfig,
+    });
+  };
+
+  const handleAddTag = () => {
+    const tag = tagInput.trim();
+    if (tag && !localConfig.defaultTags.includes(tag)) {
+      setLocalConfig((prev) => ({ ...prev, defaultTags: [...prev.defaultTags, tag] }));
+      setTagInput('');
+    }
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    setLocalConfig((prev) => ({
+      ...prev,
+      defaultTags: prev.defaultTags.filter((t) => t !== tag),
+    }));
+  };
+
+  if (isLoading || detailsLoading) {
+    return (
+      <Card className="bg-slate-900/50 border-slate-800">
+        <CardContent className="p-6">
+          <div className="flex items-center gap-2 text-slate-400">
+            <RefreshCw className="w-4 h-4 animate-spin" />
+            <span>Loading location config...</span>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="bg-slate-900/50 border-slate-800">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-lg bg-orange-500/20 flex items-center justify-center">
+            <Settings className="w-5 h-5 text-orange-400" />
+          </div>
+          <div>
+            <CardTitle className="text-white">
+              {locationDetails?.name || config?.locationName || locationId}
+            </CardTitle>
+            <CardDescription>
+              Per-location sync settings and configuration
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Location Details */}
+        {locationDetails && (
+          <div className="rounded-lg bg-slate-800/50 border border-slate-700 p-4 space-y-2">
+            <h4 className="text-sm font-medium text-slate-300 flex items-center gap-2">
+              <Building2 className="w-4 h-4" />
+              Location Details
+            </h4>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              {locationDetails.email && (
+                <div>
+                  <span className="text-slate-500">Email:</span>{' '}
+                  <span className="text-slate-300">{locationDetails.email}</span>
+                </div>
+              )}
+              {locationDetails.phone && (
+                <div>
+                  <span className="text-slate-500">Phone:</span>{' '}
+                  <span className="text-slate-300">{locationDetails.phone}</span>
+                </div>
+              )}
+              {locationDetails.city && (
+                <div>
+                  <span className="text-slate-500">City:</span>{' '}
+                  <span className="text-slate-300">
+                    {locationDetails.city}
+                    {locationDetails.state ? `, ${locationDetails.state}` : ''}
+                  </span>
+                </div>
+              )}
+              {locationDetails.timezone && (
+                <div>
+                  <span className="text-slate-500">Timezone:</span>{' '}
+                  <span className="text-slate-300">{locationDetails.timezone}</span>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Sync Settings */}
+        <div className="space-y-4">
+          <h4 className="text-sm font-medium text-slate-300">Sync Settings</h4>
+
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Users className="w-4 h-4 text-blue-400" />
+              <div>
+                <p className="text-sm text-white">Auto-sync Contacts</p>
+                <p className="text-xs text-slate-500">Automatically sync contacts from GHL</p>
+              </div>
+            </div>
+            <Switch
+              checked={localConfig.autoSyncContacts}
+              onCheckedChange={(checked) =>
+                setLocalConfig((prev) => ({ ...prev, autoSyncContacts: checked }))
+              }
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Users className="w-4 h-4 text-purple-400" />
+              <div>
+                <p className="text-sm text-white">Auto-sync Opportunities</p>
+                <p className="text-xs text-slate-500">Automatically sync pipeline opportunities</p>
+              </div>
+            </div>
+            <Switch
+              checked={localConfig.autoSyncOpportunities}
+              onCheckedChange={(checked) =>
+                setLocalConfig((prev) => ({ ...prev, autoSyncOpportunities: checked }))
+              }
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Users className="w-4 h-4 text-green-400" />
+              <div>
+                <p className="text-sm text-white">Contact Import</p>
+                <p className="text-xs text-slate-500">Allow importing contacts from this location</p>
+              </div>
+            </div>
+            <Switch
+              checked={localConfig.contactImportEnabled}
+              onCheckedChange={(checked) =>
+                setLocalConfig((prev) => ({ ...prev, contactImportEnabled: checked }))
+              }
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Webhook className="w-4 h-4 text-yellow-400" />
+              <div>
+                <p className="text-sm text-white">Webhook Events</p>
+                <p className="text-xs text-slate-500">Receive webhook events from this location</p>
+              </div>
+            </div>
+            <Switch
+              checked={localConfig.webhookEnabled}
+              onCheckedChange={(checked) =>
+                setLocalConfig((prev) => ({ ...prev, webhookEnabled: checked }))
+              }
+            />
+          </div>
+
+          {/* Sync Interval */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Clock className="w-4 h-4 text-cyan-400" />
+              <div>
+                <p className="text-sm text-white">Sync Interval</p>
+                <p className="text-xs text-slate-500">How often to sync (minutes)</p>
+              </div>
+            </div>
+            <Input
+              type="number"
+              min={5}
+              max={1440}
+              value={localConfig.syncInterval}
+              onChange={(e) =>
+                setLocalConfig((prev) => ({ ...prev, syncInterval: parseInt(e.target.value) || 30 }))
+              }
+              className="w-20 bg-slate-800 border-slate-700 text-white text-sm"
+            />
+          </div>
+        </div>
+
+        {/* Default Tags */}
+        <div className="space-y-3">
+          <h4 className="text-sm font-medium text-slate-300 flex items-center gap-2">
+            <Tag className="w-4 h-4" />
+            Default Tags
+          </h4>
+          <p className="text-xs text-slate-500">
+            Tags automatically applied to contacts synced from this location
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {localConfig.defaultTags.map((tag) => (
+              <Badge
+                key={tag}
+                className="bg-orange-500/20 text-orange-400 border-orange-500/30 cursor-pointer hover:bg-orange-500/30"
+                onClick={() => handleRemoveTag(tag)}
+              >
+                {tag} ×
+              </Badge>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <Input
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleAddTag()}
+              placeholder="Add a tag..."
+              className="bg-slate-800 border-slate-700 text-white text-sm"
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleAddTag}
+              className="border-slate-700 text-slate-300 hover:bg-slate-800"
+            >
+              Add
+            </Button>
+          </div>
+        </div>
+
+        {/* Save Button */}
+        <Button
+          className="w-full bg-orange-600 hover:bg-orange-700 text-white"
+          onClick={handleSave}
+          disabled={updateMutation.isPending}
+        >
+          {updateMutation.isPending ? (
+            <>
+              <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            <>
+              <Save className="w-4 h-4 mr-2" />
+              Save Configuration
+            </>
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default LocationConfigPanel;

--- a/client/src/components/ghl/LocationSwitcher.tsx
+++ b/client/src/components/ghl/LocationSwitcher.tsx
@@ -1,0 +1,97 @@
+/**
+ * GHL Location Switcher
+ *
+ * Dropdown component for switching between connected GHL locations.
+ * Shows the active location name and allows quick switching.
+ *
+ * Linear: AI-2881
+ */
+
+import React from 'react';
+import { trpc } from '@/lib/trpc';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { Building2, MapPin } from 'lucide-react';
+import { toast } from 'sonner';
+
+export const LocationSwitcher: React.FC<{ className?: string }> = ({ className }) => {
+  const { data: locations, isLoading: locationsLoading } = trpc.ghl.listLocations.useQuery();
+  const { data: activeLocation } = trpc.ghl.getActiveLocation.useQuery();
+  const utils = trpc.useUtils();
+
+  const setActiveMutation = trpc.ghl.setActiveLocation.useMutation({
+    onSuccess: (data) => {
+      toast.success(`Switched to location ${data.activeLocationId}`);
+      utils.ghl.getActiveLocation.invalidate();
+      utils.ghl.listLocations.invalidate();
+    },
+    onError: (err) => toast.error(`Failed to switch location: ${err.message}`),
+  });
+
+  const connectedLocations = locations || [];
+
+  if (locationsLoading) {
+    return (
+      <div className={`flex items-center gap-2 text-slate-400 text-sm ${className || ''}`}>
+        <Building2 className="w-4 h-4 animate-pulse" />
+        <span>Loading locations...</span>
+      </div>
+    );
+  }
+
+  if (connectedLocations.length === 0) {
+    return null;
+  }
+
+  const handleLocationChange = (locationId: string) => {
+    if (locationId === activeLocation?.locationId) return;
+    setActiveMutation.mutate({ locationId });
+  };
+
+  return (
+    <div className={`flex items-center gap-2 ${className || ''}`}>
+      <MapPin className="w-4 h-4 text-orange-400 shrink-0" />
+      <Select
+        value={activeLocation?.locationId || ''}
+        onValueChange={handleLocationChange}
+        disabled={setActiveMutation.isPending}
+      >
+        <SelectTrigger className="w-[220px] bg-slate-800/50 border-slate-700 text-white text-sm">
+          <SelectValue placeholder="Select a location" />
+        </SelectTrigger>
+        <SelectContent className="bg-slate-900 border-slate-700">
+          {connectedLocations.map((loc) => (
+            <SelectItem
+              key={loc.locationId}
+              value={loc.locationId}
+              className="text-white hover:bg-slate-800 focus:bg-slate-800"
+            >
+              <div className="flex items-center gap-2">
+                <Building2 className="w-3 h-3 text-orange-400" />
+                <span>{loc.name || loc.locationId}</span>
+                {loc.isActive && (
+                  <Badge className="bg-green-500/20 text-green-400 border-green-500/30 text-[10px] px-1 py-0 ml-1">
+                    Active
+                  </Badge>
+                )}
+              </div>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {connectedLocations.length > 1 && (
+        <Badge className="bg-slate-700/50 text-slate-400 border-slate-600 text-[10px]">
+          {connectedLocations.length} locations
+        </Badge>
+      )}
+    </div>
+  );
+};
+
+export default LocationSwitcher;

--- a/drizzle/0007_add-ghl-location-configs.sql
+++ b/drizzle/0007_add-ghl-location-configs.sql
@@ -1,0 +1,56 @@
+CREATE TABLE "ghl_location_configs" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"userId" integer NOT NULL,
+	"locationId" varchar(100) NOT NULL,
+	"locationName" text,
+	"companyId" varchar(100),
+	"isActive" boolean DEFAULT false NOT NULL,
+	"syncConfig" jsonb,
+	"locationDetails" jsonb,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "task_template_categories" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"slug" varchar(50) NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"description" text,
+	"icon" varchar(50),
+	"color" varchar(30),
+	"sortOrder" integer DEFAULT 0 NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "task_template_categories_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "task_templates" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"userId" integer,
+	"categorySlug" varchar(50) NOT NULL,
+	"name" varchar(200) NOT NULL,
+	"description" text,
+	"icon" varchar(50),
+	"color" varchar(30),
+	"taskType" varchar(50) DEFAULT 'custom' NOT NULL,
+	"priority" varchar(20) DEFAULT 'medium' NOT NULL,
+	"urgency" varchar(20) DEFAULT 'normal' NOT NULL,
+	"assignedToBot" boolean DEFAULT true NOT NULL,
+	"requiresHumanReview" boolean DEFAULT false NOT NULL,
+	"executionType" varchar(30) DEFAULT 'automatic' NOT NULL,
+	"steps" jsonb DEFAULT '[]' NOT NULL,
+	"executionConfig" jsonb,
+	"defaultTags" jsonb DEFAULT '[]',
+	"estimatedDuration" integer,
+	"difficulty" varchar(20) DEFAULT 'beginner',
+	"isSystem" boolean DEFAULT false NOT NULL,
+	"isPublished" boolean DEFAULT true NOT NULL,
+	"usageCount" integer DEFAULT 0 NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "ghl_location_configs" ADD CONSTRAINT "ghl_location_configs_userId_users_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "task_templates" ADD CONSTRAINT "task_templates_userId_users_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "task_templates_category_idx" ON "task_templates" USING btree ("categorySlug");--> statement-breakpoint
+CREATE INDEX "task_templates_user_idx" ON "task_templates" USING btree ("userId");--> statement-breakpoint
+CREATE INDEX "task_templates_system_idx" ON "task_templates" USING btree ("isSystem");

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -155,6 +155,51 @@ export const integrations = pgTable("integrations", {
   updatedAt: timestamp("updatedAt").defaultNow().notNull(),
 });
 
+// ========================================
+// GHL LOCATION CONFIGS (AI-2881)
+// ========================================
+
+/**
+ * Per-location configuration for GHL multi-location accounts.
+ * Stores location metadata, sync preferences, and per-location settings.
+ */
+export const ghlLocationConfigs = pgTable("ghl_location_configs", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  locationId: varchar("locationId", { length: 100 }).notNull(),
+  /** Cached location name from GHL API */
+  locationName: text("locationName"),
+  /** Cached company ID */
+  companyId: varchar("companyId", { length: 100 }),
+  /** Whether this is the user's active/selected location */
+  isActive: boolean("isActive").default(false).notNull(),
+  /** Per-location sync settings as JSON */
+  syncConfig: jsonb("syncConfig").$type<{
+    autoSyncContacts?: boolean;
+    autoSyncOpportunities?: boolean;
+    syncInterval?: number; // minutes
+    defaultTags?: string[];
+    contactImportEnabled?: boolean;
+    webhookEnabled?: boolean;
+  }>(),
+  /** Cached location details from GHL (address, phone, etc.) */
+  locationDetails: jsonb("locationDetails").$type<{
+    address?: string;
+    city?: string;
+    state?: string;
+    country?: string;
+    phone?: string;
+    email?: string;
+    website?: string;
+    timezone?: string;
+  }>(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+});
+
+export type GhlLocationConfig = typeof ghlLocationConfigs.$inferSelect;
+export type InsertGhlLocationConfig = typeof ghlLocationConfigs.$inferInsert;
+
 // Lead types are defined in schema-lead-enrichment.ts and re-exported below
 
 export type Document = typeof documents.$inferSelect;

--- a/server/api/routers/ghl.ts
+++ b/server/api/routers/ghl.ts
@@ -5,14 +5,31 @@
  * - ghl.status — connection health check per location
  * - ghl.listLocations — list all authorized GHL locations
  * - ghl.disconnect — revoke and clean up
+ * - ghl.getLocationDetails — fetch location details from GHL API
+ * - ghl.setActiveLocation — switch active location
+ * - ghl.getActiveLocation — get current active location
+ * - ghl.updateLocationConfig — update per-location settings
+ * - ghl.getLocationConfig — get per-location settings
  *
- * Linear: AI-2877
+ * Linear: AI-2877, AI-2881
  */
 
 import { z } from "zod";
 import { router, protectedProcedure } from "../../_core/trpc";
 import { TRPCError } from "@trpc/server";
 import { GHLService, GHLError } from "../../services/ghl.service";
+import { getDb } from "../../db";
+import { ghlLocationConfigs, integrations } from "../../../drizzle/schema";
+import { eq, and } from "drizzle-orm";
+
+const syncConfigSchema = z.object({
+  autoSyncContacts: z.boolean().optional(),
+  autoSyncOpportunities: z.boolean().optional(),
+  syncInterval: z.number().min(5).max(1440).optional(),
+  defaultTags: z.array(z.string()).optional(),
+  contactImportEnabled: z.boolean().optional(),
+  webhookEnabled: z.boolean().optional(),
+});
 
 export const ghlRouter = router({
   /**
@@ -50,12 +67,34 @@ export const ghlRouter = router({
     }),
 
   /**
-   * List all authorized GHL locations for the current user.
+   * List all authorized GHL locations for the current user,
+   * enriched with cached location names and config from ghl_location_configs.
    */
   listLocations: protectedProcedure.query(async ({ ctx }) => {
     try {
       const locations = await GHLService.listLocations(ctx.user.id);
-      return locations;
+
+      // Enrich with cached configs
+      const db = await getDb();
+      if (!db) return locations.map((l) => ({ ...l, name: null, isActive: false, syncConfig: null }));
+
+      const configs = await db
+        .select()
+        .from(ghlLocationConfigs)
+        .where(eq(ghlLocationConfigs.userId, ctx.user.id));
+
+      const configMap = new Map(configs.map((c) => [c.locationId, c]));
+
+      return locations.map((loc) => {
+        const config = configMap.get(loc.locationId);
+        return {
+          ...loc,
+          name: config?.locationName || null,
+          isActive: config?.isActive ?? false,
+          syncConfig: config?.syncConfig || null,
+          locationDetails: config?.locationDetails || null,
+        };
+      });
     } catch (err) {
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",
@@ -80,6 +119,20 @@ export const ghlRouter = router({
       try {
         const service = new GHLService(input.locationId, ctx.user.id);
         await service.disconnect();
+
+        // Also clean up the location config
+        const db = await getDb();
+        if (db) {
+          await db
+            .delete(ghlLocationConfigs)
+            .where(
+              and(
+                eq(ghlLocationConfigs.userId, ctx.user.id),
+                eq(ghlLocationConfigs.locationId, input.locationId)
+              )
+            );
+        }
+
         return {
           success: true,
           message: `Disconnected GHL location ${input.locationId}`,
@@ -106,7 +159,6 @@ export const ghlRouter = router({
 
   /**
    * Get the GHL OAuth configuration status (whether client ID/secret are set).
-   * Used by the UI to know if the "Connect" button should be enabled.
    */
   configStatus: protectedProcedure.query(async () => {
     return {
@@ -115,4 +167,293 @@ export const ghlRouter = router({
       hasClientSecret: !!process.env.GHL_CLIENT_SECRET,
     };
   }),
+
+  /**
+   * Fetch location details from GHL API and cache them locally.
+   */
+  getLocationDetails: protectedProcedure
+    .input(z.object({ locationId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = new GHLService(input.locationId, ctx.user.id);
+        const res = await service.request<{
+          location: {
+            id: string;
+            name: string;
+            companyId: string;
+            address?: string;
+            city?: string;
+            state?: string;
+            country?: string;
+            phone?: string;
+            email?: string;
+            website?: string;
+            timezone?: string;
+          };
+        }>({
+          method: "GET",
+          endpoint: `/locations/${input.locationId}`,
+        });
+
+        const loc = res.data.location;
+
+        // Cache the location details
+        const db = await getDb();
+        if (db) {
+          const [existing] = await db
+            .select()
+            .from(ghlLocationConfigs)
+            .where(
+              and(
+                eq(ghlLocationConfigs.userId, ctx.user.id),
+                eq(ghlLocationConfigs.locationId, input.locationId)
+              )
+            )
+            .limit(1);
+
+          const details = {
+            address: loc.address,
+            city: loc.city,
+            state: loc.state,
+            country: loc.country,
+            phone: loc.phone,
+            email: loc.email,
+            website: loc.website,
+            timezone: loc.timezone,
+          };
+
+          if (existing) {
+            await db
+              .update(ghlLocationConfigs)
+              .set({
+                locationName: loc.name,
+                companyId: loc.companyId,
+                locationDetails: details,
+                updatedAt: new Date(),
+              })
+              .where(eq(ghlLocationConfigs.id, existing.id));
+          } else {
+            await db.insert(ghlLocationConfigs).values({
+              userId: ctx.user.id,
+              locationId: input.locationId,
+              locationName: loc.name,
+              companyId: loc.companyId,
+              isActive: false,
+              locationDetails: details,
+              syncConfig: {
+                autoSyncContacts: false,
+                autoSyncOpportunities: false,
+                syncInterval: 30,
+                defaultTags: [],
+                contactImportEnabled: false,
+                webhookEnabled: false,
+              },
+            });
+          }
+        }
+
+        return loc;
+      } catch (err) {
+        if (err instanceof GHLError) {
+          throw new TRPCError({
+            code: err.category === "auth" ? "UNAUTHORIZED" : "INTERNAL_SERVER_ERROR",
+            message: err.message,
+          });
+        }
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: err instanceof Error ? err.message : "Failed to get location details",
+        });
+      }
+    }),
+
+  /**
+   * Set the active GHL location for the current user.
+   * Deactivates all other locations for this user first.
+   */
+  setActiveLocation: protectedProcedure
+    .input(z.object({ locationId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const db = await getDb();
+      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+
+      // Verify the location exists as a connected integration
+      const [integration] = await db
+        .select()
+        .from(integrations)
+        .where(
+          and(
+            eq(integrations.userId, ctx.user.id),
+            eq(integrations.service, `ghl:${input.locationId}`),
+            eq(integrations.isActive, "true")
+          )
+        )
+        .limit(1);
+
+      if (!integration) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `GHL location ${input.locationId} is not connected`,
+        });
+      }
+
+      // Deactivate all locations for this user
+      const allConfigs = await db
+        .select()
+        .from(ghlLocationConfigs)
+        .where(eq(ghlLocationConfigs.userId, ctx.user.id));
+
+      for (const config of allConfigs) {
+        if (config.isActive) {
+          await db
+            .update(ghlLocationConfigs)
+            .set({ isActive: false, updatedAt: new Date() })
+            .where(eq(ghlLocationConfigs.id, config.id));
+        }
+      }
+
+      // Activate the target location (upsert)
+      const [existing] = await db
+        .select()
+        .from(ghlLocationConfigs)
+        .where(
+          and(
+            eq(ghlLocationConfigs.userId, ctx.user.id),
+            eq(ghlLocationConfigs.locationId, input.locationId)
+          )
+        )
+        .limit(1);
+
+      if (existing) {
+        await db
+          .update(ghlLocationConfigs)
+          .set({ isActive: true, updatedAt: new Date() })
+          .where(eq(ghlLocationConfigs.id, existing.id));
+      } else {
+        await db.insert(ghlLocationConfigs).values({
+          userId: ctx.user.id,
+          locationId: input.locationId,
+          isActive: true,
+          syncConfig: {
+            autoSyncContacts: false,
+            autoSyncOpportunities: false,
+            syncInterval: 30,
+            defaultTags: [],
+            contactImportEnabled: false,
+            webhookEnabled: false,
+          },
+        });
+      }
+
+      return { success: true, activeLocationId: input.locationId };
+    }),
+
+  /**
+   * Get the current active GHL location for the user.
+   */
+  getActiveLocation: protectedProcedure.query(async ({ ctx }) => {
+    const db = await getDb();
+    if (!db) return null;
+
+    const [config] = await db
+      .select()
+      .from(ghlLocationConfigs)
+      .where(
+        and(
+          eq(ghlLocationConfigs.userId, ctx.user.id),
+          eq(ghlLocationConfigs.isActive, true)
+        )
+      )
+      .limit(1);
+
+    if (!config) return null;
+
+    return {
+      locationId: config.locationId,
+      locationName: config.locationName,
+      companyId: config.companyId,
+      syncConfig: config.syncConfig,
+      locationDetails: config.locationDetails,
+    };
+  }),
+
+  /**
+   * Update per-location configuration (sync settings, tags, etc.)
+   */
+  updateLocationConfig: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().min(1),
+        locationName: z.string().optional(),
+        syncConfig: syncConfigSchema.optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const db = await getDb();
+      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+
+      const [existing] = await db
+        .select()
+        .from(ghlLocationConfigs)
+        .where(
+          and(
+            eq(ghlLocationConfigs.userId, ctx.user.id),
+            eq(ghlLocationConfigs.locationId, input.locationId)
+          )
+        )
+        .limit(1);
+
+      if (existing) {
+        const updates: Record<string, unknown> = { updatedAt: new Date() };
+        if (input.locationName !== undefined) updates.locationName = input.locationName;
+        if (input.syncConfig !== undefined) {
+          updates.syncConfig = { ...((existing.syncConfig as object) || {}), ...input.syncConfig };
+        }
+        await db
+          .update(ghlLocationConfigs)
+          .set(updates)
+          .where(eq(ghlLocationConfigs.id, existing.id));
+
+        return { success: true, locationId: input.locationId };
+      } else {
+        await db.insert(ghlLocationConfigs).values({
+          userId: ctx.user.id,
+          locationId: input.locationId,
+          locationName: input.locationName || null,
+          isActive: false,
+          syncConfig: input.syncConfig || {
+            autoSyncContacts: false,
+            autoSyncOpportunities: false,
+            syncInterval: 30,
+            defaultTags: [],
+            contactImportEnabled: false,
+            webhookEnabled: false,
+          },
+        });
+        return { success: true, locationId: input.locationId };
+      }
+    }),
+
+  /**
+   * Get per-location configuration.
+   */
+  getLocationConfig: protectedProcedure
+    .input(z.object({ locationId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const db = await getDb();
+      if (!db) return null;
+
+      const [config] = await db
+        .select()
+        .from(ghlLocationConfigs)
+        .where(
+          and(
+            eq(ghlLocationConfigs.userId, ctx.user.id),
+            eq(ghlLocationConfigs.locationId, input.locationId)
+          )
+        )
+        .limit(1);
+
+      return config || null;
+    }),
 });


### PR DESCRIPTION
## Summary
- Add `ghl_location_configs` DB table for per-location settings, cached details, and active location tracking
- Extend GHL tRPC router with 5 new endpoints: `getLocationDetails`, `setActiveLocation`, `getActiveLocation`, `updateLocationConfig`, `getLocationConfig`
- Enrich `listLocations` with cached location names and config
- New `LocationSwitcher` component for quick location switching via dropdown
- New `LocationConfigPanel` for per-location sync settings (auto-sync contacts/opportunities, sync interval, default tags, webhook toggle)
- Updated `GHLConnectionCard` with active location indicator, set-active button, and expandable config panel
- Auto-caches GHL location details on first API fetch
- Cleans up location configs on disconnect

## Test Plan
- [ ] Connect multiple GHL locations via OAuth flow
- [ ] Verify location names are fetched and cached from GHL API
- [ ] Switch active location using LocationSwitcher dropdown
- [ ] Open per-location config panel and update sync settings
- [ ] Add/remove default tags for a location
- [ ] Disconnect a location and verify config cleanup
- [ ] Verify only one location can be active at a time

Closes AI-2881
https://linear.app/ai-acrobatics/issue/AI-2881