### PR TITLE
AI-2887: Add multi-step workflow execution with data passing

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
     "./drizzle/schema-sop.ts",
     "./drizzle/schema-subscriptions.ts",
     "./drizzle/schema-webhooks.ts",
+    "./drizzle/schema-pipelines.ts",
     "./drizzle/schema-support.ts",
     "./drizzle/schema-task-templates.ts",
     "./drizzle/relations.ts",

--- a/drizzle/0007_add_pipeline_tables.sql
+++ b/drizzle/0007_add_pipeline_tables.sql
@@ -1,0 +1,41 @@
+-- Multi-Step Workflow Pipelines
+-- Supports chained workflow execution with data passing between steps
+
+CREATE TABLE IF NOT EXISTS "workflow_pipelines" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "userId" integer NOT NULL REFERENCES "users"("id"),
+  "name" text NOT NULL,
+  "description" text,
+  "steps" jsonb NOT NULL,
+  "trigger" varchar(20) DEFAULT 'manual' NOT NULL,
+  "isActive" boolean DEFAULT true NOT NULL,
+  "executionCount" integer DEFAULT 0 NOT NULL,
+  "lastExecutedAt" timestamp,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "workflow_pipelines_user_id_idx" ON "workflow_pipelines" ("userId");
+CREATE INDEX IF NOT EXISTS "workflow_pipelines_is_active_idx" ON "workflow_pipelines" ("isActive");
+
+CREATE TABLE IF NOT EXISTS "pipeline_executions" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "pipelineId" integer NOT NULL REFERENCES "workflow_pipelines"("id"),
+  "userId" integer NOT NULL REFERENCES "users"("id"),
+  "status" varchar(20) DEFAULT 'pending' NOT NULL,
+  "input" jsonb,
+  "output" jsonb,
+  "error" text,
+  "currentStepIndex" integer DEFAULT 0 NOT NULL,
+  "totalSteps" integer NOT NULL,
+  "stepResults" jsonb,
+  "startedAt" timestamp,
+  "completedAt" timestamp,
+  "duration" integer,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "pipeline_executions_pipeline_id_idx" ON "pipeline_executions" ("pipelineId");
+CREATE INDEX IF NOT EXISTS "pipeline_executions_user_id_idx" ON "pipeline_executions" ("userId");
+CREATE INDEX IF NOT EXISTS "pipeline_executions_status_idx" ON "pipeline_executions" ("status");

--- a/drizzle/schema-pipelines.ts
+++ b/drizzle/schema-pipelines.ts
@@ -1,0 +1,98 @@
+/**
+ * Multi-Step Workflow Pipelines Schema
+ * Database tables for chained workflow execution with data passing between steps
+ *
+ * A pipeline chains multiple workflows (or inline tasks) together,
+ * passing output from each step as input to the next.
+ */
+
+import {
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar,
+  integer,
+  boolean,
+  jsonb,
+  index,
+} from "drizzle-orm/pg-core";
+import { users } from "./schema";
+
+// ========================================
+// PIPELINE DEFINITIONS
+// ========================================
+
+/**
+ * Workflow pipeline definitions
+ * A pipeline is a sequence of steps where each step either references
+ * an existing workflow or defines an inline task (apiCall, notification, etc.)
+ */
+export const workflowPipelines = pgTable("workflow_pipelines", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  name: text("name").notNull(),
+  description: text("description"),
+
+  /**
+   * Array of pipeline step definitions. Each step:
+   * {
+   *   stepId: string,           // Unique ID within pipeline (e.g. "scrape", "enrich")
+   *   type: "workflow" | "inline", // Reference existing workflow or inline task
+   *   workflowId?: number,      // For type=workflow: ID of automation_workflows row
+   *   inlineConfig?: {...},     // For type=inline: step config (apiCall, notification, etc.)
+   *   inputMapping?: Record<string, string>,  // Map previous step outputs to this step's variables
+   *   condition?: string,       // Optional condition to skip this step
+   *   continueOnError?: boolean,
+   *   retryCount?: number,
+   *   retryDelayMs?: number,
+   * }
+   */
+  steps: jsonb("steps").notNull(),
+
+  trigger: varchar("trigger", { length: 20 }).default("manual").notNull(), // manual, scheduled, webhook
+  isActive: boolean("isActive").default(true).notNull(),
+  executionCount: integer("executionCount").default(0).notNull(),
+  lastExecutedAt: timestamp("lastExecutedAt"),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  userIdIdx: index("workflow_pipelines_user_id_idx").on(table.userId),
+  isActiveIdx: index("workflow_pipelines_is_active_idx").on(table.isActive),
+}));
+
+export type WorkflowPipeline = typeof workflowPipelines.$inferSelect;
+export type InsertWorkflowPipeline = typeof workflowPipelines.$inferInsert;
+
+// ========================================
+// PIPELINE EXECUTION TRACKING
+// ========================================
+
+/**
+ * Pipeline execution runs
+ * Tracks the overall execution of a pipeline
+ */
+export const pipelineExecutions = pgTable("pipeline_executions", {
+  id: serial("id").primaryKey(),
+  pipelineId: integer("pipelineId").references(() => workflowPipelines.id).notNull(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  status: varchar("status", { length: 20 }).default("pending").notNull(), // pending, running, completed, failed, cancelled
+  input: jsonb("input"), // Initial input variables
+  output: jsonb("output"), // Final aggregated output
+  error: text("error"),
+  currentStepIndex: integer("currentStepIndex").default(0).notNull(),
+  totalSteps: integer("totalSteps").notNull(),
+  stepResults: jsonb("stepResults"), // Array of per-step results
+  startedAt: timestamp("startedAt"),
+  completedAt: timestamp("completedAt"),
+  duration: integer("duration"), // Total duration in ms
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  pipelineIdIdx: index("pipeline_executions_pipeline_id_idx").on(table.pipelineId),
+  userIdIdx: index("pipeline_executions_user_id_idx").on(table.userId),
+  statusIdx: index("pipeline_executions_status_idx").on(table.status),
+}));
+
+export type PipelineExecution = typeof pipelineExecutions.$inferSelect;
+export type InsertPipelineExecution = typeof pipelineExecutions.$inferInsert;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -683,6 +683,16 @@ export {
   type InsertCostBudget,
 } from "./schema-costs";
 
