### PR TITLE
AI-5149: GHL communication endpoints — SMS, email, templates, delivery status

### DIFF
--- a/drizzle/0008_ghl_webhook_processing.sql
+++ b/drizzle/0008_ghl_webhook_processing.sql
@@ -1,0 +1,82 @@
+-- GHL Webhook Processing: contacts, opportunities, event dedup, dead letter queue
+-- Linear: AI-5147
+
+-- Synced contacts from GHL webhooks
+CREATE TABLE IF NOT EXISTS "ghl_contacts" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "userId" integer NOT NULL REFERENCES "users"("id"),
+  "ghlContactId" varchar(128) NOT NULL,
+  "locationId" varchar(128) NOT NULL,
+  "firstName" text,
+  "lastName" text,
+  "email" varchar(320),
+  "phone" varchar(30),
+  "tags" jsonb,
+  "source" varchar(128),
+  "customFields" jsonb,
+  "lastWebhookAt" timestamp NOT NULL,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ghl_contacts_ghl_id_idx" ON "ghl_contacts" ("ghlContactId", "locationId");
+CREATE INDEX IF NOT EXISTS "ghl_contacts_user_idx" ON "ghl_contacts" ("userId");
+CREATE INDEX IF NOT EXISTS "ghl_contacts_location_idx" ON "ghl_contacts" ("locationId");
+CREATE INDEX IF NOT EXISTS "ghl_contacts_email_idx" ON "ghl_contacts" ("email");
+
+-- Synced opportunities from GHL webhooks
+CREATE TABLE IF NOT EXISTS "ghl_opportunities" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "userId" integer NOT NULL REFERENCES "users"("id"),
+  "ghlOpportunityId" varchar(128) NOT NULL,
+  "locationId" varchar(128) NOT NULL,
+  "name" text,
+  "pipelineId" varchar(128),
+  "pipelineStageId" varchar(128),
+  "status" varchar(64),
+  "monetaryValue" numeric(12, 2),
+  "ghlContactId" varchar(128),
+  "lastWebhookAt" timestamp NOT NULL,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ghl_opportunities_ghl_id_idx" ON "ghl_opportunities" ("ghlOpportunityId", "locationId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_user_idx" ON "ghl_opportunities" ("userId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_location_idx" ON "ghl_opportunities" ("locationId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_pipeline_idx" ON "ghl_opportunities" ("pipelineId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_status_idx" ON "ghl_opportunities" ("status");
+
+-- Webhook event log for deduplication
+CREATE TABLE IF NOT EXISTS "ghl_webhook_events" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "eventId" varchar(256) NOT NULL UNIQUE,
+  "eventType" varchar(128) NOT NULL,
+  "locationId" varchar(128),
+  "processedAt" timestamp DEFAULT now() NOT NULL,
+  "success" boolean NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ghl_webhook_events_event_id_idx" ON "ghl_webhook_events" ("eventId");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_events_type_idx" ON "ghl_webhook_events" ("eventType");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_events_processed_at_idx" ON "ghl_webhook_events" ("processedAt");
+
+-- Dead letter queue for failed webhook events
+CREATE TABLE IF NOT EXISTS "ghl_webhook_dead_letters" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "eventId" varchar(256),
+  "eventType" varchar(128) NOT NULL,
+  "locationId" varchar(128),
+  "payload" jsonb NOT NULL,
+  "error" text NOT NULL,
+  "retryCount" integer DEFAULT 0 NOT NULL,
+  "maxRetries" integer DEFAULT 3 NOT NULL,
+  "lastRetriedAt" timestamp,
+  "resolved" boolean DEFAULT false NOT NULL,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "ghl_webhook_dlq_resolved_idx" ON "ghl_webhook_dead_letters" ("resolved");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_dlq_type_idx" ON "ghl_webhook_dead_letters" ("eventType");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_dlq_created_at_idx" ON "ghl_webhook_dead_letters" ("createdAt");

--- a/drizzle/schema-ghl-webhooks.ts
+++ b/drizzle/schema-ghl-webhooks.ts
@@ -1,0 +1,130 @@
+/**
+ * GHL Webhook Processing Schema
+ *
+ * Tables for synced contacts, opportunities, webhook event dedup,
+ * and dead letter queue for failed webhook processing.
+ *
+ * Linear: AI-5147
+ */
+
+import {
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar,
+  integer,
+  boolean,
+  jsonb,
+  index,
+  uniqueIndex,
+  numeric,
+} from "drizzle-orm/pg-core";
+import { users } from "./schema";
+
+// ========================================
+// GHL CONTACTS (synced from webhooks)
+// ========================================
+
+export const ghlContacts = pgTable("ghl_contacts", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  ghlContactId: varchar("ghlContactId", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }).notNull(),
+  firstName: text("firstName"),
+  lastName: text("lastName"),
+  email: varchar("email", { length: 320 }),
+  phone: varchar("phone", { length: 30 }),
+  tags: jsonb("tags").$type<string[]>(),
+  source: varchar("source", { length: 128 }),
+  customFields: jsonb("customFields").$type<Array<{ id: string; value: string }>>(),
+  lastWebhookAt: timestamp("lastWebhookAt").notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  ghlContactIdx: uniqueIndex("ghl_contacts_ghl_id_idx").on(table.ghlContactId, table.locationId),
+  userIdx: index("ghl_contacts_user_idx").on(table.userId),
+  locationIdx: index("ghl_contacts_location_idx").on(table.locationId),
+  emailIdx: index("ghl_contacts_email_idx").on(table.email),
+}));
+
+export type GHLContactRow = typeof ghlContacts.$inferSelect;
+export type InsertGHLContact = typeof ghlContacts.$inferInsert;
+
+// ========================================
+// GHL OPPORTUNITIES (synced from webhooks)
+// ========================================
+
+export const ghlOpportunities = pgTable("ghl_opportunities", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  ghlOpportunityId: varchar("ghlOpportunityId", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }).notNull(),
+  name: text("name"),
+  pipelineId: varchar("pipelineId", { length: 128 }),
+  pipelineStageId: varchar("pipelineStageId", { length: 128 }),
+  status: varchar("status", { length: 64 }),
+  monetaryValue: numeric("monetaryValue", { precision: 12, scale: 2 }),
+  ghlContactId: varchar("ghlContactId", { length: 128 }),
+  lastWebhookAt: timestamp("lastWebhookAt").notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  ghlOppIdx: uniqueIndex("ghl_opportunities_ghl_id_idx").on(table.ghlOpportunityId, table.locationId),
+  userIdx: index("ghl_opportunities_user_idx").on(table.userId),
+  locationIdx: index("ghl_opportunities_location_idx").on(table.locationId),
+  pipelineIdx: index("ghl_opportunities_pipeline_idx").on(table.pipelineId),
+  statusIdx: index("ghl_opportunities_status_idx").on(table.status),
+}));
+
+export type GHLOpportunityRow = typeof ghlOpportunities.$inferSelect;
+export type InsertGHLOpportunity = typeof ghlOpportunities.$inferInsert;
+
+// ========================================
+// WEBHOOK EVENT LOG (for dedup)
+// ========================================
+
+export const ghlWebhookEvents = pgTable("ghl_webhook_events", {
+  id: serial("id").primaryKey(),
+  eventId: varchar("eventId", { length: 256 }).notNull().unique(),
+  eventType: varchar("eventType", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }),
+  processedAt: timestamp("processedAt").defaultNow().notNull(),
+  /** Whether processing completed successfully */
+  success: boolean("success").notNull(),
+}, (table) => ({
+  eventIdIdx: uniqueIndex("ghl_webhook_events_event_id_idx").on(table.eventId),
+  eventTypeIdx: index("ghl_webhook_events_type_idx").on(table.eventType),
+  processedAtIdx: index("ghl_webhook_events_processed_at_idx").on(table.processedAt),
+}));
+
+export type GHLWebhookEventRow = typeof ghlWebhookEvents.$inferSelect;
+export type InsertGHLWebhookEvent = typeof ghlWebhookEvents.$inferInsert;
+
+// ========================================
+// DEAD LETTER QUEUE (failed webhook events)
+// ========================================
+
+export const ghlWebhookDeadLetters = pgTable("ghl_webhook_dead_letters", {
+  id: serial("id").primaryKey(),
+  eventId: varchar("eventId", { length: 256 }),
+  eventType: varchar("eventType", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }),
+  payload: jsonb("payload").notNull(),
+  error: text("error").notNull(),
+  retryCount: integer("retryCount").default(0).notNull(),
+  maxRetries: integer("maxRetries").default(3).notNull(),
+  /** null = pending retry, timestamp = retried at */
+  lastRetriedAt: timestamp("lastRetriedAt"),
+  /** Whether this DLQ entry has been resolved (retried successfully or manually dismissed) */
+  resolved: boolean("resolved").default(false).notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  resolvedIdx: index("ghl_webhook_dlq_resolved_idx").on(table.resolved),
+  eventTypeIdx: index("ghl_webhook_dlq_type_idx").on(table.eventType),
+  createdAtIdx: index("ghl_webhook_dlq_created_at_idx").on(table.createdAt),
+}));
+
+export type GHLWebhookDeadLetterRow = typeof ghlWebhookDeadLetters.$inferSelect;
+export type InsertGHLWebhookDeadLetter = typeof ghlWebhookDeadLetters.$inferInsert;

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -28,6 +28,7 @@ import {
 } from "../lib/sentry";
 import { createRestApi } from "../api/rest";
 import ghlOAuthRouter from "../api/routes/ghl-oauth";
