### PR TITLE
AI-2881: Implement multi-location management

### DIFF
--- a/client/src/components/GHLConnectionCard.tsx
+++ b/client/src/components/GHLConnectionCard.tsx
@@ -117,7 +117,10 @@ export const GHLConnectionCard: React.FC = () => {
                     </div>
                     <div>
                       <p className="text-sm font-medium text-white">
-                        Location: {loc.locationId}
+                        {loc.name || `Location ${loc.locationId.substring(0, 8)}`}
+                      </p>
+                      <p className="text-xs text-slate-500">
+                        ID: {loc.locationId}
                       </p>
                       {loc.companyId && (
                         <p className="text-xs text-slate-400">Company: {loc.companyId}</p>

--- a/client/src/components/GHLLocationSwitcher.tsx
+++ b/client/src/components/GHLLocationSwitcher.tsx
@@ -1,0 +1,87 @@
+/**
+ * GHL Location Switcher
+ *
+ * Dropdown to switch between connected GHL locations.
+ * Shows active location name + allows switching.
+ *
+ * Linear: AI-2881
+ */
+
+import React from 'react';
+import { trpc } from '@/lib/trpc';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Badge } from '@/components/ui/badge';
+import { Building2, MapPin } from 'lucide-react';
+import { toast } from 'sonner';
+
+export const GHLLocationSwitcher: React.FC = () => {
+  const { data: locations } = trpc.ghl.listLocations.useQuery();
+  const { data: activeLocation } = trpc.ghl.getActiveLocation.useQuery();
+  const utils = trpc.useUtils();
+
+  const setActiveMutation = trpc.ghl.setActiveLocation.useMutation({
+    onSuccess: (data) => {
+      toast.success(`Switched to ${data.name || data.locationId}`);
+      utils.ghl.getActiveLocation.invalidate();
+    },
+    onError: (error) => toast.error(`Failed to switch: ${error.message}`),
+  });
+
+  if (!locations || locations.length === 0) return null;
+
+  // Don't show switcher for single location
+  if (locations.length === 1) {
+    const loc = locations[0];
+    return (
+      <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-slate-800/50 border border-slate-700">
+        <Building2 className="w-4 h-4 text-orange-400" />
+        <span className="text-sm text-slate-300 truncate max-w-[160px]">
+          {loc.name || `Location ${loc.locationId.substring(0, 8)}`}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <Select
+      value={activeLocation?.locationId || ''}
+      onValueChange={(locationId) => setActiveMutation.mutate({ locationId })}
+      disabled={setActiveMutation.isPending}
+    >
+      <SelectTrigger className="w-[220px] bg-slate-800/50 border-slate-700 text-slate-300">
+        <div className="flex items-center gap-2">
+          <Building2 className="w-4 h-4 text-orange-400 shrink-0" />
+          <SelectValue placeholder="Select location" />
+        </div>
+      </SelectTrigger>
+      <SelectContent className="bg-slate-900 border-slate-700">
+        {locations.map((loc) => (
+          <SelectItem
+            key={loc.locationId}
+            value={loc.locationId}
+            className="text-slate-300 focus:bg-slate-800 focus:text-white"
+          >
+            <div className="flex items-center gap-2">
+              <span className="truncate">
+                {loc.name || `Location ${loc.locationId.substring(0, 8)}`}
+              </span>
+              {loc.locationId === activeLocation?.locationId && (
+                <Badge className="bg-green-500/20 text-green-400 border-green-500/30 text-[10px] px-1">
+                  Active
+                </Badge>
+              )}
+            </div>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};
+
+export default GHLLocationSwitcher;

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     "./drizzle/schema-webhooks.ts",
     "./drizzle/schema-support.ts",
     "./drizzle/schema-task-templates.ts",
+    "./drizzle/schema-ghl-locations.ts",
     "./drizzle/relations.ts",
     "./server/rag/schema.ts",
   ],

--- a/drizzle/0007_ghl_multi_location.sql
+++ b/drizzle/0007_ghl_multi_location.sql
@@ -1,0 +1,36 @@
+-- GHL Multi-Location Management
+-- Linear: AI-2881
+
+CREATE TABLE IF NOT EXISTS "ghl_locations" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "userId" integer NOT NULL REFERENCES "users"("id"),
+  "locationId" varchar(128) NOT NULL,
+  "companyId" varchar(128),
+  "name" text,
+  "address" text,
+  "city" varchar(100),
+  "state" varchar(100),
+  "country" varchar(100),
+  "phone" varchar(30),
+  "email" varchar(320),
+  "timezone" varchar(64),
+  "website" text,
+  "logoUrl" text,
+  "config" jsonb,
+  "isActive" boolean DEFAULT true NOT NULL,
+  "lastSyncedAt" timestamp,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ghl_locations_user_location_idx" ON "ghl_locations" ("userId", "locationId");
+CREATE INDEX IF NOT EXISTS "ghl_locations_user_idx" ON "ghl_locations" ("userId");
+
+CREATE TABLE IF NOT EXISTS "ghl_active_location" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "userId" integer NOT NULL REFERENCES "users"("id") UNIQUE,
+  "locationId" varchar(128) NOT NULL,
+  "selectedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ghl_active_location_user_idx" ON "ghl_active_location" ("userId");

--- a/drizzle/schema-ghl-locations.ts
+++ b/drizzle/schema-ghl-locations.ts
@@ -1,0 +1,83 @@
+/**
+ * GHL Multi-Location Management Schema
+ *
+ * Stores location details, per-location config, and tracks active location per user.
+ * Linear: AI-2881
+ */
+
+import { pgTable, serial, text, timestamp, varchar, integer, boolean, jsonb, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { users } from "./schema";
+
+/**
+ * GHL locations with metadata and per-location configuration
+ */
+export const ghlLocations = pgTable("ghl_locations", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  locationId: varchar("locationId", { length: 128 }).notNull(), // GHL location ID
+  companyId: varchar("companyId", { length: 128 }), // GHL company/agency ID
+  name: text("name"), // Location display name (fetched from GHL API)
+  address: text("address"),
+  city: varchar("city", { length: 100 }),
+  state: varchar("state", { length: 100 }),
+  country: varchar("country", { length: 100 }),
+  phone: varchar("phone", { length: 30 }),
+  email: varchar("email", { length: 320 }),
+  timezone: varchar("timezone", { length: 64 }),
+  website: text("website"),
+  logoUrl: text("logoUrl"),
+
+  // Per-location configuration
+  config: jsonb("config").$type<GHLLocationConfig>(),
+
+  isActive: boolean("isActive").default(true).notNull(), // Whether this location connection is active
+  lastSyncedAt: timestamp("lastSyncedAt"), // Last time we synced data from this location
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  // One row per user+location combination
+  userLocationIdx: uniqueIndex("ghl_locations_user_location_idx").on(table.userId, table.locationId),
+  userIdx: index("ghl_locations_user_idx").on(table.userId),
+}));
+
+/**
+ * Tracks which GHL location is currently active/selected per user.
+ * Only one active location per user at a time.
+ */
+export const ghlActiveLocation = pgTable("ghl_active_location", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull().unique(),
+  locationId: varchar("locationId", { length: 128 }).notNull(),
+  selectedAt: timestamp("selectedAt").defaultNow().notNull(),
+}, (table) => ({
+  userIdx: uniqueIndex("ghl_active_location_user_idx").on(table.userId),
+}));
+
+// Types
+export interface GHLLocationConfig {
+  /** Enable/disable automations for this location */
+  automationsEnabled?: boolean;
+  /** Enable/disable contact sync */
+  contactSyncEnabled?: boolean;
+  /** Enable/disable pipeline sync */
+  pipelineSyncEnabled?: boolean;
+  /** Enable/disable calendar sync */
+  calendarSyncEnabled?: boolean;
+  /** Custom webhook URL for this location */
+  webhookUrl?: string;
+  /** Default pipeline ID for new opportunities */
+  defaultPipelineId?: string;
+  /** Default calendar ID for bookings */
+  defaultCalendarId?: string;
+  /** Custom brand voice override for this location */
+  brandVoice?: string;
+  /** Custom agent instructions for this location */
+  agentInstructions?: string;
+  /** Tags for organization */
+  tags?: string[];
+}
+
+export type GHLLocationRow = typeof ghlLocations.$inferSelect;
+export type InsertGHLLocation = typeof ghlLocations.$inferInsert;
+export type GHLActiveLocationRow = typeof ghlActiveLocation.$inferSelect;
+export type InsertGHLActiveLocation = typeof ghlActiveLocation.$inferInsert;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -700,3 +700,14 @@ export {
   type PasswordResetConfirm,
   type EmailVerificationRequest,
 } from "./schema-auth";
+
+// GHL Multi-Location Management
+export {
+  ghlLocations,
+  ghlActiveLocation,
+  type GHLLocationConfig,
+  type GHLLocationRow,
+  type InsertGHLLocation,
+  type GHLActiveLocationRow,
+  type InsertGHLActiveLocation,
+} from "./schema-ghl-locations";

--- a/server/api/routers/ghl.ts
+++ b/server/api/routers/ghl.ts
@@ -5,14 +5,36 @@
  * - ghl.status — connection health check per location
  * - ghl.listLocations — list all authorized GHL locations
  * - ghl.disconnect — revoke and clean up
+ * - ghl.configStatus — check OAuth configuration
+ * - ghl.getActiveLocation — get user's currently selected location
+ * - ghl.setActiveLocation — switch active location
+ * - ghl.getLocationConfig — get per-location config
+ * - ghl.updateLocationConfig — update per-location config
+ * - ghl.updateLocationDetails — update location name/metadata
  *
- * Linear: AI-2877
+ * Linear: AI-2877, AI-2881
  */
 
 import { z } from "zod";
 import { router, protectedProcedure } from "../../_core/trpc";
 import { TRPCError } from "@trpc/server";
 import { GHLService, GHLError } from "../../services/ghl.service";
+import { getDb } from "../../db";
+import { ghlLocations, ghlActiveLocation } from "../../../drizzle/schema-ghl-locations";
+import { eq, and } from "drizzle-orm";
+
+const locationConfigSchema = z.object({
+  automationsEnabled: z.boolean().optional(),
+  contactSyncEnabled: z.boolean().optional(),
+  pipelineSyncEnabled: z.boolean().optional(),
+  calendarSyncEnabled: z.boolean().optional(),
+  webhookUrl: z.string().url().optional().or(z.literal("")),
+  defaultPipelineId: z.string().optional(),
+  defaultCalendarId: z.string().optional(),
+  brandVoice: z.string().max(2000).optional(),
+  agentInstructions: z.string().max(5000).optional(),
+  tags: z.array(z.string()).optional(),
+});
 
 export const ghlRouter = router({
   /**
@@ -51,11 +73,50 @@ export const ghlRouter = router({
 
   /**
    * List all authorized GHL locations for the current user.
+   * Merges data from integrations table + ghl_locations table.
    */
   listLocations: protectedProcedure.query(async ({ ctx }) => {
     try {
-      const locations = await GHLService.listLocations(ctx.user.id);
-      return locations;
+      // Get OAuth-connected locations from integrations table
+      const oauthLocations = await GHLService.listLocations(ctx.user.id);
+
+      // Get enriched location data from ghl_locations table
+      const db = await getDb();
+      if (!db) return oauthLocations;
+
+      const locationRows = await db
+        .select()
+        .from(ghlLocations)
+        .where(
+          and(
+            eq(ghlLocations.userId, ctx.user.id),
+            eq(ghlLocations.isActive, true)
+          )
+        );
+
+      // Build lookup map of enriched data
+      const enrichedMap = new Map(
+        locationRows.map((row) => [row.locationId, row])
+      );
+
+      // Merge: OAuth data + enriched metadata
+      return oauthLocations.map((loc) => {
+        const enriched = enrichedMap.get(loc.locationId);
+        return {
+          ...loc,
+          name: enriched?.name || null,
+          address: enriched?.address || null,
+          city: enriched?.city || null,
+          state: enriched?.state || null,
+          phone: enriched?.phone || null,
+          email: enriched?.email || null,
+          timezone: enriched?.timezone || null,
+          website: enriched?.website || null,
+          logoUrl: enriched?.logoUrl || null,
+          config: enriched?.config || null,
+          lastSyncedAt: enriched?.lastSyncedAt || null,
+        };
+      });
     } catch (err) {
       throw new TRPCError({
         code: "INTERNAL_SERVER_ERROR",
@@ -80,6 +141,34 @@ export const ghlRouter = router({
       try {
         const service = new GHLService(input.locationId, ctx.user.id);
         await service.disconnect();
+
+        // Also deactivate in ghl_locations table
+        const db = await getDb();
+        if (db) {
+          await db
+            .update(ghlLocations)
+            .set({ isActive: false, updatedAt: new Date() })
+            .where(
+              and(
+                eq(ghlLocations.userId, ctx.user.id),
+                eq(ghlLocations.locationId, input.locationId)
+              )
+            );
+
+          // If this was the active location, clear it
+          const [active] = await db
+            .select()
+            .from(ghlActiveLocation)
+            .where(eq(ghlActiveLocation.userId, ctx.user.id))
+            .limit(1);
+
+          if (active?.locationId === input.locationId) {
+            await db
+              .delete(ghlActiveLocation)
+              .where(eq(ghlActiveLocation.userId, ctx.user.id));
+          }
+        }
+
         return {
           success: true,
           message: `Disconnected GHL location ${input.locationId}`,
@@ -106,7 +195,6 @@ export const ghlRouter = router({
 
   /**
    * Get the GHL OAuth configuration status (whether client ID/secret are set).
-   * Used by the UI to know if the "Connect" button should be enabled.
    */
   configStatus: protectedProcedure.query(async () => {
     return {
@@ -115,4 +203,227 @@ export const ghlRouter = router({
       hasClientSecret: !!process.env.GHL_CLIENT_SECRET,
     };
   }),
+
+  /**
+   * Get the user's currently active/selected GHL location.
+   */
+  getActiveLocation: protectedProcedure.query(async ({ ctx }) => {
+    const db = await getDb();
+    if (!db) return null;
+
+    const [active] = await db
+      .select()
+      .from(ghlActiveLocation)
+      .where(eq(ghlActiveLocation.userId, ctx.user.id))
+      .limit(1);
+
+    if (!active) return null;
+
+    // Fetch enriched details
+    const [location] = await db
+      .select()
+      .from(ghlLocations)
+      .where(
+        and(
+          eq(ghlLocations.userId, ctx.user.id),
+          eq(ghlLocations.locationId, active.locationId),
+          eq(ghlLocations.isActive, true)
+        )
+      )
+      .limit(1);
+
+    return {
+      locationId: active.locationId,
+      selectedAt: active.selectedAt,
+      name: location?.name || null,
+      companyId: location?.companyId || null,
+    };
+  }),
+
+  /**
+   * Set the active/selected GHL location for the current user.
+   */
+  setActiveLocation: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().min(1, "locationId is required"),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const db = await getDb();
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+      }
+
+      // Verify this location exists and belongs to user
+      const [location] = await db
+        .select()
+        .from(ghlLocations)
+        .where(
+          and(
+            eq(ghlLocations.userId, ctx.user.id),
+            eq(ghlLocations.locationId, input.locationId),
+            eq(ghlLocations.isActive, true)
+          )
+        )
+        .limit(1);
+
+      if (!location) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `GHL location ${input.locationId} not found or not connected`,
+        });
+      }
+
+      // Upsert active location
+      const [existing] = await db
+        .select()
+        .from(ghlActiveLocation)
+        .where(eq(ghlActiveLocation.userId, ctx.user.id))
+        .limit(1);
+
+      if (existing) {
+        await db
+          .update(ghlActiveLocation)
+          .set({ locationId: input.locationId, selectedAt: new Date() })
+          .where(eq(ghlActiveLocation.userId, ctx.user.id));
+      } else {
+        await db.insert(ghlActiveLocation).values({
+          userId: ctx.user.id,
+          locationId: input.locationId,
+          selectedAt: new Date(),
+        });
+      }
+
+      return {
+        success: true,
+        locationId: input.locationId,
+        name: location.name,
+      };
+    }),
+
+  /**
+   * Get per-location configuration.
+   */
+  getLocationConfig: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().min(1),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const db = await getDb();
+      if (!db) return null;
+
+      const [location] = await db
+        .select()
+        .from(ghlLocations)
+        .where(
+          and(
+            eq(ghlLocations.userId, ctx.user.id),
+            eq(ghlLocations.locationId, input.locationId)
+          )
+        )
+        .limit(1);
+
+      return location?.config || {
+        automationsEnabled: true,
+        contactSyncEnabled: true,
+        pipelineSyncEnabled: true,
+        calendarSyncEnabled: false,
+      };
+    }),
+
+  /**
+   * Update per-location configuration.
+   */
+  updateLocationConfig: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().min(1),
+        config: locationConfigSchema,
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const db = await getDb();
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+      }
+
+      // Get current config and merge
+      const [location] = await db
+        .select()
+        .from(ghlLocations)
+        .where(
+          and(
+            eq(ghlLocations.userId, ctx.user.id),
+            eq(ghlLocations.locationId, input.locationId)
+          )
+        )
+        .limit(1);
+
+      if (!location) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `GHL location ${input.locationId} not found`,
+        });
+      }
+
+      const mergedConfig = { ...(location.config || {}), ...input.config };
+
+      await db
+        .update(ghlLocations)
+        .set({ config: mergedConfig, updatedAt: new Date() })
+        .where(
+          and(
+            eq(ghlLocations.userId, ctx.user.id),
+            eq(ghlLocations.locationId, input.locationId)
+          )
+        );
+
+      return { success: true, config: mergedConfig };
+    }),
+
+  /**
+   * Update location display name and metadata.
+   */
+  updateLocationDetails: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().min(1),
+        name: z.string().max(200).optional(),
+        phone: z.string().max(30).optional(),
+        email: z.string().email().optional().or(z.literal("")),
+        website: z.string().url().optional().or(z.literal("")),
+        timezone: z.string().max(64).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const db = await getDb();
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+      }
+
+      const { locationId, ...updates } = input;
+
+      // Filter out undefined values
+      const setValues: Record<string, unknown> = { updatedAt: new Date() };
+      for (const [key, value] of Object.entries(updates)) {
+        if (value !== undefined) {
+          setValues[key] = value || null;
+        }
+      }
+
+      await db
+        .update(ghlLocations)
+        .set(setValues)
+        .where(
+          and(
+            eq(ghlLocations.userId, ctx.user.id),
+            eq(ghlLocations.locationId, locationId)
+          )
+        );
+
+      return { success: true };
+    }),
 });