+// Multi-Step Workflow Pipelines
+export {
+  workflowPipelines,
+  pipelineExecutions,
+  type WorkflowPipeline,
+  type InsertWorkflowPipeline,
+  type PipelineExecution,
+  type InsertPipelineExecution,
+} from "./schema-pipelines";
+
 // Authentication Enhancement
 export {
   passwordResetTokens,

--- a/server/api/routers/pipelines.ts
+++ b/server/api/routers/pipelines.ts
@@ -1,0 +1,409 @@
+/**
+ * Pipelines Router - tRPC API for Multi-Step Workflow Pipelines
+ *
+ * Supports chained workflows where each step can reference an existing workflow
+ * or define an inline task, with data passing between steps via inputMapping.
+ */
+
+import { z } from "zod";
+import { router, protectedProcedure } from "../../_core/trpc";
+import { TRPCError } from "@trpc/server";
+import { getDb } from "../../db";
+import { eq, and, desc } from "drizzle-orm";
+import {
+  workflowPipelines,
+  pipelineExecutions,
+} from "../../../drizzle/schema-pipelines";
+import {
+  executePipeline,
+  getPipelineExecutionStatus,
+  cancelPipelineExecution,
+} from "../../services/pipelineExecution.service";
+
+// ========================================
+// Validation Schemas
+// ========================================
+
+const inlineConfigSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("apiCall"),
+    url: z.string().min(1),
+    method: z.enum(["GET", "POST", "PUT", "DELETE", "PATCH"]).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    body: z.any().optional(),
+  }),
+  z.object({
+    type: z.literal("notification"),
+    message: z.string().min(1),
+    notificationType: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal("transform"),
+    expression: z.string().min(1),
+  }),
+]);
+
+const pipelineStepSchema = z.object({
+  stepId: z.string().min(1).max(64),
+  type: z.enum(["workflow", "inline"]),
+  workflowId: z.number().int().positive().optional(),
+  inlineConfig: inlineConfigSchema.optional(),
+  inputMapping: z.record(z.string(), z.string()).optional(),
+  condition: z.string().optional(),
+  continueOnError: z.boolean().default(false),
+  retryCount: z.number().int().min(0).max(5).default(0),
+  retryDelayMs: z.number().int().min(0).max(60000).default(1000),
+}).refine(
+  (step) => {
+    if (step.type === "workflow") return step.workflowId != null;
+    if (step.type === "inline") return step.inlineConfig != null;
+    return false;
+  },
+  { message: "Workflow steps require workflowId; inline steps require inlineConfig" }
+);
+
+const createPipelineSchema = z.object({
+  name: z.string().min(1).max(255),
+  description: z.string().max(1000).optional(),
+  trigger: z.enum(["manual", "scheduled", "webhook"]).default("manual"),
+  steps: z.array(pipelineStepSchema).min(1).max(20),
+});
+
+const updatePipelineSchema = z.object({
+  id: z.number().int().positive(),
+  name: z.string().min(1).max(255).optional(),
+  description: z.string().max(1000).optional(),
+  trigger: z.enum(["manual", "scheduled", "webhook"]).optional(),
+  isActive: z.boolean().optional(),
+  steps: z.array(pipelineStepSchema).min(1).max(20).optional(),
+});
+
+// ========================================
+// Router
+// ========================================
+
+export const pipelinesRouter = router({
+  /**
+   * Create a new pipeline
+   */
+  create: protectedProcedure
+    .input(createPipelineSchema)
+    .mutation(async ({ input, ctx }) => {
+      const userId = ctx.user.id;
+      const db = await getDb();
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not initialized" });
+      }
+
+      // Validate that all referenced workflow IDs exist and belong to this user
+      const workflowSteps = input.steps.filter((s) => s.type === "workflow" && s.workflowId);
+      if (workflowSteps.length > 0) {
+        const { automationWorkflows } = await import("../../../drizzle/schema");
+        for (const step of workflowSteps) {
+          const [wf] = await db
+            .select({ id: automationWorkflows.id })
+            .from(automationWorkflows)
+            .where(and(eq(automationWorkflows.id, step.workflowId!), eq(automationWorkflows.userId, userId)))
+            .limit(1);
+          if (!wf) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `Workflow ${step.workflowId} not found for step "${step.stepId}"`,
+            });
+          }
+        }
+      }
+
+      // Validate unique stepIds
+      const stepIds = input.steps.map((s) => s.stepId);
+      if (new Set(stepIds).size !== stepIds.length) {
+        throw new TRPCError({ code: "BAD_REQUEST", message: "Step IDs must be unique within a pipeline" });
+      }
+
+      const [pipeline] = await db
+        .insert(workflowPipelines)
+        .values({
+          userId,
+          name: input.name,
+          description: input.description,
+          trigger: input.trigger,
+          steps: input.steps,
+          isActive: true,
+        })
+        .returning();
+
+      return pipeline;
+    }),
+
+  /**
+   * List pipelines for the authenticated user
+   */
+  list: protectedProcedure
+    .input(
+      z.object({
+        isActive: z.boolean().optional(),
+        limit: z.number().int().min(1).max(100).default(50),
+        offset: z.number().int().min(0).default(0),
+      }).optional()
+    )
+    .query(async ({ input, ctx }) => {
+      const userId = ctx.user.id;
+      const db = await getDb();
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not initialized" });
+      }
+
+      const params = input || { limit: 50, offset: 0 };
+      const conditions = [eq(workflowPipelines.userId, userId)];
+      if (params.isActive !== undefined) {
+        conditions.push(eq(workflowPipelines.isActive, params.isActive));
+      }
+
+      const pipelines = await db
+        .select()
+        .from(workflowPipelines)
+        .where(and(...conditions))
+        .orderBy(desc(workflowPipelines.createdAt))
+        .limit(params.limit)
+        .offset(params.offset);
+
+      return pipelines.map((p) => ({
+        ...p,
+        stepCount: Array.isArray(p.steps) ? (p.steps as unknown[]).length : 0,
+      }));
+    }),
+
+  /**
+   * Get a single pipeline by ID
+   */
+  get: protectedProcedure
+    .input(z.object({ id: z.number().int().positive() }))
+    .query(async ({ input, ctx }) => {
+      const userId = ctx.user.id;
+      const db = await getDb();
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not initialized" });
+      }
+
+      const [pipeline] = await db
+        .select()
+        .from(workflowPipelines)
+        .where(and(eq(workflowPipelines.id, input.id), eq(workflowPipelines.userId, userId)))
+        .limit(1);
+
+      if (!pipeline) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Pipeline not found" });
+      }
+
+      return pipeline;
+    }),
+
+  /**
+   * Update an existing pipeline
+   */
+  update: protectedProcedure
+    .input(updatePipelineSchema)
+    .mutation(async ({ input, ctx }) => {
+      const userId = ctx.user.id;
+      const db = await getDb();
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not initialized" });
+      }
+
+      const [existing] = await db
+        .select()
+        .from(workflowPipelines)
+        .where(and(eq(workflowPipelines.id, input.id), eq(workflowPipelines.userId, userId)))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Pipeline not found" });
+      }
+
+      const updateData: Partial<typeof workflowPipelines.$inferInsert> = {
+        updatedAt: new Date(),
+      };
+      if (input.name !== undefined) updateData.name = input.name;
+      if (input.description !== undefined) updateData.description = input.description;
+      if (input.trigger !== undefined) updateData.trigger = input.trigger;
+      if (input.isActive !== undefined) updateData.isActive = input.isActive;
+      if (input.steps !== undefined) updateData.steps = input.steps;
+
+      const [updated] = await db
+        .update(workflowPipelines)
+        .set(updateData)
+        .where(eq(workflowPipelines.id, input.id))
+        .returning();
+
+      return updated;
+    }),
+
+  /**
+   * Delete (soft) a pipeline
+   */
+  delete: protectedProcedure
+    .input(z.object({ id: z.number().int().positive() }))
+    .mutation(async ({ input, ctx }) => {
+      const userId = ctx.user.id;
+      const db = await getDb();
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not initialized" });
+      }
+
+      const [existing] = await db
+        .select()
+        .from(workflowPipelines)
+        .where(and(eq(workflowPipelines.id, input.id), eq(workflowPipelines.userId, userId)))
+        .limit(1);
+
+      if (!existing) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Pipeline not found" });
+      }
+
+      await db
+        .update(workflowPipelines)
+        .set({ isActive: false, updatedAt: new Date() })
+        .where(eq(workflowPipelines.id, input.id));
+
+      return { success: true, id: input.id };
+    }),
+
+  /**
+   * Execute a pipeline
+   */
+  execute: protectedProcedure
+    .input(
+      z.object({
+        pipelineId: z.number().int().positive(),
+        variables: z.record(z.string(), z.any()).optional(),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      const userId = ctx.user.id;
+
+      try {
+        const result = await executePipeline({
+          pipelineId: input.pipelineId,
+          userId,
+          variables: input.variables,
+        });
+
+        return {
+          success: true,
+          executionId: result.executionId,
+          pipelineId: result.pipelineId,
+          status: result.status,
+          stepResults: result.stepResults,
+          output: result.output,
+        };
+      } catch (error) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: `Pipeline execution failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        });
+      }
+    }),
+
+  /**
+   * Get execution history for a pipeline
+   */
+  getExecutions: protectedProcedure
+    .input(
+      z.object({
+        pipelineId: z.number().int().positive(),
+        status: z.enum(["pending", "running", "completed", "failed", "cancelled"]).optional(),
+        limit: z.number().int().min(1).max(100).default(20),
+        offset: z.number().int().min(0).default(0),
+      })
+    )
+    .query(async ({ input, ctx }) => {
+      const userId = ctx.user.id;
+      const db = await getDb();
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not initialized" });
+      }
+
+      // Verify pipeline ownership
+      const [pipeline] = await db
+        .select()
+        .from(workflowPipelines)
+        .where(and(eq(workflowPipelines.id, input.pipelineId), eq(workflowPipelines.userId, userId)))
+        .limit(1);
+
+      if (!pipeline) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Pipeline not found" });
+      }
+
+      const conditions = [eq(pipelineExecutions.pipelineId, input.pipelineId)];
+      if (input.status) {
+        conditions.push(eq(pipelineExecutions.status, input.status));
+      }
+
+      return db
+        .select()
+        .from(pipelineExecutions)
+        .where(and(...conditions))
+        .orderBy(desc(pipelineExecutions.startedAt))
+        .limit(input.limit)
+        .offset(input.offset);
+    }),
+
+  /**
+   * Get a single pipeline execution status
+   */
+  getExecution: protectedProcedure
+    .input(z.object({ executionId: z.number().int().positive() }))
+    .query(async ({ input, ctx }) => {
+      const userId = ctx.user.id;
+      const db = await getDb();
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not initialized" });
+      }
+
+      // Verify ownership
+      const [execution] = await db
+        .select()
+        .from(pipelineExecutions)
+        .where(and(
+          eq(pipelineExecutions.id, input.executionId),
+          eq(pipelineExecutions.userId, userId)
+        ))
+        .limit(1);
+
+      if (!execution) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Pipeline execution not found" });
+      }
+
+      return getPipelineExecutionStatus(input.executionId);
+    }),
+
+  /**
+   * Cancel a running pipeline execution
+   */
+  cancelExecution: protectedProcedure
+    .input(z.object({ executionId: z.number().int().positive() }))
+    .mutation(async ({ input, ctx }) => {
+      const userId = ctx.user.id;
+      const db = await getDb();
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not initialized" });
+      }
+
+      // Verify ownership
+      const [execution] = await db
+        .select()
+        .from(pipelineExecutions)
+        .where(and(
+          eq(pipelineExecutions.id, input.executionId),
+          eq(pipelineExecutions.userId, userId)
+        ))
+        .limit(1);
+
+      if (!execution) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Pipeline execution not found" });
+      }
+
+      await cancelPipelineExecution(input.executionId);
+      return { success: true, executionId: input.executionId };
+    }),
+});

--- a/server/services/pipelineExecution.service.ts
+++ b/server/services/pipelineExecution.service.ts
@@ -1,0 +1,454 @@
+/**
+ * Pipeline Execution Service
+ * Handles chained multi-step workflow execution with data passing between steps.
+ *
+ * A pipeline runs a sequence of steps where each step can be:
+ * - A reference to an existing automation workflow (executed via workflowExecution.service)
+ * - An inline task (API call, notification, data transform)
+ *
+ * Output from each step is stored in a shared context and can be mapped
+ * as input to subsequent steps via inputMapping expressions.
+ */
+
+import { getDb } from "../db";
+import { eq, and, desc } from "drizzle-orm";
+import {
+  workflowPipelines,
+  pipelineExecutions,
+} from "../../drizzle/schema-pipelines";
+import { automationWorkflows } from "../../drizzle/schema";
+import { evaluateExpression } from "../lib/safeExpressionParser";
+import { substituteVariables } from "../_core/variableSubstitution";
+import type {
+  PipelineStepDefinition,
+  PipelineStepResult,
+  PipelineExecutionStatus,
+  ExecutePipelineOptions,
+  InlineApiCallConfig,
+  InlineNotificationConfig,
+  InlineTransformConfig,
+  HttpMethod,
+} from "../types";
+
+// ========================================
+// CONTEXT & HELPERS
+// ========================================
+
+interface PipelineContext {
+  pipelineId: number;
+  executionId: number;
+  userId: number;
+  /** Shared variables — each step's output is stored under its stepId */
+  variables: Record<string, unknown>;
+  stepResults: PipelineStepResult[];
+}
+
+/**
+ * Resolve inputMapping expressions against pipeline context.
+ * Supports {{stepId.field.nested}} syntax to reference previous step outputs.
+ */
+function resolveInputMapping(
+  mapping: Record<string, string>,
+  variables: Record<string, unknown>
+): Record<string, unknown> {
+  const resolved: Record<string, unknown> = {};
+  for (const [key, expression] of Object.entries(mapping)) {
+    resolved[key] = substituteVariables(expression, variables);
+  }
+  return resolved;
+}
+
+/**
+ * Update pipeline execution status in the database.
+ */
+async function updatePipelineExecution(
+  executionId: number,
+  updates: Partial<{
+    status: string;
+    currentStepIndex: number;
+    output: unknown;
+    stepResults: unknown[];
+    completedAt: Date;
+    duration: number;
+    error: string;
+  }>
+): Promise<void> {
+  const db = await getDb();
+  if (!db) throw new Error("Database not initialized");
+
+  await db
+    .update(pipelineExecutions)
+    .set({ ...updates, updatedAt: new Date() })
+    .where(eq(pipelineExecutions.id, executionId));
+}
+
+// ========================================
+// INLINE STEP HANDLERS
+// ========================================
+
+async function executeInlineApiCall(
+  config: InlineApiCallConfig,
+  variables: Record<string, unknown>
+): Promise<unknown> {
+  const url = String(substituteVariables(config.url, variables));
+  const method = (config.method || "GET").toUpperCase() as HttpMethod;
+  const headers = config.headers
+    ? (substituteVariables(config.headers, variables) as Record<string, string>)
+    : {};
+  const body = config.body ? substituteVariables(config.body, variables) : undefined;
+
+  const fetchOptions: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json", ...headers },
+  };
+
+  if (body && method !== "GET") {
+    fetchOptions.body = typeof body === "string" ? body : JSON.stringify(body);
+  }
+
+  const response = await fetch(url, fetchOptions);
+  const data = await response.json().catch(() => response.text());
+
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    data,
+  };
+}
+
+function executeInlineNotification(
+  config: InlineNotificationConfig,
+  variables: Record<string, unknown>
+): unknown {
+  const message = substituteVariables(config.message, variables);
+  const type = config.notificationType || "info";
+  console.log(`[Pipeline Notification - ${type}]: ${message}`);
+  return { message, type, timestamp: new Date() };
+}
+
+function executeInlineTransform(
+  config: InlineTransformConfig,
+  variables: Record<string, unknown>
+): unknown {
+  const result = evaluateExpression(String(config.expression), variables);
+  if (!result.success) {
+    throw new Error(`Transform expression failed: ${result.error}`);
+  }
+  return result.result;
+}
+
+// ========================================
+// WORKFLOW STEP HANDLER
+// ========================================
+
+/**
+ * Execute a workflow step by running all its defined steps inline.
+ * We load the workflow definition and execute its steps without spinning up
+ * a Browserbase session (that's only needed for browser-type steps).
+ * For non-browser workflows, we run the API/notification/condition steps directly.
+ * For browser workflows, we delegate to the existing workflowExecution service.
+ */
+async function executeWorkflowStep(
+  workflowId: number,
+  userId: number,
+  stepVariables: Record<string, unknown>
+): Promise<unknown> {
+  // Dynamic import to avoid circular dependencies
+  const { executeWorkflow } = await import("./workflowExecution.service");
+
+  const result = await executeWorkflow({
+    workflowId,
+    userId,
+    variables: stepVariables,
+  });
+
+  return {
+    executionId: result.executionId,
+    status: result.status,
+    output: result.output,
+    stepResults: result.stepResults,
+  };
+}
+
+// ========================================
+// CORE PIPELINE EXECUTION
+// ========================================
+
+/**
+ * Execute a complete pipeline — runs each step sequentially,
+ * passing data between steps via the shared context.
+ */
+export async function executePipeline(
+  options: ExecutePipelineOptions
+): Promise<PipelineExecutionStatus> {
+  const { pipelineId, userId, variables = {} } = options;
+
+  const db = await getDb();
+  if (!db) throw new Error("Database not initialized");
+
+  // 1. Load pipeline definition
+  const [pipeline] = await db
+    .select()
+    .from(workflowPipelines)
+    .where(and(eq(workflowPipelines.id, pipelineId), eq(workflowPipelines.userId, userId)))
+    .limit(1);
+
+  if (!pipeline) throw new Error("Pipeline not found");
+  if (!pipeline.isActive) throw new Error("Pipeline is not active");
+
+  const steps = pipeline.steps as PipelineStepDefinition[];
+  if (!Array.isArray(steps) || steps.length === 0) {
+    throw new Error("Pipeline has no steps");
+  }
+
+  // 2. Create execution record
+  const [execution] = await db
+    .insert(pipelineExecutions)
+    .values({
+      pipelineId,
+      userId,
+      status: "running",
+      input: variables,
+      totalSteps: steps.length,
+      currentStepIndex: 0,
+      startedAt: new Date(),
+    })
+    .returning();
+
+  const executionId = execution.id;
+  const startTime = Date.now();
+
+  // 3. Build pipeline context
+  const context: PipelineContext = {
+    pipelineId,
+    executionId,
+    userId,
+    variables: { ...variables, __pipeline: { id: pipelineId, executionId } },
+    stepResults: [],
+  };
+
+  try {
+    // 4. Execute steps sequentially
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i];
+      const stepStart = Date.now();
+
+      // Update progress
+      await updatePipelineExecution(executionId, {
+        currentStepIndex: i,
+        stepResults: context.stepResults,
+      });
+
+      // Check condition (skip if condition evaluates to false)
+      if (step.condition) {
+        const condResult = evaluateExpression(step.condition, context.variables);
+        if (condResult.success && !condResult.result) {
+          context.stepResults.push({
+            stepId: step.stepId,
+            stepIndex: i,
+            type: step.type,
+            status: "skipped",
+            startedAt: new Date(stepStart),
+            completedAt: new Date(),
+            duration: Date.now() - stepStart,
+          });
+          continue;
+        }
+      }
+
+      // Resolve input mapping
+      const stepVariables: Record<string, unknown> = { ...variables };
+      if (step.inputMapping) {
+        const mapped = resolveInputMapping(step.inputMapping, context.variables);
+        Object.assign(stepVariables, mapped);
+      }
+
+      let output: unknown;
+      let retries = step.retryCount || 0;
+      let lastError: Error | undefined;
+
+      // Execute with retry logic
+      while (true) {
+        try {
+          if (step.type === "workflow" && step.workflowId) {
+            output = await executeWorkflowStep(step.workflowId, userId, stepVariables);
+          } else if (step.type === "inline" && step.inlineConfig) {
+            switch (step.inlineConfig.type) {
+              case "apiCall":
+                output = await executeInlineApiCall(
+                  step.inlineConfig as InlineApiCallConfig,
+                  stepVariables
+                );
+                break;
+              case "notification":
+                output = executeInlineNotification(
+                  step.inlineConfig as InlineNotificationConfig,
+                  stepVariables
+                );
+                break;
+              case "transform":
+                output = executeInlineTransform(
+                  step.inlineConfig as InlineTransformConfig,
+                  stepVariables
+                );
+                break;
+              default:
+                throw new Error(`Unknown inline step type: ${(step.inlineConfig as any).type}`);
+            }
+          } else {
+            throw new Error(`Invalid step configuration for step "${step.stepId}"`);
+          }
+
+          lastError = undefined;
+          break; // Success
+        } catch (err) {
+          lastError = err instanceof Error ? err : new Error(String(err));
+          if (retries > 0) {
+            retries--;
+            const delay = step.retryDelayMs || 1000;
+            await new Promise((r) => setTimeout(r, delay));
+          } else {
+            break; // No more retries
+          }
+        }
+      }
+
+      const stepDuration = Date.now() - stepStart;
+
+      if (lastError) {
+        // Step failed
+        context.stepResults.push({
+          stepId: step.stepId,
+          stepIndex: i,
+          type: step.type,
+          status: "failed",
+          error: lastError.message,
+          startedAt: new Date(stepStart),
+          completedAt: new Date(),
+          duration: stepDuration,
+        });
+
+        if (!step.continueOnError) {
+          throw new Error(`Pipeline step "${step.stepId}" failed: ${lastError.message}`);
+        }
+      } else {
+        // Step succeeded — store output in context
+        context.variables[step.stepId] = output;
+
+        context.stepResults.push({
+          stepId: step.stepId,
+          stepIndex: i,
+          type: step.type,
+          status: "completed",
+          output,
+          startedAt: new Date(stepStart),
+          completedAt: new Date(),
+          duration: stepDuration,
+        });
+      }
+    }
+
+    // 5. Pipeline completed
+    const totalDuration = Date.now() - startTime;
+
+    await updatePipelineExecution(executionId, {
+      status: "completed",
+      completedAt: new Date(),
+      duration: totalDuration,
+      output: context.variables,
+      stepResults: context.stepResults,
+    });
+
+    // Update pipeline statistics
+    await db
+      .update(workflowPipelines)
+      .set({
+        executionCount: (pipeline.executionCount || 0) + 1,
+        lastExecutedAt: new Date(),
+      })
+      .where(eq(workflowPipelines.id, pipelineId));
+
+    return {
+      executionId,
+      pipelineId,
+      status: "completed",
+      currentStepIndex: steps.length,
+      totalSteps: steps.length,
+      stepResults: context.stepResults,
+      input: variables,
+      output: context.variables,
+      startedAt: execution.startedAt || undefined,
+      completedAt: new Date(),
+      duration: totalDuration,
+    };
+  } catch (error) {
+    const totalDuration = Date.now() - startTime;
+    const errorMsg = error instanceof Error ? error.message : "Unknown error";
+
+    await updatePipelineExecution(executionId, {
+      status: "failed",
+      completedAt: new Date(),
+      duration: totalDuration,
+      error: errorMsg,
+      stepResults: context.stepResults,
+    });
+
+    throw error;
+  }
+}
+
+// ========================================
+// STATUS & CANCELLATION
+// ========================================
+
+export async function getPipelineExecutionStatus(
+  executionId: number
+): Promise<PipelineExecutionStatus> {
+  const db = await getDb();
+  if (!db) throw new Error("Database not initialized");
+
+  const [execution] = await db
+    .select()
+    .from(pipelineExecutions)
+    .where(eq(pipelineExecutions.id, executionId))
+    .limit(1);
+
+  if (!execution) throw new Error("Pipeline execution not found");
+
+  return {
+    executionId: execution.id,
+    pipelineId: execution.pipelineId,
+    status: execution.status,
+    currentStepIndex: execution.currentStepIndex,
+    totalSteps: execution.totalSteps,
+    stepResults: (execution.stepResults as PipelineStepResult[]) || [],
+    input: execution.input,
+    output: execution.output,
+    error: execution.error || undefined,
+    startedAt: execution.startedAt || undefined,
+    completedAt: execution.completedAt || undefined,
+    duration: execution.duration || undefined,
+  };
+}
+
+export async function cancelPipelineExecution(executionId: number): Promise<void> {
+  const db = await getDb();
+  if (!db) throw new Error("Database not initialized");
+
+  const [execution] = await db
+    .select()
+    .from(pipelineExecutions)
+    .where(eq(pipelineExecutions.id, executionId))
+    .limit(1);
+
+  if (!execution) throw new Error("Pipeline execution not found");
+  if (execution.status !== "running") {
+    throw new Error("Only running pipeline executions can be cancelled");
+  }
+
+  await updatePipelineExecution(executionId, {
+    status: "cancelled",
+    completedAt: new Date(),
+    error: "Cancelled by user",
+  });
+}

--- a/server/services/pipelineExecution.test.ts
+++ b/server/services/pipelineExecution.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Pipeline Execution Service Tests
+ * Tests for multi-step workflow pipeline execution with data passing
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PipelineStepDefinition } from "../types";
+
+// ========================================
+// MOCK SETUP
+// ========================================
+
+/**
+ * Create a chainable mock DB that supports multiple query chains.
+ * Each call to select/insert/update starts a fresh chain.
+ */
+function createMockDb() {
+  const queryResults: unknown[][] = [];
+  let resultIndex = 0;
+
+  function createChain(): Record<string, any> {
+    const chain: Record<string, any> = {};
+    const methods = ["select", "from", "where", "limit", "insert", "values",
+      "returning", "update", "set", "orderBy", "offset"];
+    for (const m of methods) {
+      chain[m] = vi.fn(() => chain);
+    }
+    // limit() and returning() resolve from the queue
+    chain.limit = vi.fn(() => {
+      const idx = resultIndex++;
+      return Promise.resolve(queryResults[idx] ?? []);
+    });
+    chain.returning = vi.fn(() => {
+      const idx = resultIndex++;
+      return Promise.resolve(queryResults[idx] ?? []);
+    });
+    // where() after update().set() also needs to resolve
+    const origWhere = chain.where;
+    chain.where = vi.fn((...args: any[]) => {
+      // Return the chain so limit/returning can be called
+      return chain;
+    });
+    return chain;
+  }
+
+  const rootChain = createChain();
+
+  return {
+    ...rootChain,
+    _results: queryResults,
+    _resetIndex() { resultIndex = 0; },
+    _pushResult(result: unknown[]) { queryResults.push(result); },
+  };
+}
+
+const mockDb = createMockDb();
+
+vi.mock("../db", () => ({
+  getDb: vi.fn(() => Promise.resolve(mockDb)),
+}));
+
+vi.mock("../lib/safeExpressionParser", () => ({
+  evaluateExpression: vi.fn((expr: string, vars: Record<string, unknown>) => {
+    if (expr === "true") return { success: true, result: true };
+    if (expr === "false") return { success: true, result: false };
+    // Simple variable lookup
+    if (vars[expr] !== undefined) return { success: true, result: vars[expr] };
+    return { success: true, result: true };
+  }),
+}));
+
+vi.mock("../_core/variableSubstitution", () => ({
+  substituteVariables: vi.fn((val: unknown, vars: Record<string, unknown>) => {
+    if (typeof val === "string") {
+      // Simple {{var}} substitution for tests
+      return val.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_match, key) => {
+        const parts = key.split(".");
+        let current: any = vars;
+        for (const part of parts) {
+          current = current?.[part];
+        }
+        return current !== undefined ? String(current) : "";
+      });
+    }
+    return val;
+  }),
+}));
+
+// Mock the workflow execution service (used by workflow-type steps)
+vi.mock("./workflowExecution.service", () => ({
+  executeWorkflow: vi.fn(() =>
+    Promise.resolve({
+      executionId: 100,
+      status: "completed",
+      output: { extractedData: [{ data: "test" }], finalVariables: { result: "ok" } },
+      stepResults: [],
+    })
+  ),
+}));
+
+// ========================================
+// IMPORT AFTER MOCKS
+// ========================================
+
+import {
+  executePipeline,
+  getPipelineExecutionStatus,
+  cancelPipelineExecution,
+} from "./pipelineExecution.service";
+
+// ========================================
+// HELPERS
+// ========================================
+
+function mockPipeline(steps: PipelineStepDefinition[], overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    userId: 1,
+    name: "Test Pipeline",
+    description: "Test",
+    steps,
+    trigger: "manual",
+    isActive: true,
+    executionCount: 0,
+    lastExecutedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function mockExecution(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 10,
+    pipelineId: 1,
+    userId: 1,
+    status: "running",
+    input: {},
+    output: null,
+    error: null,
+    currentStepIndex: 0,
+    totalSteps: 2,
+    stepResults: null,
+    startedAt: new Date(),
+    completedAt: null,
+    duration: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+// ========================================
+// TESTS
+// ========================================
+
+describe("Pipeline Execution Service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb._results.length = 0;
+    mockDb._resetIndex();
+  });
+
+  describe("executePipeline", () => {
+    it("should execute a pipeline with an inline notification step", async () => {
+      const steps: PipelineStepDefinition[] = [
+        {
+          stepId: "step1",
+          type: "inline",
+          inlineConfig: { type: "notification", message: "Test notification" },
+        },
+      ];
+
+      // 1: select pipeline, 2: insert execution, 3+: updates (progress, completion, stats)
+      mockDb._pushResult([mockPipeline(steps)]);
+      mockDb._pushResult([mockExecution({ totalSteps: 1 })]);
+
+      const result = await executePipeline({
+        pipelineId: 1,
+        userId: 1,
+        variables: { name: "Julian" },
+      });
+
+      expect(result.status).toBe("completed");
+      expect(result.stepResults).toHaveLength(1);
+      expect(result.stepResults[0].stepId).toBe("step1");
+      expect(result.stepResults[0].status).toBe("completed");
+    });
+
+    it("should pass data between steps via inputMapping", async () => {
+      const steps: PipelineStepDefinition[] = [
+        {
+          stepId: "step1",
+          type: "inline",
+          inlineConfig: { type: "notification", message: "First" },
+        },
+        {
+          stepId: "step2",
+          type: "inline",
+          inlineConfig: { type: "notification", message: "Got: {{step1.message}}" },
+          inputMapping: { prevResult: "{{step1}}" },
+        },
+      ];
+
+      mockDb._pushResult([mockPipeline(steps)]);
+      mockDb._pushResult([mockExecution({ totalSteps: 2 })]);
+
+      const result = await executePipeline({
+        pipelineId: 1,
+        userId: 1,
+      });
+
+      expect(result.status).toBe("completed");
+      expect(result.stepResults).toHaveLength(2);
+      expect(result.stepResults[0].status).toBe("completed");
+      expect(result.stepResults[1].status).toBe("completed");
+    });
+
+    it("should skip steps when condition evaluates to false", async () => {
+      const steps: PipelineStepDefinition[] = [
+        {
+          stepId: "step1",
+          type: "inline",
+          inlineConfig: { type: "notification", message: "Always runs" },
+        },
+        {
+          stepId: "step2",
+          type: "inline",
+          inlineConfig: { type: "notification", message: "Skipped" },
+          condition: "false",
+        },
+      ];
+
+      mockDb._pushResult([mockPipeline(steps)]);
+      mockDb._pushResult([mockExecution({ totalSteps: 2 })]);
+
+      const result = await executePipeline({
+        pipelineId: 1,
+        userId: 1,
+      });
+
+      expect(result.status).toBe("completed");
+      expect(result.stepResults).toHaveLength(2);
+      expect(result.stepResults[0].status).toBe("completed");
+      expect(result.stepResults[1].status).toBe("skipped");
+    });
+
+    it("should fail pipeline when step fails and continueOnError is false", async () => {
+      const steps: PipelineStepDefinition[] = [
+        {
+          stepId: "bad_step",
+          type: "inline",
+          // Missing inlineConfig — will throw
+        } as PipelineStepDefinition,
+      ];
+
+      mockDb._pushResult([mockPipeline(steps)]);
+      mockDb._pushResult([mockExecution({ totalSteps: 1 })]);
+
+      await expect(
+        executePipeline({ pipelineId: 1, userId: 1 })
+      ).rejects.toThrow('Pipeline step "bad_step" failed');
+    });
+
+    it("should continue when step fails and continueOnError is true", async () => {
+      const steps: PipelineStepDefinition[] = [
+        {
+          stepId: "bad_step",
+          type: "inline",
+          continueOnError: true,
+          // Missing inlineConfig — will fail but continue
+        } as PipelineStepDefinition,
+        {
+          stepId: "good_step",
+          type: "inline",
+          inlineConfig: { type: "notification", message: "Still running" },
+        },
+      ];
+
+      mockDb._pushResult([mockPipeline(steps)]);
+      mockDb._pushResult([mockExecution({ totalSteps: 2 })]);
+
+      const result = await executePipeline({
+        pipelineId: 1,
+        userId: 1,
+      });
+
+      expect(result.status).toBe("completed");
+      expect(result.stepResults[0].status).toBe("failed");
+      expect(result.stepResults[1].status).toBe("completed");
+    });
+
+    it("should throw if pipeline not found", async () => {
+      mockDb._pushResult([]);
+
+      await expect(
+        executePipeline({ pipelineId: 999, userId: 1 })
+      ).rejects.toThrow("Pipeline not found");
+    });
+
+    it("should throw if pipeline is inactive", async () => {
+      mockDb._pushResult([mockPipeline([], { isActive: false })]);
+
+      await expect(
+        executePipeline({ pipelineId: 1, userId: 1 })
+      ).rejects.toThrow("Pipeline is not active");
+    });
+  });
+
+  describe("getPipelineExecutionStatus", () => {
+    it("should return execution status", async () => {
+      mockDb._pushResult([
+        mockExecution({
+          status: "completed",
+          stepResults: [{ stepId: "s1", status: "completed" }],
+        }),
+      ]);
+
+      const status = await getPipelineExecutionStatus(10);
+      expect(status.executionId).toBe(10);
+      expect(status.status).toBe("completed");
+      expect(status.stepResults).toHaveLength(1);
+    });
+
+    it("should throw if execution not found", async () => {
+      mockDb._pushResult([]);
+
+      await expect(getPipelineExecutionStatus(999)).rejects.toThrow(
+        "Pipeline execution not found"
+      );
+    });
+  });
+
+  describe("cancelPipelineExecution", () => {
+    it("should cancel a running execution", async () => {
+      mockDb._pushResult([mockExecution({ status: "running" })]);
+
+      await expect(cancelPipelineExecution(10)).resolves.toBeUndefined();
+    });
+
+    it("should throw when cancelling a non-running execution", async () => {
+      mockDb._pushResult([mockExecution({ status: "completed" })]);
+
+      await expect(cancelPipelineExecution(10)).rejects.toThrow(
+        "Only running pipeline executions can be cancelled"
+      );
+    });
+  });
+});

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -501,6 +501,89 @@ export type Optional<T> = T | undefined;
 
 export type StringKeys<T> = Extract<keyof T, string>;
 
+// ========================================
+// PIPELINE TYPES (Multi-Step Workflow Chaining)
+// ========================================
+
+export type PipelineStepType = 'workflow' | 'inline';
+
+export type InlineStepType = 'apiCall' | 'notification' | 'condition' | 'transform';
+
+export interface PipelineStepDefinition {
+  stepId: string;
+  type: PipelineStepType;
+  /** For type=workflow: references an automationWorkflows row */
+  workflowId?: number;
+  /** For type=inline: defines the task inline */
+  inlineConfig?: InlineTaskConfig;
+  /** Maps output from previous steps into this step's input variables.
+   *  Keys are variable names, values are expressions like "{{stepId.output.field}}" */
+  inputMapping?: Record<string, string>;
+  /** Optional condition expression; if falsy, step is skipped */
+  condition?: string;
+  continueOnError?: boolean;
+  retryCount?: number;
+  retryDelayMs?: number;
+}
+
+export type InlineTaskConfig =
+  | InlineApiCallConfig
+  | InlineNotificationConfig
+  | InlineTransformConfig;
+
+export interface InlineApiCallConfig {
+  type: 'apiCall';
+  url: string;
+  method?: HttpMethod;
+  headers?: Record<string, string>;
+  body?: unknown;
+}
+
+export interface InlineNotificationConfig {
+  type: 'notification';
+  message: string;
+  notificationType?: string;
+}
+
+export interface InlineTransformConfig {
+  type: 'transform';
+  /** JavaScript-safe expression evaluated against the pipeline context */
+  expression: string;
+}
+
+export interface PipelineStepResult {
+  stepId: string;
+  stepIndex: number;
+  type: PipelineStepType;
+  status: 'completed' | 'failed' | 'skipped';
+  output?: unknown;
+  error?: string;
+  startedAt: Date;
+  completedAt: Date;
+  duration: number;
+}
+
+export interface PipelineExecutionStatus {
+  executionId: number;
+  pipelineId: number;
+  status: string;
+  currentStepIndex: number;
+  totalSteps: number;
+  stepResults: PipelineStepResult[];
+  input?: unknown;
+  output?: unknown;
+  error?: string;
+  startedAt?: Date;
+  completedAt?: Date;
+  duration?: number;
+}
+
+export interface ExecutePipelineOptions {
+  pipelineId: number;
+  userId: number;
+  variables?: Record<string, unknown>;
+}
+
 export type JsonValue =
   | string
   | number


### PR DESCRIPTION
## Summary
1d5980c feat(pipelines): add multi-step workflow execution with data passing

## Changes
8 files changed (+1445 / -0)

<details>
<summary>Files changed</summary>

- `drizzle.config.ts`
- `drizzle/0007_add_pipeline_tables.sql`
- `drizzle/schema-pipelines.ts`
- `drizzle/schema.ts`
- `server/api/routers/pipelines.ts`
- `server/services/pipelineExecution.service.ts`
- `server/services/pipelineExecution.test.ts`
- `server/types/index.ts`

</details>

## Verification
- [x] Build passes
- [ ] Tests pass
- [ ] Type-check clean

## How to Verify
Review the PR diff and test manually.

## Metrics
- Cost: $3.3908
- Duration: 12m 38s

Closes AI-2887
https://linear.app/ai-acrobatics/issue/AI-2887