+import ghlWebhookRouter from "../api/routes/ghl-webhooks";
 
 // Initialize Sentry as early as possible
 initSentry();
@@ -137,6 +138,7 @@ export async function createApp() {
   app.use("/api/webhooks/stripe", stripeWebhookRouter);
   // GHL OAuth routes (AI-2877)
   app.use("/api/ghl/oauth", ghlOAuthRouter);
+  app.use("/api/ghl/webhooks", ghlWebhookRouter);
 
   // Mount REST API v1 routes (includes /api/v1/health, /api/v1/tasks, etc.)
   const restApi = createRestApi();

--- a/server/api/routers/ghl.ts
+++ b/server/api/routers/ghl.ts
@@ -8,7 +8,9 @@
  * - Campaign/drip management (list, add/remove contacts)
  * - Workflow listing
  *
- * Linear: AI-2877, AI-2881, AI-3461
+ * - Messaging (send SMS, send email, delivery status, templates)
+ *
+ * Linear: AI-2877, AI-2881, AI-3461, AI-5149
  */
 
 import { z } from "zod";
@@ -644,6 +646,106 @@ export const ghlRouter = router({
       try {
         const service = await getServiceForUser(ctx.user.id, input?.locationId);
         const result = await service.listWorkflows();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Messaging / Communication (AI-5149)
+  // ----------------------------------------
+
+  sendSMS: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        message: z.string().min(1).max(1600),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.sendSMS(input.contactId, input.message);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  sendEmail: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        subject: z.string().min(1).max(998),
+        html: z.string().min(1),
+        emailFrom: z.string().email().optional(),
+        emailTo: z.string().email().optional(),
+        emailReplyTo: z.string().email().optional(),
+        templateId: z.string().optional(),
+        attachments: z
+          .array(
+            z.object({
+              url: z.string().url(),
+              name: z.string().optional(),
+            })
+          )
+          .optional(),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { contactId, locationId, ...emailData } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.sendEmail(contactId, emailData);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  getMessageStatus: protectedProcedure
+    .input(
+      z.object({
+        messageId: z.string().min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.getMessageStatus(input.messageId);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  listTemplates: protectedProcedure
+    .input(
+      z
+        .object({
+          locationId: z.string().optional(),
+          type: z.enum(["sms", "email", "whatsapp"]).optional(),
+          limit: z.number().int().min(1).max(100).default(20),
+          offset: z.number().int().min(0).default(0),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listTemplates({
+          type: input?.type,
+          limit: input?.limit,
+          offset: input?.offset,
+        });
         return result.data;
       } catch (err) {
         if (err instanceof TRPCError) throw err;

--- a/server/api/routers/ghl.ts
+++ b/server/api/routers/ghl.ts
@@ -2,17 +2,13 @@
  * GHL tRPC Router
  *
  * Provides typed RPC endpoints for GHL integration management:
- * - ghl.status — connection health check per location
- * - ghl.listLocations — list all authorized GHL locations
- * - ghl.disconnect — revoke and clean up
- * - ghl.configStatus — check OAuth configuration
- * - ghl.getActiveLocation — get user's currently selected location
- * - ghl.setActiveLocation — switch active location
- * - ghl.getLocationConfig — get per-location config
- * - ghl.updateLocationConfig — update per-location config
- * - ghl.updateLocationDetails — update location name/metadata
+ * - Connection management (status, list, disconnect, config)
+ * - Contact/lead management (search, create, update, tag)
+ * - Pipeline/opportunity management (list, search, create, update)
+ * - Campaign/drip management (list, add/remove contacts)
+ * - Workflow listing
  *
- * Linear: AI-2877, AI-2881
+ * Linear: AI-2877, AI-2881, AI-3461
  */
 
 import { z } from "zod";
@@ -22,6 +18,57 @@ import { GHLService, GHLError } from "../../services/ghl.service";
 import { getDb } from "../../db";
 import { ghlLocations, ghlActiveLocation } from "../../../drizzle/schema-ghl-locations";
 import { eq, and } from "drizzle-orm";
+
+// ========================================
+// HELPERS
+// ========================================
+
+function ghlErrorToTRPC(err: unknown): never {
+  if (err instanceof GHLError) {
+    throw new TRPCError({
+      code:
+        err.category === "auth"
+          ? "UNAUTHORIZED"
+          : err.category === "rate_limit"
+            ? "TOO_MANY_REQUESTS"
+            : "INTERNAL_SERVER_ERROR",
+      message: err.message,
+    });
+  }
+  throw new TRPCError({
+    code: "INTERNAL_SERVER_ERROR",
+    message: err instanceof Error ? err.message : "GHL operation failed",
+  });
+}
+
+/** Get a GHL service for the user's active location, or a specified one. */
+async function getServiceForUser(
+  userId: number,
+  locationId?: string
+): Promise<GHLService> {
+  if (locationId) {
+    return new GHLService(locationId, userId);
+  }
+
+  // Fall back to active location
+  const db = await getDb();
+  if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+
+  const [active] = await db
+    .select()
+    .from(ghlActiveLocation)
+    .where(eq(ghlActiveLocation.userId, userId))
+    .limit(1);
+
+  if (!active) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "No active GHL location. Connect and select a location first.",
+    });
+  }
+
+  return new GHLService(active.locationId, userId);
+}
 
 const locationConfigSchema = z.object({
   automationsEnabled: z.boolean().optional(),
@@ -36,51 +83,29 @@ const locationConfigSchema = z.object({
   tags: z.array(z.string()).optional(),
 });
 
+// ========================================
+// ROUTER
+// ========================================
+
 export const ghlRouter = router({
-  /**
-   * Get connection status for a specific GHL location.
-   */
+  // ----------------------------------------
+  // Connection Management (existing)
+  // ----------------------------------------
+
   status: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1, "locationId is required"),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       try {
         const service = new GHLService(input.locationId, ctx.user.id);
-        const status = await service.getConnectionStatus();
-        return status;
+        return await service.getConnectionStatus();
       } catch (err) {
-        if (err instanceof GHLError) {
-          throw new TRPCError({
-            code:
-              err.category === "auth"
-                ? "UNAUTHORIZED"
-                : err.category === "rate_limit"
-                  ? "TOO_MANY_REQUESTS"
-                  : "INTERNAL_SERVER_ERROR",
-            message: err.message,
-          });
-        }
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message:
-            err instanceof Error ? err.message : "Failed to check GHL status",
-        });
+        ghlErrorToTRPC(err);
       }
     }),
 
-  /**
-   * List all authorized GHL locations for the current user.
-   * Merges data from integrations table + ghl_locations table.
-   */
   listLocations: protectedProcedure.query(async ({ ctx }) => {
     try {
-      // Get OAuth-connected locations from integrations table
       const oauthLocations = await GHLService.listLocations(ctx.user.id);
-
-      // Get enriched location data from ghl_locations table
       const db = await getDb();
       if (!db) return oauthLocations;
 
@@ -94,12 +119,10 @@ export const ghlRouter = router({
           )
         );
 
-      // Build lookup map of enriched data
       const enrichedMap = new Map(
         locationRows.map((row) => [row.locationId, row])
       );
 
-      // Merge: OAuth data + enriched metadata
       return oauthLocations.map((loc) => {
         const enriched = enrichedMap.get(loc.locationId);
         return {
@@ -118,31 +141,17 @@ export const ghlRouter = router({
         };
       });
     } catch (err) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message:
-          err instanceof Error
-            ? err.message
-            : "Failed to list GHL locations",
-      });
+      ghlErrorToTRPC(err);
     }
   }),
 
-  /**
-   * Disconnect a GHL location (revoke tokens and mark inactive).
-   */
   disconnect: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1, "locationId is required"),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       try {
         const service = new GHLService(input.locationId, ctx.user.id);
         await service.disconnect();
 
-        // Also deactivate in ghl_locations table
         const db = await getDb();
         if (db) {
           await db
@@ -155,7 +164,6 @@ export const ghlRouter = router({
               )
             );
 
-          // If this was the active location, clear it
           const [active] = await db
             .select()
             .from(ghlActiveLocation)
@@ -169,33 +177,12 @@ export const ghlRouter = router({
           }
         }
 
-        return {
-          success: true,
-          message: `Disconnected GHL location ${input.locationId}`,
-        };
+        return { success: true, message: `Disconnected GHL location ${input.locationId}` };
       } catch (err) {
-        if (err instanceof GHLError) {
-          throw new TRPCError({
-            code:
-              err.category === "auth"
-                ? "UNAUTHORIZED"
-                : "INTERNAL_SERVER_ERROR",
-            message: err.message,
-          });
-        }
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message:
-            err instanceof Error
-              ? err.message
-              : "Failed to disconnect GHL location",
-        });
+        ghlErrorToTRPC(err);
       }
     }),
 
-  /**
-   * Get the GHL OAuth configuration status (whether client ID/secret are set).
-   */
   configStatus: protectedProcedure.query(async () => {
     return {
       configured: !!process.env.GHL_CLIENT_ID && !!process.env.GHL_CLIENT_SECRET,
@@ -204,9 +191,6 @@ export const ghlRouter = router({
     };
   }),
 
-  /**
-   * Get the user's currently active/selected GHL location.
-   */
   getActiveLocation: protectedProcedure.query(async ({ ctx }) => {
     const db = await getDb();
     if (!db) return null;
@@ -219,7 +203,6 @@ export const ghlRouter = router({
 
     if (!active) return null;
 
-    // Fetch enriched details
     const [location] = await db
       .select()
       .from(ghlLocations)
@@ -240,22 +223,12 @@ export const ghlRouter = router({
     };
   }),
 
-  /**
-   * Set the active/selected GHL location for the current user.
-   */
   setActiveLocation: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1, "locationId is required"),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
-      }
+      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
 
-      // Verify this location exists and belongs to user
       const [location] = await db
         .select()
         .from(ghlLocations)
@@ -269,13 +242,9 @@ export const ghlRouter = router({
         .limit(1);
 
       if (!location) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `GHL location ${input.locationId} not found or not connected`,
-        });
+        throw new TRPCError({ code: "NOT_FOUND", message: `GHL location ${input.locationId} not found` });
       }
 
-      // Upsert active location
       const [existing] = await db
         .select()
         .from(ghlActiveLocation)
@@ -295,22 +264,11 @@ export const ghlRouter = router({
         });
       }
 
-      return {
-        success: true,
-        locationId: input.locationId,
-        name: location.name,
-      };
+      return { success: true, locationId: input.locationId, name: location.name };
     }),
 