--- a/server/api/routes/ghl-oauth.ts
+++ b/server/api/routes/ghl-oauth.ts
@@ -17,6 +17,7 @@ import { oauthStateService } from "../../services/oauthState.service";
 import { GHLService, type GHLScope } from "../../services/ghl.service";
 import { getDb } from "../../db";
 import { integrations } from "../../../drizzle/schema";
+import { ghlLocations, ghlActiveLocation } from "../../../drizzle/schema-ghl-locations";
 import { eq, and } from "drizzle-orm";
 
 const router = express.Router();
@@ -234,6 +235,60 @@ router.get("/callback", async (req: Request, res: Response) => {
       console.log(
         `[GHL OAuth] Created new integration for location ${tokens.locationId}`
       );
+    }
+
+    // Auto-create/update ghl_locations entry
+    const [existingLocation] = await db
+      .select()
+      .from(ghlLocations)
+      .where(
+        and(
+          eq(ghlLocations.userId, userId),
+          eq(ghlLocations.locationId, tokens.locationId)
+        )
+      )
+      .limit(1);
+
+    if (existingLocation) {
+      await db
+        .update(ghlLocations)
+        .set({
+          companyId: tokens.companyId,
+          isActive: true,
+          updatedAt: new Date(),
+        })
+        .where(eq(ghlLocations.id, existingLocation.id));
+    } else {
+      await db.insert(ghlLocations).values({
+        userId,
+        locationId: tokens.locationId,
+        companyId: tokens.companyId,
+        name: `Location ${tokens.locationId.substring(0, 8)}`,
+        isActive: true,
+        config: {
+          automationsEnabled: true,
+          contactSyncEnabled: true,
+          pipelineSyncEnabled: true,
+          calendarSyncEnabled: false,
+        },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    }
+
+    // Auto-set as active location if it's the first one
+    const [existingActive] = await db
+      .select()
+      .from(ghlActiveLocation)
+      .where(eq(ghlActiveLocation.userId, userId))
+      .limit(1);
+
+    if (!existingActive) {
+      await db.insert(ghlActiveLocation).values({
+        userId,
+        locationId: tokens.locationId,
+        selectedAt: new Date(),
+      });
     }
 
     res.redirect(


### PR DESCRIPTION
## Summary
- Added `ghl_locations` table for storing location metadata (name, address, config) and `ghl_active_location` table for tracking selected location per user
- Extended GHL tRPC router with 5 new endpoints: `getActiveLocation`, `setActiveLocation`, `getLocationConfig`, `updateLocationConfig`, `updateLocationDetails`
- OAuth callback now auto-creates location records and auto-selects first location as active
- `listLocations` merges OAuth token data with enriched location metadata
- New `GHLLocationSwitcher` dropdown component for switching between locations
- Updated `GHLConnectionCard` to show location names instead of raw IDs

## Test Plan
- [ ] Connect a GHL account via OAuth — verify `ghl_locations` row created automatically
- [ ] Connect a second location — verify first stays active, both appear in list
- [ ] Use location switcher to switch active location
- [ ] Update per-location config (automations, contact sync toggles)
- [ ] Disconnect a location — verify it's deactivated and active location cleared if needed
- [ ] Run migration: `psql < drizzle/0007_ghl_multi_location.sql`

Closes AI-2881
https://linear.app/ai-acrobatics/issue/AI-2881

🤖 Generated with [Claude Code](https://claude.com/claude-code)