-  /**
-   * Get per-location configuration.
-   */
   getLocationConfig: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const db = await getDb();
       if (!db) return null;
@@ -334,23 +292,12 @@ export const ghlRouter = router({
       };
     }),
 
-  /**
-   * Update per-location configuration.
-   */
   updateLocationConfig: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1),
-        config: locationConfigSchema,
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1), config: locationConfigSchema }))
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
-      }
+      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
 
-      // Get current config and merge
       const [location] = await db
         .select()
         .from(ghlLocations)
@@ -362,12 +309,7 @@ export const ghlRouter = router({
         )
         .limit(1);
 
-      if (!location) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `GHL location ${input.locationId} not found`,
-        });
-      }
+      if (!location) throw new TRPCError({ code: "NOT_FOUND", message: `Location not found` });
 
       const mergedConfig = { ...(location.config || {}), ...input.config };
 
@@ -384,9 +326,6 @@ export const ghlRouter = router({
       return { success: true, config: mergedConfig };
     }),
 
-  /**
-   * Update location display name and metadata.
-   */
   updateLocationDetails: protectedProcedure
     .input(
       z.object({
@@ -400,18 +339,12 @@ export const ghlRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
-      }
+      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
 
       const { locationId, ...updates } = input;
-
-      // Filter out undefined values
       const setValues: Record<string, unknown> = { updatedAt: new Date() };
       for (const [key, value] of Object.entries(updates)) {
-        if (value !== undefined) {
-          setValues[key] = value || null;
-        }
+        if (value !== undefined) setValues[key] = value || null;
       }
 
       await db
@@ -425,5 +358,296 @@ export const ghlRouter = router({
         );
 
       return { success: true };
+    }),
+
+  // ----------------------------------------
+  // Contact / Lead Management (AI-3461)
+  // ----------------------------------------
+
+  searchContacts: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        query: z.string().optional(),
+        limit: z.number().int().min(1).max(100).default(20),
+        offset: z.number().int().min(0).default(0),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.searchContacts({
+          query: input.query,
+          limit: input.limit,
+          offset: input.offset,
+        });
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  getContact: protectedProcedure
+    .input(z.object({ contactId: z.string().min(1), locationId: z.string().optional() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.getContact(input.contactId);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  createContact: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        firstName: z.string().optional(),
+        lastName: z.string().optional(),
+        email: z.string().email().optional(),
+        phone: z.string().optional(),
+        tags: z.array(z.string()).optional(),
+        source: z.string().optional(),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { locationId, ...contactData } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.createContact(contactData);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  updateContact: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        locationId: z.string().optional(),
+        firstName: z.string().optional(),
+        lastName: z.string().optional(),
+        email: z.string().email().optional(),
+        phone: z.string().optional(),
+        tags: z.array(z.string()).optional(),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { contactId, locationId, ...updateData } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.updateContact(contactId, updateData);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  addContactTags: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        tags: z.array(z.string().min(1)).min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.addContactTags(input.contactId, input.tags);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  removeContactTags: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        tags: z.array(z.string().min(1)).min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        await service.removeContactTags(input.contactId, input.tags);
+        return { success: true };
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Pipeline / Opportunity Management (AI-3461)
+  // ----------------------------------------
+
+  listPipelines: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listPipelines();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  searchOpportunities: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        pipelineId: z.string().optional(),
+        stageId: z.string().optional(),
+        status: z.enum(["open", "won", "lost", "abandoned", "all"]).default("open"),
+        query: z.string().optional(),
+        limit: z.number().int().min(1).max(100).default(20),
+        offset: z.number().int().min(0).default(0),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const { locationId, ...params } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.searchOpportunities(params);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  createOpportunity: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        pipelineId: z.string().min(1),
+        stageId: z.string().min(1),
+        contactId: z.string().min(1),
+        name: z.string().min(1),
+        monetaryValue: z.number().optional(),
+        status: z.enum(["open", "won", "lost", "abandoned"]).default("open"),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { locationId, ...data } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.createOpportunity(data);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  updateOpportunity: protectedProcedure
+    .input(
+      z.object({
+        opportunityId: z.string().min(1),
+        locationId: z.string().optional(),
+        stageId: z.string().optional(),
+        status: z.enum(["open", "won", "lost", "abandoned"]).optional(),
+        monetaryValue: z.number().optional(),
+        name: z.string().optional(),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { opportunityId, locationId, ...data } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.updateOpportunity(opportunityId, data);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Campaign / Drip Management (AI-3461)
+  // ----------------------------------------
+
+  listCampaigns: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listCampaigns();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  addContactToCampaign: protectedProcedure
+    .input(
+      z.object({
+        campaignId: z.string().min(1),
+        contactId: z.string().min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        await service.addContactToCampaign(input.campaignId, input.contactId);
+        return { success: true };
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  removeContactFromCampaign: protectedProcedure
+    .input(
+      z.object({
+        campaignId: z.string().min(1),
+        contactId: z.string().min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        await service.removeContactFromCampaign(input.campaignId, input.contactId);
+        return { success: true };
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Workflows (AI-3461)
+  // ----------------------------------------
+
+  listWorkflows: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listWorkflows();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
     }),
 });

--- a/server/api/routes/ghl-webhooks.ts
+++ b/server/api/routes/ghl-webhooks.ts
@@ -1,21 +1,36 @@
 /**
- * GHL Webhook Receiver
+ * GHL Webhook Receiver -- Production-Grade
  *
  * Express routes for receiving inbound webhooks from GoHighLevel.
  * Handles contact events, opportunity events, and campaign events
- * for lead routing and data flow synchronization.
+ * with real DB sync, event deduplication, dead letter queue,
+ * structured logging, and workflow engine integration.
  *
  * Routes:
- *   POST /api/ghl/webhooks/inbound — receive GHL webhook events
- *   GET  /api/ghl/webhooks/health  — health check
+ *   POST /api/ghl/webhooks/inbound  -- receive GHL webhook events
+ *   GET  /api/ghl/webhooks/health   -- health check
+ *   GET  /api/ghl/webhooks/dlq      -- view dead letter queue
+ *   POST /api/ghl/webhooks/dlq/:id/retry -- retry a dead letter
  *
- * Linear: AI-3461
+ * Linear: AI-5147
  */
 
 import express, { Request, Response } from "express";
 import crypto from "crypto";
+import { eq, and, desc } from "drizzle-orm";
+import { getDb } from "../../db";
+import { ghlLocations } from "../../../drizzle/schema-ghl-locations";
+import {
+  ghlContacts,
+  ghlOpportunities,
+  ghlWebhookEvents,
+  ghlWebhookDeadLetters,
+} from "../../../drizzle/schema-ghl-webhooks";
+import { addWorkflowExecutionJob, REDIS_AVAILABLE } from "../../_core/queue";
+import { logger } from "../../lib/logger";
 
 const webhookRouter = express.Router();
+const log = logger.child({ service: "ghl-webhooks" });
 
 // ========================================
 // TYPES
@@ -24,6 +39,8 @@ const webhookRouter = express.Router();
 interface GHLWebhookEvent {
   type: string;
   locationId?: string;
+  /** GHL-provided event ID for deduplication */
+  id?: string;
   // Contact events
   contact?: {
     id: string;
@@ -54,75 +71,371 @@ interface GHLWebhookEvent {
   timestamp?: string;
 }
 
-type WebhookHandler = (event: GHLWebhookEvent) => Promise<void>;
+type WebhookHandler = (event: GHLWebhookEvent, userId: number) => Promise<void>;
+
+// ========================================
+// HELPERS
+// ========================================
+
+/**
+ * Resolve the userId that owns a given GHL locationId.
+ * Returns null if the location is not connected.
+ */
+async function resolveUserForLocation(locationId: string): Promise<number | null> {
+  const db = await getDb();
+  if (!db || !locationId) return null;
+
+  const rows = await db
+    .select({ userId: ghlLocations.userId })
+    .from(ghlLocations)
+    .where(and(eq(ghlLocations.locationId, locationId), eq(ghlLocations.isActive, true)))
+    .limit(1);
+
+  return rows.length > 0 ? rows[0].userId : null;
+}
+
+/**
+ * Generate a deterministic event ID when GHL does not provide one.
+ * Uses type + locationId + contactId/opportunityId + timestamp.
+ */
+function deriveEventId(event: GHLWebhookEvent): string {
+  if (event.id) return event.id;
+  const parts = [
+    event.type,
+    event.locationId || "",
+    event.contact?.id || event.opportunity?.id || event.contactId || "",
+    event.timestamp || "",
+  ];
+  return crypto.createHash("sha256").update(parts.join("|")).digest("hex").slice(0, 64);
+}
+
+/**
+ * Check if this event has already been processed (dedup).
+ */
+async function isDuplicateEvent(eventId: string): Promise<boolean> {
+  const db = await getDb();
+  if (!db) return false;
+
+  const rows = await db
+    .select({ id: ghlWebhookEvents.id })
+    .from(ghlWebhookEvents)
+    .where(eq(ghlWebhookEvents.eventId, eventId))
+    .limit(1);
+
+  return rows.length > 0;
+}
+
+/**
+ * Record a processed event for future dedup.
+ */
+async function recordEvent(eventId: string, eventType: string, locationId: string | undefined, success: boolean): Promise<void> {
+  const db = await getDb();
+  if (!db) return;
+
+  await db.insert(ghlWebhookEvents).values({
+    eventId,
+    eventType,
+    locationId: locationId || null,
+    success,
+  }).onConflictDoNothing();
+}
+
+/**
+ * Push a failed event into the dead letter queue.
+ */
+async function pushToDeadLetterQueue(
+  event: GHLWebhookEvent,
+  eventId: string,
+  error: string
+): Promise<void> {
+  const db = await getDb();
+  if (!db) return;
+
+  await db.insert(ghlWebhookDeadLetters).values({
+    eventId,
+    eventType: event.type,
+    locationId: event.locationId || null,
+    payload: event as unknown as Record<string, unknown>,
+    error,
+  });
+
+  log.warn({ eventId, eventType: event.type, error }, "Event pushed to dead letter queue");
+}
+
+/**
+ * Fire a workflow execution job if Redis + workflow queue is available.
+ */
+async function triggerWorkflow(userId: number, event: GHLWebhookEvent): Promise<void> {
+  if (!REDIS_AVAILABLE) return;
+
+  try {
+    await addWorkflowExecutionJob({
+      userId: String(userId),
+      workflowId: `ghl-webhook-${event.type}`,
+      triggerId: event.id || deriveEventId(event),
+      context: {
+        source: "ghl-webhook",
+        eventType: event.type,
+        locationId: event.locationId,
+        contactId: event.contact?.id || event.contactId,
+        opportunityId: event.opportunity?.id,
+        campaignId: event.campaign?.id,
+        timestamp: event.timestamp || new Date().toISOString(),
+      },
+    });
+
+    log.debug({ eventType: event.type, userId }, "Workflow job enqueued");
+  } catch (err) {
+    log.warn({ err, eventType: event.type }, "Failed to enqueue workflow job (non-fatal)");
+  }
+}
 
 // ========================================
 // EVENT HANDLERS
 // ========================================
 
 const eventHandlers: Record<string, WebhookHandler> = {
-  "ContactCreate": async (event) => {
-    console.log("[GHL Webhook] New contact created:", {
-      contactId: event.contact?.id,
-      name: `${event.contact?.firstName || ""} ${event.contact?.lastName || ""}`.trim(),
-      email: event.contact?.email,
-      source: event.contact?.source,
-      locationId: event.locationId,
+  ContactCreate: async (event, userId) => {
+    const c = event.contact;
+    if (!c?.id) throw new Error("Missing contact.id in ContactCreate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlContacts).values({
+      userId,
+      ghlContactId: c.id,
+      locationId: event.locationId || "",
+      firstName: c.firstName || null,
+      lastName: c.lastName || null,
+      email: c.email || null,
+      phone: c.phone || null,
+      tags: c.tags || null,
+      source: c.source || null,
+      customFields: c.customFields || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+      set: {
+        firstName: c.firstName || null,
+        lastName: c.lastName || null,
+        email: c.email || null,
+        phone: c.phone || null,
+        tags: c.tags || null,
+        source: c.source || null,
+        customFields: c.customFields || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
-    // Lead routing logic: tag-based routing happens in GHL workflows,
-    // but we log and can trigger internal automations here
+
+    log.info({
+      contactId: c.id,
+      email: c.email,
+      locationId: event.locationId,
+    }, "Contact created/upserted");
   },
 
-  "ContactUpdate": async (event) => {
-    console.log("[GHL Webhook] Contact updated:", {
-      contactId: event.contact?.id,
-      locationId: event.locationId,
+  ContactUpdate: async (event, userId) => {
+    const c = event.contact;
+    if (!c?.id) throw new Error("Missing contact.id in ContactUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlContacts).values({
+      userId,
+      ghlContactId: c.id,
+      locationId: event.locationId || "",
+      firstName: c.firstName || null,
+      lastName: c.lastName || null,
+      email: c.email || null,
+      phone: c.phone || null,
+      tags: c.tags || null,
+      source: c.source || null,
+      customFields: c.customFields || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+      set: {
+        firstName: c.firstName || null,
+        lastName: c.lastName || null,
+        email: c.email || null,
+        phone: c.phone || null,
+        tags: c.tags || null,
+        source: c.source || null,
+        customFields: c.customFields || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({ contactId: c.id, locationId: event.locationId }, "Contact updated");
   },
 
-  "ContactTagUpdate": async (event) => {
-    console.log("[GHL Webhook] Contact tags changed:", {
-      contactId: event.contact?.id,
-      tags: event.contact?.tags,
-      locationId: event.locationId,
+  ContactTagUpdate: async (event, userId) => {
+    const c = event.contact;
+    if (!c?.id) throw new Error("Missing contact.id in ContactTagUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlContacts).values({
+      userId,
+      ghlContactId: c.id,
+      locationId: event.locationId || "",
+      tags: c.tags || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+      set: {
+        tags: c.tags || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({ contactId: c.id, tags: c.tags, locationId: event.locationId }, "Contact tags updated");
   },
 
-  "OpportunityCreate": async (event) => {
-    console.log("[GHL Webhook] New opportunity:", {
-      opportunityId: event.opportunity?.id,
-      name: event.opportunity?.name,
-      pipelineId: event.opportunity?.pipelineId,
-      stageId: event.opportunity?.pipelineStageId,
-      contactId: event.opportunity?.contactId,
-      value: event.opportunity?.monetaryValue,
-      locationId: event.locationId,
+  OpportunityCreate: async (event, userId) => {
+    const o = event.opportunity;
+    if (!o?.id) throw new Error("Missing opportunity.id in OpportunityCreate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlOpportunities).values({
+      userId,
+      ghlOpportunityId: o.id,
+      locationId: event.locationId || "",
+      name: o.name || null,
+      pipelineId: o.pipelineId || null,
+      pipelineStageId: o.pipelineStageId || null,
+      status: o.status || null,
+      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+      ghlContactId: o.contactId || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+      set: {
+        name: o.name || null,
+        pipelineId: o.pipelineId || null,
+        pipelineStageId: o.pipelineStageId || null,
+        status: o.status || null,
+        monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+        ghlContactId: o.contactId || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({
+      opportunityId: o.id,
+      pipeline: o.pipelineId,
+      stage: o.pipelineStageId,
+      value: o.monetaryValue,
+      locationId: event.locationId,
+    }, "Opportunity created/upserted");
   },
 
-  "OpportunityStageUpdate": async (event) => {
-    console.log("[GHL Webhook] Opportunity stage changed:", {
-      opportunityId: event.opportunity?.id,
-      newStage: event.opportunity?.pipelineStageId,
-      status: event.opportunity?.status,
-      locationId: event.locationId,
+  OpportunityStageUpdate: async (event, userId) => {
+    const o = event.opportunity;
+    if (!o?.id) throw new Error("Missing opportunity.id in OpportunityStageUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlOpportunities).values({
+      userId,
+      ghlOpportunityId: o.id,
+      locationId: event.locationId || "",
+      name: o.name || null,
+      pipelineId: o.pipelineId || null,
+      pipelineStageId: o.pipelineStageId || null,
+      status: o.status || null,
+      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+      ghlContactId: o.contactId || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+      set: {
+        pipelineStageId: o.pipelineStageId || null,
+        status: o.status || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({
+      opportunityId: o.id,
+      newStage: o.pipelineStageId,
+      status: o.status,
+      locationId: event.locationId,
+    }, "Opportunity stage updated");
   },
 
-  "OpportunityStatusUpdate": async (event) => {
-    console.log("[GHL Webhook] Opportunity status changed:", {
-      opportunityId: event.opportunity?.id,
-      status: event.opportunity?.status,
-      locationId: event.locationId,
+  OpportunityStatusUpdate: async (event, userId) => {
+    const o = event.opportunity;
+    if (!o?.id) throw new Error("Missing opportunity.id in OpportunityStatusUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlOpportunities).values({
+      userId,
+      ghlOpportunityId: o.id,
+      locationId: event.locationId || "",
+      name: o.name || null,
+      pipelineId: o.pipelineId || null,
+      pipelineStageId: o.pipelineStageId || null,
+      status: o.status || null,
+      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+      ghlContactId: o.contactId || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+      set: {
+        status: o.status || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({
+      opportunityId: o.id,
+      status: o.status,
+      locationId: event.locationId,
+    }, "Opportunity status updated");
   },
 
-  "CampaignStatusUpdate": async (event) => {
-    console.log("[GHL Webhook] Campaign status update:", {
+  CampaignStatusUpdate: async (event, _userId) => {
+    // Campaign events are logged and forwarded to workflow engine.
+    // No dedicated table -- these trigger internal automations.
+    log.info({
       campaignId: event.campaign?.id,
+      campaignName: event.campaign?.name,
       contactId: event.contactId,
       locationId: event.locationId,
-    });
+    }, "Campaign status update received");
   },
 };
 
@@ -157,7 +470,7 @@ webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Reques
 
   // Verify signature if secret is configured
   if (webhookSecret && !verifyWebhookSignature(rawBody, signature, webhookSecret)) {
-    console.warn("[GHL Webhook] Invalid signature, rejecting");
+    log.warn({ ip: req.ip }, "Invalid webhook signature, rejecting");
     res.status(401).json({ error: "Invalid webhook signature" });
     return;
   }
@@ -166,36 +479,73 @@ webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Reques
   try {
     event = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
   } catch {
-    console.error("[GHL Webhook] Failed to parse body");
+    log.error("Failed to parse webhook body");
     res.status(400).json({ error: "Invalid JSON body" });
     return;
   }
 
   const eventType = event.type;
   if (!eventType) {
-    console.warn("[GHL Webhook] Missing event type");
+    log.warn("Missing event type in webhook payload");
     res.status(400).json({ error: "Missing event type" });
     return;
   }
 
-  console.log(`[GHL Webhook] Received event: ${eventType}`, {
+  const eventId = deriveEventId(event);
+
+  log.info({
+    eventId,
+    eventType,
     locationId: event.locationId,
     timestamp: event.timestamp || new Date().toISOString(),
-  });
+  }, "Webhook received");
 
   // Respond immediately (GHL expects quick 200)
-  res.status(200).json({ received: true, type: eventType });
+  res.status(200).json({ received: true, type: eventType, eventId });
 
-  // Process event asynchronously
+  // ---- Async processing below ----
+
+  // 1. Dedup check
+  try {
+    if (await isDuplicateEvent(eventId)) {
+      log.info({ eventId, eventType }, "Duplicate event, skipping");
+      return;
+    }
+  } catch (err) {
+    log.warn({ err, eventId }, "Dedup check failed, processing anyway");
+  }
+
+  // 2. Resolve user from locationId
+  let userId: number | null = null;
+  if (event.locationId) {
+    userId = await resolveUserForLocation(event.locationId);
+  }
+
+  if (!userId) {
+    log.warn({ locationId: event.locationId, eventType }, "No user found for location, using DLQ");
+    await pushToDeadLetterQueue(event, eventId, `No user found for locationId: ${event.locationId || "missing"}`);
+    await recordEvent(eventId, eventType, event.locationId, false);
+    return;
+  }
+
+  // 3. Process event
   const handler = eventHandlers[eventType];
   if (handler) {
     try {
-      await handler(event);
+      await handler(event, userId);
+      await recordEvent(eventId, eventType, event.locationId, true);
+
+      // 4. Trigger workflow engine
+      await triggerWorkflow(userId, event);
     } catch (err) {
-      console.error(`[GHL Webhook] Error handling ${eventType}:`, err);
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      log.error({ err, eventId, eventType, locationId: event.locationId }, "Handler failed");
+      await pushToDeadLetterQueue(event, eventId, errorMsg);
+      await recordEvent(eventId, eventType, event.locationId, false);
     }
   } else {
-    console.log(`[GHL Webhook] No handler for event type: ${eventType}`);
+    log.info({ eventType }, "No handler registered for event type");
+    await recordEvent(eventId, eventType, event.locationId, true);
   }
 });
 
@@ -203,14 +553,152 @@ webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Reques
 // HEALTH CHECK
 // ========================================
 
-webhookRouter.get("/health", (_req: Request, res: Response) => {
+webhookRouter.get("/health", async (_req: Request, res: Response) => {
+  const db = await getDb();
+  let dlqCount = 0;
+
+  if (db) {
+    try {
+      const rows = await db
+        .select({ id: ghlWebhookDeadLetters.id })
+        .from(ghlWebhookDeadLetters)
+        .where(eq(ghlWebhookDeadLetters.resolved, false));
+      dlqCount = rows.length;
+    } catch {
+      // DB may not have the table yet
+    }
+  }
+
   res.json({
     status: "ok",
     service: "ghl-webhooks",
     configured: !!process.env.GHL_WEBHOOK_SECRET,
     supportedEvents: Object.keys(eventHandlers),
+    deadLetterCount: dlqCount,
+    workflowQueueAvailable: REDIS_AVAILABLE,
     timestamp: new Date().toISOString(),
   });
+});
+
+// ========================================
+// DLQ MANAGEMENT
+// ========================================
+
+webhookRouter.get("/dlq", async (_req: Request, res: Response) => {
+  const db = await getDb();
+  if (!db) {
+    res.status(503).json({ error: "Database not available" });
+    return;
+  }
+
+  try {
+    const items = await db
+      .select()
+      .from(ghlWebhookDeadLetters)
+      .where(eq(ghlWebhookDeadLetters.resolved, false))
+      .orderBy(desc(ghlWebhookDeadLetters.createdAt))
+      .limit(100);
+
+    res.json({ count: items.length, items });
+  } catch (err) {
+    log.error({ err }, "Failed to fetch DLQ items");
+    res.status(500).json({ error: "Failed to fetch dead letter queue" });
+  }
+});
+
+webhookRouter.post("/dlq/:id/retry", async (req: Request, res: Response) => {
+  const db = await getDb();
+  if (!db) {
+    res.status(503).json({ error: "Database not available" });
+    return;
+  }
+
+  const dlqId = parseInt(req.params.id, 10);
+  if (isNaN(dlqId)) {
+    res.status(400).json({ error: "Invalid DLQ entry ID" });
+    return;
+  }
+
+  try {
+    const rows = await db
+      .select()
+      .from(ghlWebhookDeadLetters)
+      .where(eq(ghlWebhookDeadLetters.id, dlqId))
+      .limit(1);
+
+    if (rows.length === 0) {
+      res.status(404).json({ error: "DLQ entry not found" });
+      return;
+    }
+
+    const entry = rows[0];
+    if (entry.resolved) {
+      res.status(400).json({ error: "DLQ entry already resolved" });
+      return;
+    }
+
+    if (entry.retryCount >= entry.maxRetries) {
+      res.status(400).json({ error: "Max retries exceeded" });
+      return;
+    }
+
+    const event = entry.payload as unknown as GHLWebhookEvent;
+    const eventType = event.type || entry.eventType;
+
+    // Re-resolve user
+    let userId: number | null = null;
+    if (event.locationId) {
+      userId = await resolveUserForLocation(event.locationId);
+    }
+
+    if (!userId) {
+      await db.update(ghlWebhookDeadLetters).set({
+        retryCount: entry.retryCount + 1,
+        lastRetriedAt: new Date(),
+        error: `Retry failed: No user found for locationId: ${event.locationId || "missing"}`,
+        updatedAt: new Date(),
+      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+
+      res.status(422).json({ error: "No user found for location on retry" });
+      return;
+    }
+
+    const handler = eventHandlers[eventType];
+    if (!handler) {
+      res.status(422).json({ error: `No handler for event type: ${eventType}` });
+      return;
+    }
+
+    try {
+      await handler(event, userId);
+      await triggerWorkflow(userId, event);
+
+      // Mark resolved
+      await db.update(ghlWebhookDeadLetters).set({
+        resolved: true,
+        retryCount: entry.retryCount + 1,
+        lastRetriedAt: new Date(),
+        updatedAt: new Date(),
+      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+
+      log.info({ dlqId, eventType }, "DLQ entry retried successfully");
+      res.json({ success: true, message: "Event reprocessed successfully" });
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      await db.update(ghlWebhookDeadLetters).set({
+        retryCount: entry.retryCount + 1,
+        lastRetriedAt: new Date(),
+        error: `Retry failed: ${errorMsg}`,
+        updatedAt: new Date(),
+      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+
+      log.error({ err, dlqId, eventType }, "DLQ retry failed");
+      res.status(500).json({ error: "Retry failed", detail: errorMsg });
+    }
+  } catch (err) {
+    log.error({ err }, "Failed to process DLQ retry");
+    res.status(500).json({ error: "Failed to process retry" });
+  }
 });
 
 export default webhookRouter;

--- a/server/api/routes/ghl-webhooks.ts
+++ b/server/api/routes/ghl-webhooks.ts
@@ -1,0 +1,216 @@
+/**
+ * GHL Webhook Receiver
+ *
+ * Express routes for receiving inbound webhooks from GoHighLevel.
+ * Handles contact events, opportunity events, and campaign events
+ * for lead routing and data flow synchronization.
+ *
+ * Routes:
+ *   POST /api/ghl/webhooks/inbound — receive GHL webhook events
+ *   GET  /api/ghl/webhooks/health  — health check
+ *
+ * Linear: AI-3461
+ */
+
+import express, { Request, Response } from "express";
+import crypto from "crypto";
+
+const webhookRouter = express.Router();
+
+// ========================================
+// TYPES
+// ========================================
+
+interface GHLWebhookEvent {
+  type: string;
+  locationId?: string;
+  // Contact events
+  contact?: {
+    id: string;
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phone?: string;
+    tags?: string[];
+    source?: string;
+    customFields?: Array<{ id: string; value: string }>;
+  };
+  // Opportunity events
+  opportunity?: {
+    id: string;
+    name: string;
+    pipelineId: string;
+    pipelineStageId: string;
+    status: string;
+    monetaryValue?: number;
+    contactId: string;
+  };
+  // Campaign events
+  campaign?: {
+    id: string;
+    name: string;
+  };
+  contactId?: string;
+  timestamp?: string;
+}
+
+type WebhookHandler = (event: GHLWebhookEvent) => Promise<void>;
+
+// ========================================
+// EVENT HANDLERS
+// ========================================
+
+const eventHandlers: Record<string, WebhookHandler> = {
+  "ContactCreate": async (event) => {
+    console.log("[GHL Webhook] New contact created:", {
+      contactId: event.contact?.id,
+      name: `${event.contact?.firstName || ""} ${event.contact?.lastName || ""}`.trim(),
+      email: event.contact?.email,
+      source: event.contact?.source,
+      locationId: event.locationId,
+    });
+    // Lead routing logic: tag-based routing happens in GHL workflows,
+    // but we log and can trigger internal automations here
+  },
+
+  "ContactUpdate": async (event) => {
+    console.log("[GHL Webhook] Contact updated:", {
+      contactId: event.contact?.id,
+      locationId: event.locationId,
+    });
+  },
+
+  "ContactTagUpdate": async (event) => {
+    console.log("[GHL Webhook] Contact tags changed:", {
+      contactId: event.contact?.id,
+      tags: event.contact?.tags,
+      locationId: event.locationId,
+    });
+  },
+
+  "OpportunityCreate": async (event) => {
+    console.log("[GHL Webhook] New opportunity:", {
+      opportunityId: event.opportunity?.id,
+      name: event.opportunity?.name,
+      pipelineId: event.opportunity?.pipelineId,
+      stageId: event.opportunity?.pipelineStageId,
+      contactId: event.opportunity?.contactId,
+      value: event.opportunity?.monetaryValue,
+      locationId: event.locationId,
+    });
+  },
+
+  "OpportunityStageUpdate": async (event) => {
+    console.log("[GHL Webhook] Opportunity stage changed:", {
+      opportunityId: event.opportunity?.id,
+      newStage: event.opportunity?.pipelineStageId,
+      status: event.opportunity?.status,
+      locationId: event.locationId,
+    });
+  },
+
+  "OpportunityStatusUpdate": async (event) => {
+    console.log("[GHL Webhook] Opportunity status changed:", {
+      opportunityId: event.opportunity?.id,
+      status: event.opportunity?.status,
+      locationId: event.locationId,
+    });
+  },
+
+  "CampaignStatusUpdate": async (event) => {
+    console.log("[GHL Webhook] Campaign status update:", {
+      campaignId: event.campaign?.id,
+      contactId: event.contactId,
+      locationId: event.locationId,
+    });
+  },
+};
+
+// ========================================
+// SIGNATURE VERIFICATION
+// ========================================
+
+function verifyWebhookSignature(
+  body: string,
+  signature: string | undefined,
+  secret: string
+): boolean {
+  if (!signature || !secret) return !secret; // Skip if no secret configured
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(body)
+    .digest("hex");
+  return crypto.timingSafeEqual(
+    Buffer.from(signature),
+    Buffer.from(expected)
+  );
+}
+
+// ========================================
+// POST /api/ghl/webhooks/inbound
+// ========================================
+
+webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Request, res: Response) => {
+  const webhookSecret = process.env.GHL_WEBHOOK_SECRET;
+  const signature = req.headers["x-ghl-signature"] as string | undefined;
+  const rawBody = typeof req.body === "string" ? req.body : JSON.stringify(req.body);
+
+  // Verify signature if secret is configured
+  if (webhookSecret && !verifyWebhookSignature(rawBody, signature, webhookSecret)) {
+    console.warn("[GHL Webhook] Invalid signature, rejecting");
+    res.status(401).json({ error: "Invalid webhook signature" });
+    return;
+  }
+
+  let event: GHLWebhookEvent;
+  try {
+    event = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+  } catch {
+    console.error("[GHL Webhook] Failed to parse body");
+    res.status(400).json({ error: "Invalid JSON body" });
+    return;
+  }
+
+  const eventType = event.type;
+  if (!eventType) {
+    console.warn("[GHL Webhook] Missing event type");
+    res.status(400).json({ error: "Missing event type" });
+    return;
+  }
+
+  console.log(`[GHL Webhook] Received event: ${eventType}`, {
+    locationId: event.locationId,
+    timestamp: event.timestamp || new Date().toISOString(),
+  });
+
+  // Respond immediately (GHL expects quick 200)
+  res.status(200).json({ received: true, type: eventType });
+
+  // Process event asynchronously
+  const handler = eventHandlers[eventType];
+  if (handler) {
+    try {
+      await handler(event);
+    } catch (err) {
+      console.error(`[GHL Webhook] Error handling ${eventType}:`, err);
+    }
+  } else {
+    console.log(`[GHL Webhook] No handler for event type: ${eventType}`);
+  }
+});
+
+// ========================================
+// HEALTH CHECK
+// ========================================
+
+webhookRouter.get("/health", (_req: Request, res: Response) => {
+  res.json({
+    status: "ok",
+    service: "ghl-webhooks",
+    configured: !!process.env.GHL_WEBHOOK_SECRET,
+    supportedEvents: Object.keys(eventHandlers),
+    timestamp: new Date().toISOString(),
+  });
+});
+
+export default webhookRouter;

--- a/server/services/ghl.service.ts
+++ b/server/services/ghl.service.ts
@@ -187,6 +187,37 @@ export interface GHLWorkflow {
   locationId: string;
 }
 
+export interface GHLMessage {
+  id: string;
+  conversationId: string;
+  contactId: string;
+  locationId: string;
+  body?: string;
+  type: "SMS" | "Email" | "TYPE_CALL" | "TYPE_LIVE_CHAT" | "TYPE_ACTIVITY_CONTACT";
+  direction: "inbound" | "outbound";
+  status: "pending" | "sent" | "delivered" | "read" | "failed" | "undelivered";
+  dateAdded?: string;
+  messageType?: string;
+  source?: string;
+  contentType?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface GHLEmailAttachment {
+  url: string;
+  name?: string;
+}
+
+export interface GHLTemplate {
+  id: string;
+  name: string;
+  type: "sms" | "email" | "whatsapp";
+  body?: string;
+  subject?: string;
+  locationId: string;
+  dateAdded?: string;
+}
+
 // ========================================
 // TOKEN BUCKET RATE LIMITER
 // ========================================
@@ -1018,6 +1049,88 @@ export class GHLService {
       method: "GET",
       endpoint: "/workflows/",
       params: { locationId: this.locationId },
+    });
+  }
+
+  // ----------------------------------------
+  // Messaging / Communication (AI-5149)
+  // ----------------------------------------
+
+  /**
+   * Send an SMS message to a contact via GHL Conversations API.
+   */
+  async sendSMS(
+    contactId: string,
+    message: string
+  ): Promise<GHLApiResponse<{ messageId: string; message: GHLMessage }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/conversations/messages",
+      data: {
+        type: "SMS",
+        contactId,
+        message,
+      },
+    });
+  }
+
+  /**
+   * Send an email to a contact via GHL Conversations API.
+   */
+  async sendEmail(
+    contactId: string,
+    data: {
+      subject: string;
+      html: string;
+      emailFrom?: string;
+      emailTo?: string;
+      emailReplyTo?: string;
+      templateId?: string;
+      attachments?: GHLEmailAttachment[];
+    }
+  ): Promise<GHLApiResponse<{ messageId: string; message: GHLMessage }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/conversations/messages",
+      data: {
+        type: "Email",
+        contactId,
+        ...data,
+      },
+    });
+  }
+
+  /**
+   * Get message delivery status by message ID.
+   */
+  async getMessageStatus(
+    messageId: string
+  ): Promise<GHLApiResponse<{ message: GHLMessage }>> {
+    return this.request({
+      method: "GET",
+      endpoint: `/conversations/messages/${messageId}`,
+    });
+  }
+
+  /**
+   * List email/SMS templates for this location.
+   */
+  async listTemplates(params?: {
+    type?: "sms" | "email" | "whatsapp";
+    limit?: number;
+    offset?: number;
+  }): Promise<GHLApiResponse<{ templates: GHLTemplate[]; total: number }>> {
+    const searchParams: Record<string, string> = {
+      locationId: this.locationId,
+      ...(params?.type ? { type: params.type } : {}),
+      ...(params?.limit ? { limit: String(params.limit) } : {}),
+      ...(params?.offset ? { offset: String(params.offset) } : {}),
+    };
+
+    return this.request({
+      method: "GET",
+      endpoint: "/conversations/templates",
+      params: searchParams,
     });
   }
 

--- a/server/services/ghl.service.ts
+++ b/server/services/ghl.service.ts
@@ -134,6 +134,59 @@ export interface GHLLocation {
   email?: string;
 }
 
+export interface GHLContact {
+  id: string;
+  locationId: string;
+  firstName?: string;
+  lastName?: string;
+  name?: string;
+  email?: string;
+  phone?: string;
+  tags?: string[];
+  source?: string;
+  dateAdded?: string;
+  customFields?: Array<{ id: string; value: string }>;
+}
+
+export interface GHLPipeline {
+  id: string;
+  name: string;
+  locationId: string;
+  stages: Array<{
+    id: string;
+    name: string;
+    position: number;
+  }>;
+}
+
+export interface GHLOpportunity {
+  id: string;
+  name: string;
+  pipelineId: string;
+  pipelineStageId: string;
+  status: "open" | "won" | "lost" | "abandoned";
+  monetaryValue?: number;
+  contactId: string;
+  locationId: string;
+  createdAt?: string;
+  updatedAt?: string;
+  customFields?: Array<{ id: string; value: string }>;
+}
+
+export interface GHLCampaign {
+  id: string;
+  name: string;
+  status: string;
+  locationId: string;
+}
+
+export interface GHLWorkflow {
+  id: string;
+  name: string;
+  status: string;
+  locationId: string;
+}
+
 // ========================================
 // TOKEN BUCKET RATE LIMITER
 // ========================================
@@ -716,6 +769,256 @@ export class GHLService {
     console.log(
       `[GHL] Disconnected location ${this.locationId} for user ${this.userId}`
     );
+  }
+
+  // ----------------------------------------
+  // Contact / Lead Management
+  // ----------------------------------------
+
+  /**
+   * Search contacts with optional filters.
+   */
+  async searchContacts(params: {
+    query?: string;
+    limit?: number;
+    offset?: number;
+    filters?: Record<string, string>;
+  }): Promise<GHLApiResponse<{ contacts: GHLContact[]; total: number }>> {
+    const searchParams: Record<string, string> = {
+      locationId: this.locationId,
+      ...(params.query ? { query: params.query } : {}),
+      ...(params.limit ? { limit: String(params.limit) } : {}),
+      ...(params.offset ? { startAfter: String(params.offset) } : {}),
+      ...(params.filters || {}),
+    };
+
+    return this.request({
+      method: "GET",
+      endpoint: "/contacts/",
+      params: searchParams,
+    });
+  }
+
+  /**
+   * Get a single contact by ID.
+   */
+  async getContact(contactId: string): Promise<GHLApiResponse<{ contact: GHLContact }>> {
+    return this.request({
+      method: "GET",
+      endpoint: `/contacts/${contactId}`,
+    });
+  }
+
+  /**
+   * Create a new contact in GHL.
+   */
+  async createContact(data: {
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phone?: string;
+    tags?: string[];
+    customFields?: Array<{ id: string; value: string }>;
+    source?: string;
+  }): Promise<GHLApiResponse<{ contact: GHLContact }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/contacts/",
+      data: {
+        ...data,
+        locationId: this.locationId,
+      },
+    });
+  }
+
+  /**
+   * Update an existing contact.
+   */
+  async updateContact(
+    contactId: string,
+    data: {
+      firstName?: string;
+      lastName?: string;
+      email?: string;
+      phone?: string;
+      tags?: string[];
+      customFields?: Array<{ id: string; value: string }>;
+    }
+  ): Promise<GHLApiResponse<{ contact: GHLContact }>> {
+    return this.request({
+      method: "PUT",
+      endpoint: `/contacts/${contactId}`,
+      data,
+    });
+  }
+
+  /**
+   * Add tags to a contact (used for lead routing).
+   */
+  async addContactTags(
+    contactId: string,
+    tags: string[]
+  ): Promise<GHLApiResponse<{ tags: string[] }>> {
+    return this.request({
+      method: "POST",
+      endpoint: `/contacts/${contactId}/tags`,
+      data: { tags },
+    });
+  }
+
+  /**
+   * Remove tags from a contact.
+   */
+  async removeContactTags(
+    contactId: string,
+    tags: string[]
+  ): Promise<GHLApiResponse<unknown>> {
+    return this.request({
+      method: "DELETE",
+      endpoint: `/contacts/${contactId}/tags`,
+      data: { tags },
+    });
+  }
+
+  // ----------------------------------------
+  // Pipeline / Opportunity Management
+  // ----------------------------------------
+
+  /**
+   * List all pipelines for this location.
+   */
+  async listPipelines(): Promise<GHLApiResponse<{ pipelines: GHLPipeline[] }>> {
+    return this.request({
+      method: "GET",
+      endpoint: "/opportunities/pipelines",
+      params: { locationId: this.locationId },
+    });
+  }
+
+  /**
+   * Search opportunities (deals) with filters.
+   */
+  async searchOpportunities(params: {
+    pipelineId?: string;
+    stageId?: string;
+    status?: "open" | "won" | "lost" | "abandoned" | "all";
+    query?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<GHLApiResponse<{ opportunities: GHLOpportunity[]; meta: { total: number } }>> {
+    const searchParams: Record<string, string> = {
+      location_id: this.locationId,
+      ...(params.pipelineId ? { pipeline_id: params.pipelineId } : {}),
+      ...(params.stageId ? { stage_id: params.stageId } : {}),
+      ...(params.status && params.status !== "all" ? { status: params.status } : {}),
+      ...(params.query ? { q: params.query } : {}),
+      ...(params.limit ? { limit: String(params.limit) } : {}),
+      ...(params.offset ? { startAfter: String(params.offset) } : {}),
+    };
+
+    return this.request({
+      method: "GET",
+      endpoint: "/opportunities/search",
+      params: searchParams,
+    });
+  }
+
+  /**
+   * Create a new opportunity (deal/showing request).
+   */
+  async createOpportunity(data: {
+    pipelineId: string;
+    stageId: string;
+    contactId: string;
+    name: string;
+    monetaryValue?: number;
+    status?: "open" | "won" | "lost" | "abandoned";
+    customFields?: Array<{ id: string; value: string }>;
+  }): Promise<GHLApiResponse<{ opportunity: GHLOpportunity }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/opportunities/",
+      data: {
+        ...data,
+        locationId: this.locationId,
+      },
+    });
+  }
+
+  /**
+   * Update an opportunity (move stage, change status, etc.).
+   */
+  async updateOpportunity(
+    opportunityId: string,
+    data: {
+      stageId?: string;
+      status?: "open" | "won" | "lost" | "abandoned";
+      monetaryValue?: number;
+      name?: string;
+      customFields?: Array<{ id: string; value: string }>;
+    }
+  ): Promise<GHLApiResponse<{ opportunity: GHLOpportunity }>> {
+    return this.request({
+      method: "PUT",
+      endpoint: `/opportunities/${opportunityId}`,
+      data,
+    });
+  }
+
+  // ----------------------------------------
+  // Campaign / Drip Management
+  // ----------------------------------------
+
+  /**
+   * List all campaigns for this location.
+   */
+  async listCampaigns(): Promise<GHLApiResponse<{ campaigns: GHLCampaign[] }>> {
+    return this.request({
+      method: "GET",
+      endpoint: "/campaigns/",
+      params: { locationId: this.locationId },
+    });
+  }
+
+  /**
+   * Add a contact to a campaign (drip sequence).
+   */
+  async addContactToCampaign(
+    campaignId: string,
+    contactId: string
+  ): Promise<GHLApiResponse<unknown>> {
+    return this.request({
+      method: "POST",
+      endpoint: `/campaigns/${campaignId}/contacts/${contactId}`,
+    });
+  }
+
+  /**
+   * Remove a contact from a campaign.
+   */
+  async removeContactFromCampaign(
+    campaignId: string,
+    contactId: string
+  ): Promise<GHLApiResponse<unknown>> {
+    return this.request({
+      method: "DELETE",
+      endpoint: `/campaigns/${campaignId}/contacts/${contactId}`,
+    });
+  }
+
+  // ----------------------------------------
+  // Workflow Triggers
+  // ----------------------------------------
+
+  /**
+   * List available workflows for this location.
+   */
+  async listWorkflows(): Promise<GHLApiResponse<{ workflows: GHLWorkflow[] }>> {
+    return this.request({
+      method: "GET",
+      endpoint: "/workflows/",
+      params: { locationId: this.locationId },
+    });
   }
 
   // ----------------------------------------


### PR DESCRIPTION
Closes AI-5149

## Changes
- Added 4 new GHL service methods in `ghl.service.ts`:
  - `sendSMS(contactId, message)` — send SMS via GHL Conversations API
  - `sendEmail(contactId, {subject, html, attachments, ...})` — send email with template/attachment support
  - `getMessageStatus(messageId)` — check delivery status (pending/sent/delivered/read/failed)
  - `listTemplates({type?, limit?, offset?})` — list SMS/email/WhatsApp templates
- Added corresponding tRPC endpoints in `ghl.ts` router with full Zod validation
- Added TypeScript interfaces: `GHLMessage`, `GHLEmailAttachment`, `GHLTemplate`

## Testing
- TypeScript compilation passes (`tsc --noEmit` — zero errors in changed files)
- All existing GHL tests pass (vitest)
- Pre-existing test failures in unrelated files (OnboardingWizard, TaskTemplates) unchanged

Linear: https://linear.app/ai-acrobatics/issue/AI-5149/ghl-communication-endpoints-sms-email-templates-delivery-status