### PR TITLE
feat: GHL CRM frontend UI — contacts, pipeline, campaigns, webhook log

### DIFF
--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -35,7 +35,10 @@ import {
   LifeBuoy,
   Shield,
   Bot,
-  GraduationCap
+  GraduationCap,
+  Contact,
+  Kanban,
+  Webhook,
 } from "lucide-react";
 import { CSSProperties, useEffect, useRef, useState } from "react";
 import { useLocation } from "wouter";
@@ -53,6 +56,10 @@ const menuItems = [
   { icon: Users, label: "Lead Lists", path: "/dashboard/lead-lists" },
   { icon: Megaphone, label: "AI Campaigns", path: "/dashboard/ai-campaigns" },
   { icon: CreditCard, label: "Credits", path: "/dashboard/credits" },
+  { icon: Contact, label: "GHL Contacts", path: "/dashboard/ghl/contacts" },
+  { icon: Kanban, label: "GHL Pipeline", path: "/dashboard/ghl/pipeline" },
+  { icon: Megaphone, label: "GHL Campaigns", path: "/dashboard/ghl/campaigns" },
+  { icon: Webhook, label: "Webhook Log", path: "/dashboard/ghl/webhooks" },
   { icon: Settings, label: "Settings", path: "/dashboard/settings" },
 ];
 

--- a/client/src/components/Routes.tsx
+++ b/client/src/components/Routes.tsx
@@ -17,6 +17,10 @@ import AICampaigns from '@/pages/AICampaigns';
 import CampaignDetails from '@/pages/CampaignDetails';
 import CreditPurchase from '@/pages/CreditPurchase';
 import Training from '@/pages/Training';
+import GHLContacts from '@/pages/GHLContacts';
+import GHLPipeline from '@/pages/GHLPipeline';
+import GHLCampaigns from '@/pages/GHLCampaigns';
+import GHLWebhookLog from '@/pages/GHLWebhookLog';
 import { AdminDashboard } from '@/pages/admin/AdminDashboard';
 import { UserManagement } from '@/pages/admin/UserManagement';
 import { SystemHealth } from '@/pages/admin/SystemHealth';
@@ -51,6 +55,11 @@ export function Routes() {
           <Route path="/dashboard/ai-campaigns/:id" component={CampaignDetails} />
           <Route path="/dashboard/credits" component={CreditPurchase} />
           <Route path="/dashboard/training" component={Training} />
+          {/* GHL CRM routes */}
+          <Route path="/dashboard/ghl/contacts" component={GHLContacts} />
+          <Route path="/dashboard/ghl/pipeline" component={GHLPipeline} />
+          <Route path="/dashboard/ghl/campaigns" component={GHLCampaigns} />
+          <Route path="/dashboard/ghl/webhooks" component={GHLWebhookLog} />
           {/* Admin routes */}
           <Route path="/dashboard/admin" component={AdminDashboard} />
           <Route path="/dashboard/admin/users" component={UserManagement} />

--- a/client/src/pages/GHLCampaigns.tsx
+++ b/client/src/pages/GHLCampaigns.tsx
@@ -1,0 +1,240 @@
+/**
+ * GHL Campaign List
+ *
+ * View campaigns, add/remove contacts, see campaign status.
+ * Wired to ghl.listCampaigns / addContactToCampaign / removeContactFromCampaign.
+ *
+ * Linear: AI-5214
+ */
+
+import { useState } from 'react';
+import { trpc } from '@/lib/trpc';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  RefreshCw,
+  Megaphone,
+  UserPlus,
+  UserMinus,
+  Search,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+export default function GHLCampaigns() {
+  const [search, setSearch] = useState('');
+  const [addContactDialog, setAddContactDialog] = useState<string | null>(null);
+  const [removeContactDialog, setRemoveContactDialog] = useState<string | null>(null);
+  const [contactId, setContactId] = useState('');
+
+  const {
+    data: campaignsData,
+    isLoading,
+    refetch,
+  } = trpc.ghl.listCampaigns.useQuery();
+
+  const addContactMutation = trpc.ghl.addContactToCampaign.useMutation({
+    onSuccess: () => {
+      toast.success('Contact added to campaign');
+      setAddContactDialog(null);
+      setContactId('');
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const removeContactMutation = trpc.ghl.removeContactFromCampaign.useMutation({
+    onSuccess: () => {
+      toast.success('Contact removed from campaign');
+      setRemoveContactDialog(null);
+      setContactId('');
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const campaigns = (campaignsData as any)?.campaigns ?? campaignsData ?? [];
+  const filteredCampaigns = search
+    ? (campaigns as any[]).filter((c: any) =>
+        c.name?.toLowerCase().includes(search.toLowerCase())
+      )
+    : (campaigns as any[]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+            <Megaphone className="h-6 w-6" /> GHL Campaigns
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            View campaigns and manage contact enrollment
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetch()}>
+          <RefreshCw className="h-4 w-4 mr-1" /> Refresh
+        </Button>
+      </div>
+
+      {/* Search */}
+      <div className="relative max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Filter campaigns..."
+          className="pl-9"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </div>
+
+      {/* Campaign list */}
+      <Card>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="p-6 space-y-3">
+              {[1, 2, 3, 4].map((i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : filteredCampaigns.length === 0 ? (
+            <div className="p-12 text-center text-muted-foreground">
+              {search ? 'No campaigns match your filter.' : 'No campaigns found. Set up campaigns in GHL first.'}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Campaign Name</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredCampaigns.map((campaign: any) => (
+                  <TableRow key={campaign.id}>
+                    <TableCell className="font-medium">{campaign.name}</TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={campaign.status === 'published' || campaign.status === 'active' ? 'default' : 'secondary'}
+                        className="text-xs"
+                      >
+                        {campaign.status || 'unknown'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex gap-1 justify-end">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            setAddContactDialog(campaign.id);
+                            setContactId('');
+                          }}
+                        >
+                          <UserPlus className="h-3.5 w-3.5 mr-1" /> Add Contact
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            setRemoveContactDialog(campaign.id);
+                            setContactId('');
+                          }}
+                        >
+                          <UserMinus className="h-3.5 w-3.5 mr-1" /> Remove
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Add Contact to Campaign Dialog */}
+      <Dialog open={!!addContactDialog} onOpenChange={(open) => !open && setAddContactDialog(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Contact to Campaign</DialogTitle>
+          </DialogHeader>
+          <div>
+            <label className="text-sm font-medium">Contact ID</label>
+            <Input
+              placeholder="Enter GHL Contact ID"
+              value={contactId}
+              onChange={(e) => setContactId(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Find contact IDs on the Contacts page
+            </p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddContactDialog(null)}>Cancel</Button>
+            <Button
+              disabled={addContactMutation.isPending || !contactId.trim()}
+              onClick={() =>
+                addContactDialog &&
+                addContactMutation.mutate({
+                  campaignId: addContactDialog,
+                  contactId: contactId.trim(),
+                })
+              }
+            >
+              {addContactMutation.isPending ? 'Adding...' : 'Add to Campaign'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Remove Contact from Campaign Dialog */}
+      <Dialog open={!!removeContactDialog} onOpenChange={(open) => !open && setRemoveContactDialog(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove Contact from Campaign</DialogTitle>
+          </DialogHeader>
+          <div>
+            <label className="text-sm font-medium">Contact ID</label>
+            <Input
+              placeholder="Enter GHL Contact ID"
+              value={contactId}
+              onChange={(e) => setContactId(e.target.value)}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRemoveContactDialog(null)}>Cancel</Button>
+            <Button
+              variant="destructive"
+              disabled={removeContactMutation.isPending || !contactId.trim()}
+              onClick={() =>
+                removeContactDialog &&
+                removeContactMutation.mutate({
+                  campaignId: removeContactDialog,
+                  contactId: contactId.trim(),
+                })
+              }
+            >
+              {removeContactMutation.isPending ? 'Removing...' : 'Remove from Campaign'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/src/pages/GHLContacts.tsx
+++ b/client/src/pages/GHLContacts.tsx
@@ -1,0 +1,489 @@
+/**
+ * GHL Contact Browser
+ *
+ * Search, filter, view details, edit contacts, and manage tags.
+ * Wired to ghl.searchContacts / getContact / updateContact / addContactTags / removeContactTags.
+ *
+ * Linear: AI-5214
+ */
+
+import { useState } from 'react';
+import { trpc } from '@/lib/trpc';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Search,
+  ChevronLeft,
+  ChevronRight,
+  UserPlus,
+  Tag,
+  X,
+  Mail,
+  Phone,
+  Edit2,
+  RefreshCw,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+const PAGE_SIZE = 20;
+
+export default function GHLContacts() {
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [page, setPage] = useState(0);
+  const [selectedContact, setSelectedContact] = useState<any>(null);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editForm, setEditForm] = useState({ firstName: '', lastName: '', email: '', phone: '' });
+  const [tagInput, setTagInput] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createForm, setCreateForm] = useState({ firstName: '', lastName: '', email: '', phone: '' });
+
+  // Debounced search
+  const [searchTimeout, setSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
+  const handleSearch = (value: string) => {
+    setSearch(value);
+    if (searchTimeout) clearTimeout(searchTimeout);
+    setSearchTimeout(setTimeout(() => {
+      setDebouncedSearch(value);
+      setPage(0);
+    }, 400));
+  };
+
+  const {
+    data: contactsData,
+    isLoading,
+    refetch,
+  } = trpc.ghl.searchContacts.useQuery({
+    query: debouncedSearch || undefined,
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+  });
+
+  const { data: contactDetail, refetch: refetchDetail } = trpc.ghl.getContact.useQuery(
+    { contactId: selectedContact?.id ?? '' },
+    { enabled: !!selectedContact?.id }
+  );
+
+  const updateMutation = trpc.ghl.updateContact.useMutation({
+    onSuccess: () => {
+      toast.success('Contact updated');
+      setEditOpen(false);
+      refetch();
+      refetchDetail();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const createMutation = trpc.ghl.createContact.useMutation({
+    onSuccess: () => {
+      toast.success('Contact created');
+      setCreateOpen(false);
+      setCreateForm({ firstName: '', lastName: '', email: '', phone: '' });
+      refetch();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const addTagMutation = trpc.ghl.addContactTags.useMutation({
+    onSuccess: () => {
+      toast.success('Tag added');
+      setTagInput('');
+      refetchDetail();
+      refetch();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const removeTagMutation = trpc.ghl.removeContactTags.useMutation({
+    onSuccess: () => {
+      toast.success('Tag removed');
+      refetchDetail();
+      refetch();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const contacts = contactsData?.contacts ?? contactsData ?? [];
+  const totalCount = (contactsData as any)?.total ?? (contacts as any[]).length;
+
+  const openEdit = (contact: any) => {
+    setEditForm({
+      firstName: contact.firstName || '',
+      lastName: contact.lastName || '',
+      email: contact.email || '',
+      phone: contact.phone || '',
+    });
+    setEditOpen(true);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">GHL Contacts</h1>
+          <p className="text-muted-foreground text-sm">
+            Browse, search, and manage GoHighLevel contacts
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            <RefreshCw className="h-4 w-4 mr-1" /> Refresh
+          </Button>
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <UserPlus className="h-4 w-4 mr-1" /> Add Contact
+          </Button>
+        </div>
+      </div>
+
+      {/* Search bar */}
+      <div className="relative max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Search contacts by name, email, phone..."
+          className="pl-9"
+          value={search}
+          onChange={(e) => handleSearch(e.target.value)}
+        />
+      </div>
+
+      {/* Contacts table */}
+      <Card>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="p-6 space-y-3">
+              {[1, 2, 3, 4, 5].map((i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : (contacts as any[]).length === 0 ? (
+            <div className="p-12 text-center text-muted-foreground">
+              {debouncedSearch ? 'No contacts found matching your search.' : 'No contacts found. Connect a GHL location first.'}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Phone</TableHead>
+                  <TableHead>Tags</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead className="w-[80px]">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(contacts as any[]).map((contact: any) => (
+                  <TableRow
+                    key={contact.id}
+                    className="cursor-pointer hover:bg-muted/50"
+                    onClick={() => setSelectedContact(contact)}
+                  >
+                    <TableCell className="font-medium">
+                      {contact.firstName || ''} {contact.lastName || ''}
+                      {!contact.firstName && !contact.lastName && (
+                        <span className="text-muted-foreground italic">No name</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {contact.email ? (
+                        <span className="flex items-center gap-1">
+                          <Mail className="h-3 w-3 text-muted-foreground" />
+                          {contact.email}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {contact.phone ? (
+                        <span className="flex items-center gap-1">
+                          <Phone className="h-3 w-3 text-muted-foreground" />
+                          {contact.phone}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1 max-w-[200px]">
+                        {(contact.tags ?? []).slice(0, 3).map((tag: string) => (
+                          <Badge key={tag} variant="secondary" className="text-xs">
+                            {tag}
+                          </Badge>
+                        ))}
+                        {(contact.tags ?? []).length > 3 && (
+                          <Badge variant="outline" className="text-xs">
+                            +{(contact.tags as string[]).length - 3}
+                          </Badge>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {contact.source || '—'}
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedContact(contact);
+                          openEdit(contact);
+                        }}
+                      >
+                        <Edit2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Pagination */}
+      {(contacts as any[]).length > 0 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Showing {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, totalCount)} of {totalCount}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page === 0}
+              onClick={() => setPage((p) => p - 1)}
+            >
+              <ChevronLeft className="h-4 w-4" /> Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={(page + 1) * PAGE_SIZE >= totalCount}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Contact Detail Dialog */}
+      <Dialog open={!!selectedContact && !editOpen} onOpenChange={(open) => !open && setSelectedContact(null)}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {selectedContact?.firstName || ''} {selectedContact?.lastName || 'Contact Details'}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <p className="text-muted-foreground">Email</p>
+                <p>{(contactDetail as any)?.contact?.email || selectedContact?.email || '—'}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Phone</p>
+                <p>{(contactDetail as any)?.contact?.phone || selectedContact?.phone || '—'}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Source</p>
+                <p>{(contactDetail as any)?.contact?.source || selectedContact?.source || '—'}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Date Added</p>
+                <p>{(contactDetail as any)?.contact?.dateAdded ? new Date((contactDetail as any).contact.dateAdded).toLocaleDateString() : '—'}</p>
+              </div>
+            </div>
+
+            {/* Tags */}
+            <div>
+              <p className="text-sm font-medium mb-2 flex items-center gap-1">
+                <Tag className="h-3.5 w-3.5" /> Tags
+              </p>
+              <div className="flex flex-wrap gap-1 mb-2">
+                {(((contactDetail as any)?.contact?.tags ?? selectedContact?.tags) || []).map((tag: string) => (
+                  <Badge key={tag} variant="secondary" className="text-xs pr-1">
+                    {tag}
+                    <button
+                      className="ml-1 hover:text-destructive"
+                      onClick={() =>
+                        selectedContact &&
+                        removeTagMutation.mutate({ contactId: selectedContact.id, tags: [tag] })
+                      }
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+              <div className="flex gap-2">
+                <Input
+                  placeholder="Add tag..."
+                  className="h-8 text-sm"
+                  value={tagInput}
+                  onChange={(e) => setTagInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && tagInput.trim() && selectedContact) {
+                      addTagMutation.mutate({ contactId: selectedContact.id, tags: [tagInput.trim()] });
+                    }
+                  }}
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-8"
+                  disabled={!tagInput.trim()}
+                  onClick={() =>
+                    selectedContact &&
+                    tagInput.trim() &&
+                    addTagMutation.mutate({ contactId: selectedContact.id, tags: [tagInput.trim()] })
+                  }
+                >
+                  Add
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={() => setSelectedContact(null)}>
+                Close
+              </Button>
+              <Button onClick={() => openEdit(selectedContact)}>
+                <Edit2 className="h-4 w-4 mr-1" /> Edit
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Contact Dialog */}
+      <Dialog open={editOpen} onOpenChange={(open) => !open && setEditOpen(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Contact</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-sm font-medium">First Name</label>
+                <Input
+                  value={editForm.firstName}
+                  onChange={(e) => setEditForm((f) => ({ ...f, firstName: e.target.value }))}
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Last Name</label>
+                <Input
+                  value={editForm.lastName}
+                  onChange={(e) => setEditForm((f) => ({ ...f, lastName: e.target.value }))}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Email</label>
+              <Input
+                type="email"
+                value={editForm.email}
+                onChange={(e) => setEditForm((f) => ({ ...f, email: e.target.value }))}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Phone</label>
+              <Input
+                value={editForm.phone}
+                onChange={(e) => setEditForm((f) => ({ ...f, phone: e.target.value }))}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditOpen(false)}>Cancel</Button>
+            <Button
+              disabled={updateMutation.isPending}
+              onClick={() =>
+                selectedContact &&
+                updateMutation.mutate({
+                  contactId: selectedContact.id,
+                  ...editForm,
+                })
+              }
+            >
+              {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Create Contact Dialog */}
+      <Dialog open={createOpen} onOpenChange={(open) => !open && setCreateOpen(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Contact</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-sm font-medium">First Name</label>
+                <Input
+                  value={createForm.firstName}
+                  onChange={(e) => setCreateForm((f) => ({ ...f, firstName: e.target.value }))}
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Last Name</label>
+                <Input
+                  value={createForm.lastName}
+                  onChange={(e) => setCreateForm((f) => ({ ...f, lastName: e.target.value }))}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Email</label>
+              <Input
+                type="email"
+                value={createForm.email}
+                onChange={(e) => setCreateForm((f) => ({ ...f, email: e.target.value }))}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Phone</label>
+              <Input
+                value={createForm.phone}
+                onChange={(e) => setCreateForm((f) => ({ ...f, phone: e.target.value }))}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+            <Button
+              disabled={createMutation.isPending}
+              onClick={() => createMutation.mutate(createForm)}
+            >
+              {createMutation.isPending ? 'Creating...' : 'Create Contact'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/src/pages/GHLPipeline.tsx
+++ b/client/src/pages/GHLPipeline.tsx
@@ -1,0 +1,392 @@
+/**
+ * GHL Pipeline Board
+ *
+ * Kanban-style view of opportunities grouped by pipeline stage.
+ * Supports moving opportunities between stages and creating new ones.
+ *
+ * Linear: AI-5214
+ */
+
+import { useState, useMemo } from 'react';
+import { trpc } from '@/lib/trpc';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  DollarSign,
+  Plus,
+  ArrowRight,
+  RefreshCw,
+  Kanban,
+  User,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+export default function GHLPipeline() {
+  const [selectedPipelineId, setSelectedPipelineId] = useState<string>('');
+  const [statusFilter, setStatusFilter] = useState<'open' | 'won' | 'lost' | 'abandoned' | 'all'>('open');
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createForm, setCreateForm] = useState({
+    name: '',
+    contactId: '',
+    stageId: '',
+    monetaryValue: '',
+  });
+  const [moveDialog, setMoveDialog] = useState<{ opp: any; targetStageId: string } | null>(null);
+
+  const { data: pipelines, isLoading: pipelinesLoading } = trpc.ghl.listPipelines.useQuery();
+
+  // Auto-select first pipeline
+  const activePipelineId = selectedPipelineId || (pipelines as any)?.pipelines?.[0]?.id || '';
+  const activePipeline = (pipelines as any)?.pipelines?.find((p: any) => p.id === activePipelineId);
+
+  const {
+    data: oppsData,
+    isLoading: oppsLoading,
+    refetch,
+  } = trpc.ghl.searchOpportunities.useQuery(
+    {
+      pipelineId: activePipelineId,
+      status: statusFilter,
+      limit: 100,
+    },
+    { enabled: !!activePipelineId }
+  );
+
+  const updateMutation = trpc.ghl.updateOpportunity.useMutation({
+    onSuccess: () => {
+      toast.success('Opportunity updated');
+      setMoveDialog(null);
+      refetch();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const createMutation = trpc.ghl.createOpportunity.useMutation({
+    onSuccess: () => {
+      toast.success('Opportunity created');
+      setCreateOpen(false);
+      setCreateForm({ name: '', contactId: '', stageId: '', monetaryValue: '' });
+      refetch();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const opportunities = (oppsData as any)?.opportunities ?? oppsData ?? [];
+  const stages = activePipeline?.stages ?? [];
+
+  // Group opportunities by stage
+  const oppsByStage = useMemo(() => {
+    const grouped: Record<string, any[]> = {};
+    for (const stage of stages) {
+      grouped[stage.id] = [];
+    }
+    for (const opp of opportunities as any[]) {
+      const stageId = opp.pipelineStageId || opp.stageId;
+      if (grouped[stageId]) {
+        grouped[stageId].push(opp);
+      } else {
+        // Unmatched stage — put in first column
+        const firstStageId = stages[0]?.id;
+        if (firstStageId && grouped[firstStageId]) {
+          grouped[firstStageId].push(opp);
+        }
+      }
+    }
+    return grouped;
+  }, [opportunities, stages]);
+
+  const formatCurrency = (val: number | string | null | undefined) => {
+    if (val == null) return null;
+    const num = typeof val === 'string' ? parseFloat(val) : val;
+    if (isNaN(num)) return null;
+    return `$${num.toLocaleString()}`;
+  };
+
+  if (pipelinesLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-10 w-64" />
+        <div className="flex gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-96 w-72" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+            <Kanban className="h-6 w-6" /> Pipeline Board
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Manage opportunities across pipeline stages
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            <RefreshCw className="h-4 w-4 mr-1" /> Refresh
+          </Button>
+          <Button
+            size="sm"
+            disabled={!activePipelineId}
+            onClick={() => {
+              setCreateForm((f) => ({ ...f, stageId: stages[0]?.id || '' }));
+              setCreateOpen(true);
+            }}
+          >
+            <Plus className="h-4 w-4 mr-1" /> New Opportunity
+          </Button>
+        </div>
+      </div>
+
+      {/* Pipeline & status selector */}
+      <div className="flex gap-3 items-center">
+        <Select value={activePipelineId} onValueChange={setSelectedPipelineId}>
+          <SelectTrigger className="w-64">
+            <SelectValue placeholder="Select pipeline" />
+          </SelectTrigger>
+          <SelectContent>
+            {((pipelines as any)?.pipelines ?? []).map((p: any) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as any)}>
+          <SelectTrigger className="w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="open">Open</SelectItem>
+            <SelectItem value="won">Won</SelectItem>
+            <SelectItem value="lost">Lost</SelectItem>
+            <SelectItem value="abandoned">Abandoned</SelectItem>
+            <SelectItem value="all">All</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Kanban board */}
+      {!activePipelineId ? (
+        <Card>
+          <CardContent className="p-12 text-center text-muted-foreground">
+            No pipelines found. Connect a GHL location with active pipelines.
+          </CardContent>
+        </Card>
+      ) : oppsLoading ? (
+        <div className="flex gap-4 overflow-x-auto pb-4">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-96 w-72 shrink-0" />
+          ))}
+        </div>
+      ) : (
+        <div className="flex gap-4 overflow-x-auto pb-4">
+          {stages.map((stage: any) => {
+            const stageOpps = oppsByStage[stage.id] || [];
+            const totalValue = stageOpps.reduce((sum: number, o: any) => {
+              const val = parseFloat(o.monetaryValue ?? '0');
+              return sum + (isNaN(val) ? 0 : val);
+            }, 0);
+
+            return (
+              <div key={stage.id} className="w-72 shrink-0">
+                <div className="mb-3 px-1">
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-semibold text-sm">{stage.name}</h3>
+                    <Badge variant="secondary" className="text-xs">
+                      {stageOpps.length}
+                    </Badge>
+                  </div>
+                  {totalValue > 0 && (
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {formatCurrency(totalValue)} total
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2 min-h-[200px] bg-muted/30 rounded-lg p-2">
+                  {stageOpps.length === 0 ? (
+                    <p className="text-xs text-muted-foreground text-center py-8">
+                      No opportunities
+                    </p>
+                  ) : (
+                    stageOpps.map((opp: any) => (
+                      <Card key={opp.id} className="shadow-sm">
+                        <CardContent className="p-3 space-y-2">
+                          <p className="font-medium text-sm leading-tight">{opp.name}</p>
+                          {opp.monetaryValue && (
+                            <p className="text-sm font-semibold text-emerald-600 flex items-center gap-1">
+                              <DollarSign className="h-3 w-3" />
+                              {formatCurrency(opp.monetaryValue)}
+                            </p>
+                          )}
+                          {opp.contact && (
+                            <p className="text-xs text-muted-foreground flex items-center gap-1">
+                              <User className="h-3 w-3" />
+                              {opp.contact.firstName} {opp.contact.lastName}
+                            </p>
+                          )}
+                          <div className="flex items-center justify-between pt-1">
+                            <Badge
+                              variant={
+                                opp.status === 'won' ? 'default' :
+                                opp.status === 'lost' ? 'destructive' :
+                                'secondary'
+                              }
+                              className="text-xs"
+                            >
+                              {opp.status}
+                            </Badge>
+                            {/* Move to next stage button */}
+                            {stages.indexOf(stage) < stages.length - 1 && (
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-6 w-6"
+                                title="Move to next stage"
+                                onClick={() =>
+                                  setMoveDialog({
+                                    opp,
+                                    targetStageId: stages[stages.indexOf(stage) + 1].id,
+                                  })
+                                }
+                              >
+                                <ArrowRight className="h-3 w-3" />
+                              </Button>
+                            )}
+                          </div>
+                        </CardContent>
+                      </Card>
+                    ))
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Move Confirmation Dialog */}
+      <Dialog open={!!moveDialog} onOpenChange={(open) => !open && setMoveDialog(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Move Opportunity</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Move <strong>{moveDialog?.opp?.name}</strong> to{' '}
+            <strong>{stages.find((s: any) => s.id === moveDialog?.targetStageId)?.name}</strong>?
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setMoveDialog(null)}>Cancel</Button>
+            <Button
+              disabled={updateMutation.isPending}
+              onClick={() =>
+                moveDialog &&
+                updateMutation.mutate({
+                  opportunityId: moveDialog.opp.id,
+                  stageId: moveDialog.targetStageId,
+                })
+              }
+            >
+              {updateMutation.isPending ? 'Moving...' : 'Move'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Create Opportunity Dialog */}
+      <Dialog open={createOpen} onOpenChange={(open) => !open && setCreateOpen(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Opportunity</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div>
+              <label className="text-sm font-medium">Name</label>
+              <Input
+                value={createForm.name}
+                onChange={(e) => setCreateForm((f) => ({ ...f, name: e.target.value }))}
+                placeholder="Deal name"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Contact ID</label>
+              <Input
+                value={createForm.contactId}
+                onChange={(e) => setCreateForm((f) => ({ ...f, contactId: e.target.value }))}
+                placeholder="GHL Contact ID"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Stage</label>
+              <Select
+                value={createForm.stageId}
+                onValueChange={(v) => setCreateForm((f) => ({ ...f, stageId: v }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select stage" />
+                </SelectTrigger>
+                <SelectContent>
+                  {stages.map((s: any) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      {s.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Value ($)</label>
+              <Input
+                type="number"
+                value={createForm.monetaryValue}
+                onChange={(e) => setCreateForm((f) => ({ ...f, monetaryValue: e.target.value }))}
+                placeholder="0"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+            <Button
+              disabled={createMutation.isPending || !createForm.name || !createForm.contactId || !createForm.stageId}
+              onClick={() =>
+                createMutation.mutate({
+                  pipelineId: activePipelineId,
+                  stageId: createForm.stageId,
+                  contactId: createForm.contactId,
+                  name: createForm.name,
+                  monetaryValue: createForm.monetaryValue ? parseFloat(createForm.monetaryValue) : undefined,
+                })
+              }
+            >
+              {createMutation.isPending ? 'Creating...' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/src/pages/GHLWebhookLog.tsx
+++ b/client/src/pages/GHLWebhookLog.tsx
@@ -1,0 +1,342 @@
+/**
+ * GHL Webhook Event Log
+ *
+ * View recent inbound webhook events and their processing status.
+ * Includes dead letter queue management for failed events.
+ * Uses direct fetch to the webhook REST endpoints since these aren't on tRPC.
+ *
+ * Linear: AI-5214
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  RefreshCw,
+  Webhook,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  RotateCcw,
+  Eye,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+interface WebhookHealth {
+  status: string;
+  configured: boolean;
+  supportedEvents: string[];
+  deadLetterCount: number;
+  workflowQueueAvailable: boolean;
+  timestamp: string;
+}
+
+interface DLQEntry {
+  id: number;
+  eventId: string | null;
+  eventType: string;
+  locationId: string | null;
+  payload: any;
+  error: string;
+  retryCount: number;
+  maxRetries: number;
+  lastRetriedAt: string | null;
+  resolved: boolean;
+  createdAt: string;
+}
+
+export default function GHLWebhookLog() {
+  const [health, setHealth] = useState<WebhookHealth | null>(null);
+  const [dlqItems, setDlqItems] = useState<DLQEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dlqLoading, setDlqLoading] = useState(true);
+  const [selectedPayload, setSelectedPayload] = useState<any>(null);
+  const [retryingId, setRetryingId] = useState<number | null>(null);
+
+  const fetchHealth = useCallback(async () => {
+    try {
+      const res = await fetch('/api/ghl/webhooks/health');
+      if (res.ok) {
+        setHealth(await res.json());
+      }
+    } catch {
+      // Health endpoint not available
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchDLQ = useCallback(async () => {
+    setDlqLoading(true);
+    try {
+      const res = await fetch('/api/ghl/webhooks/dlq');
+      if (res.ok) {
+        const data = await res.json();
+        setDlqItems(data.items || []);
+      }
+    } catch {
+      // DLQ endpoint not available
+    } finally {
+      setDlqLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHealth();
+    fetchDLQ();
+  }, [fetchHealth, fetchDLQ]);
+
+  const retryDLQEntry = async (id: number) => {
+    setRetryingId(id);
+    try {
+      const res = await fetch(`/api/ghl/webhooks/dlq/${id}/retry`, { method: 'POST' });
+      if (res.ok) {
+        toast.success('Event reprocessed successfully');
+        fetchDLQ();
+        fetchHealth();
+      } else {
+        const data = await res.json();
+        toast.error(data.error || 'Retry failed');
+      }
+    } catch {
+      toast.error('Failed to retry event');
+    } finally {
+      setRetryingId(null);
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleString();
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+            <Webhook className="h-6 w-6" /> Webhook Event Log
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Monitor GHL webhook events and failed event queue
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            fetchHealth();
+            fetchDLQ();
+          }}
+        >
+          <RefreshCw className="h-4 w-4 mr-1" /> Refresh
+        </Button>
+      </div>
+
+      {/* Health Overview */}
+      {loading ? (
+        <div className="grid grid-cols-4 gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-24" />
+          ))}
+        </div>
+      ) : health ? (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-muted-foreground">Status</p>
+                <Badge variant={health.status === 'ok' ? 'default' : 'destructive'}>
+                  {health.status}
+                </Badge>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-muted-foreground">Configured</p>
+                {health.configured ? (
+                  <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                ) : (
+                  <XCircle className="h-5 w-5 text-red-500" />
+                )}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-muted-foreground">Failed Events</p>
+                <span className={`text-lg font-bold ${health.deadLetterCount > 0 ? 'text-red-500' : 'text-emerald-500'}`}>
+                  {health.deadLetterCount}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-muted-foreground">Queue Available</p>
+                {health.workflowQueueAvailable ? (
+                  <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                ) : (
+                  <XCircle className="h-5 w-5 text-amber-500" />
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      ) : (
+        <Card>
+          <CardContent className="p-8 text-center text-muted-foreground">
+            Webhook endpoint not reachable. Ensure the server is running.
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Supported Events */}
+      {health?.supportedEvents && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Supported Event Types</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2">
+              {health.supportedEvents.map((evt) => (
+                <Badge key={evt} variant="outline" className="text-xs">
+                  {evt}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Dead Letter Queue */}
+      <Tabs defaultValue="dlq">
+        <TabsList>
+          <TabsTrigger value="dlq" className="flex items-center gap-1">
+            <AlertTriangle className="h-3.5 w-3.5" />
+            Dead Letter Queue
+            {dlqItems.length > 0 && (
+              <Badge variant="destructive" className="ml-1 text-xs h-5 min-w-5 px-1">
+                {dlqItems.length}
+              </Badge>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="dlq">
+          <Card>
+            <CardContent className="p-0">
+              {dlqLoading ? (
+                <div className="p-6 space-y-3">
+                  {[1, 2, 3].map((i) => (
+                    <Skeleton key={i} className="h-12 w-full" />
+                  ))}
+                </div>
+              ) : dlqItems.length === 0 ? (
+                <div className="p-12 text-center text-muted-foreground">
+                  <CheckCircle2 className="h-8 w-8 mx-auto mb-2 text-emerald-500" />
+                  No failed events. All webhooks processed successfully.
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Event Type</TableHead>
+                      <TableHead>Error</TableHead>
+                      <TableHead>Retries</TableHead>
+                      <TableHead>Created</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {dlqItems.map((entry) => (
+                      <TableRow key={entry.id}>
+                        <TableCell>
+                          <Badge variant="outline" className="text-xs">
+                            {entry.eventType}
+                          </Badge>
+                          {entry.locationId && (
+                            <p className="text-xs text-muted-foreground mt-1">
+                              Location: {entry.locationId.slice(0, 12)}...
+                            </p>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <p className="text-sm text-destructive max-w-[300px] truncate" title={entry.error}>
+                            {entry.error}
+                          </p>
+                        </TableCell>
+                        <TableCell>
+                          <span className="text-sm">
+                            {entry.retryCount} / {entry.maxRetries}
+                          </span>
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
+                          {formatDate(entry.createdAt)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex gap-1 justify-end">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              title="View payload"
+                              onClick={() => setSelectedPayload(entry.payload)}
+                            >
+                              <Eye className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              disabled={entry.retryCount >= entry.maxRetries || retryingId === entry.id}
+                              onClick={() => retryDLQEntry(entry.id)}
+                            >
+                              <RotateCcw className="h-3.5 w-3.5 mr-1" />
+                              {retryingId === entry.id ? 'Retrying...' : 'Retry'}
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      {/* Payload Viewer Dialog */}
+      <Dialog open={!!selectedPayload} onOpenChange={(open) => !open && setSelectedPayload(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh]">
+          <DialogHeader>
+            <DialogTitle>Event Payload</DialogTitle>
+          </DialogHeader>
+          <pre className="bg-muted rounded-lg p-4 text-xs overflow-auto max-h-[60vh]">
+            {JSON.stringify(selectedPayload, null, 2)}
+          </pre>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/drizzle/0008_ghl_webhook_processing.sql
+++ b/drizzle/0008_ghl_webhook_processing.sql
@@ -1,0 +1,82 @@
+-- GHL Webhook Processing: contacts, opportunities, event dedup, dead letter queue
+-- Linear: AI-5147
+
+-- Synced contacts from GHL webhooks
+CREATE TABLE IF NOT EXISTS "ghl_contacts" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "userId" integer NOT NULL REFERENCES "users"("id"),
+  "ghlContactId" varchar(128) NOT NULL,
+  "locationId" varchar(128) NOT NULL,
+  "firstName" text,
+  "lastName" text,
+  "email" varchar(320),
+  "phone" varchar(30),
+  "tags" jsonb,
+  "source" varchar(128),
+  "customFields" jsonb,
+  "lastWebhookAt" timestamp NOT NULL,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ghl_contacts_ghl_id_idx" ON "ghl_contacts" ("ghlContactId", "locationId");
+CREATE INDEX IF NOT EXISTS "ghl_contacts_user_idx" ON "ghl_contacts" ("userId");
+CREATE INDEX IF NOT EXISTS "ghl_contacts_location_idx" ON "ghl_contacts" ("locationId");
+CREATE INDEX IF NOT EXISTS "ghl_contacts_email_idx" ON "ghl_contacts" ("email");
+
+-- Synced opportunities from GHL webhooks
+CREATE TABLE IF NOT EXISTS "ghl_opportunities" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "userId" integer NOT NULL REFERENCES "users"("id"),
+  "ghlOpportunityId" varchar(128) NOT NULL,
+  "locationId" varchar(128) NOT NULL,
+  "name" text,
+  "pipelineId" varchar(128),
+  "pipelineStageId" varchar(128),
+  "status" varchar(64),
+  "monetaryValue" numeric(12, 2),
+  "ghlContactId" varchar(128),
+  "lastWebhookAt" timestamp NOT NULL,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ghl_opportunities_ghl_id_idx" ON "ghl_opportunities" ("ghlOpportunityId", "locationId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_user_idx" ON "ghl_opportunities" ("userId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_location_idx" ON "ghl_opportunities" ("locationId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_pipeline_idx" ON "ghl_opportunities" ("pipelineId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_status_idx" ON "ghl_opportunities" ("status");
+
+-- Webhook event log for deduplication
+CREATE TABLE IF NOT EXISTS "ghl_webhook_events" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "eventId" varchar(256) NOT NULL UNIQUE,
+  "eventType" varchar(128) NOT NULL,
+  "locationId" varchar(128),
+  "processedAt" timestamp DEFAULT now() NOT NULL,
+  "success" boolean NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ghl_webhook_events_event_id_idx" ON "ghl_webhook_events" ("eventId");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_events_type_idx" ON "ghl_webhook_events" ("eventType");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_events_processed_at_idx" ON "ghl_webhook_events" ("processedAt");
+
+-- Dead letter queue for failed webhook events
+CREATE TABLE IF NOT EXISTS "ghl_webhook_dead_letters" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "eventId" varchar(256),
+  "eventType" varchar(128) NOT NULL,
+  "locationId" varchar(128),
+  "payload" jsonb NOT NULL,
+  "error" text NOT NULL,
+  "retryCount" integer DEFAULT 0 NOT NULL,
+  "maxRetries" integer DEFAULT 3 NOT NULL,
+  "lastRetriedAt" timestamp,
+  "resolved" boolean DEFAULT false NOT NULL,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "ghl_webhook_dlq_resolved_idx" ON "ghl_webhook_dead_letters" ("resolved");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_dlq_type_idx" ON "ghl_webhook_dead_letters" ("eventType");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_dlq_created_at_idx" ON "ghl_webhook_dead_letters" ("createdAt");

--- a/drizzle/schema-ghl-webhooks.ts
+++ b/drizzle/schema-ghl-webhooks.ts
@@ -1,0 +1,130 @@
+/**
+ * GHL Webhook Processing Schema
+ *
+ * Tables for synced contacts, opportunities, webhook event dedup,
+ * and dead letter queue for failed webhook processing.
+ *
+ * Linear: AI-5147
+ */
+
+import {
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar,
+  integer,
+  boolean,
+  jsonb,
+  index,
+  uniqueIndex,
+  numeric,
+} from "drizzle-orm/pg-core";
+import { users } from "./schema";
+
+// ========================================
+// GHL CONTACTS (synced from webhooks)
+// ========================================
+
+export const ghlContacts = pgTable("ghl_contacts", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  ghlContactId: varchar("ghlContactId", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }).notNull(),
+  firstName: text("firstName"),
+  lastName: text("lastName"),
+  email: varchar("email", { length: 320 }),
+  phone: varchar("phone", { length: 30 }),
+  tags: jsonb("tags").$type<string[]>(),
+  source: varchar("source", { length: 128 }),
+  customFields: jsonb("customFields").$type<Array<{ id: string; value: string }>>(),
+  lastWebhookAt: timestamp("lastWebhookAt").notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  ghlContactIdx: uniqueIndex("ghl_contacts_ghl_id_idx").on(table.ghlContactId, table.locationId),
+  userIdx: index("ghl_contacts_user_idx").on(table.userId),
+  locationIdx: index("ghl_contacts_location_idx").on(table.locationId),
+  emailIdx: index("ghl_contacts_email_idx").on(table.email),
+}));
+
+export type GHLContactRow = typeof ghlContacts.$inferSelect;
+export type InsertGHLContact = typeof ghlContacts.$inferInsert;
+
+// ========================================
+// GHL OPPORTUNITIES (synced from webhooks)
+// ========================================
+
+export const ghlOpportunities = pgTable("ghl_opportunities", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  ghlOpportunityId: varchar("ghlOpportunityId", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }).notNull(),
+  name: text("name"),
+  pipelineId: varchar("pipelineId", { length: 128 }),
+  pipelineStageId: varchar("pipelineStageId", { length: 128 }),
+  status: varchar("status", { length: 64 }),
+  monetaryValue: numeric("monetaryValue", { precision: 12, scale: 2 }),
+  ghlContactId: varchar("ghlContactId", { length: 128 }),
+  lastWebhookAt: timestamp("lastWebhookAt").notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  ghlOppIdx: uniqueIndex("ghl_opportunities_ghl_id_idx").on(table.ghlOpportunityId, table.locationId),
+  userIdx: index("ghl_opportunities_user_idx").on(table.userId),
+  locationIdx: index("ghl_opportunities_location_idx").on(table.locationId),
+  pipelineIdx: index("ghl_opportunities_pipeline_idx").on(table.pipelineId),
+  statusIdx: index("ghl_opportunities_status_idx").on(table.status),
+}));
+
+export type GHLOpportunityRow = typeof ghlOpportunities.$inferSelect;
+export type InsertGHLOpportunity = typeof ghlOpportunities.$inferInsert;
+
+// ========================================
+// WEBHOOK EVENT LOG (for dedup)
+// ========================================
+
+export const ghlWebhookEvents = pgTable("ghl_webhook_events", {
+  id: serial("id").primaryKey(),
+  eventId: varchar("eventId", { length: 256 }).notNull().unique(),
+  eventType: varchar("eventType", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }),
+  processedAt: timestamp("processedAt").defaultNow().notNull(),
+  /** Whether processing completed successfully */
+  success: boolean("success").notNull(),
+}, (table) => ({
+  eventIdIdx: uniqueIndex("ghl_webhook_events_event_id_idx").on(table.eventId),
+  eventTypeIdx: index("ghl_webhook_events_type_idx").on(table.eventType),
+  processedAtIdx: index("ghl_webhook_events_processed_at_idx").on(table.processedAt),
+}));
+
+export type GHLWebhookEventRow = typeof ghlWebhookEvents.$inferSelect;
+export type InsertGHLWebhookEvent = typeof ghlWebhookEvents.$inferInsert;
+
+// ========================================
+// DEAD LETTER QUEUE (failed webhook events)
+// ========================================
+
+export const ghlWebhookDeadLetters = pgTable("ghl_webhook_dead_letters", {
+  id: serial("id").primaryKey(),
+  eventId: varchar("eventId", { length: 256 }),
+  eventType: varchar("eventType", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }),
+  payload: jsonb("payload").notNull(),
+  error: text("error").notNull(),
+  retryCount: integer("retryCount").default(0).notNull(),
+  maxRetries: integer("maxRetries").default(3).notNull(),
+  /** null = pending retry, timestamp = retried at */
+  lastRetriedAt: timestamp("lastRetriedAt"),
+  /** Whether this DLQ entry has been resolved (retried successfully or manually dismissed) */
+  resolved: boolean("resolved").default(false).notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  resolvedIdx: index("ghl_webhook_dlq_resolved_idx").on(table.resolved),
+  eventTypeIdx: index("ghl_webhook_dlq_type_idx").on(table.eventType),
+  createdAtIdx: index("ghl_webhook_dlq_created_at_idx").on(table.createdAt),
+}));
+
+export type GHLWebhookDeadLetterRow = typeof ghlWebhookDeadLetters.$inferSelect;
+export type InsertGHLWebhookDeadLetter = typeof ghlWebhookDeadLetters.$inferInsert;

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -28,6 +28,7 @@ import {
 } from "../lib/sentry";
 import { createRestApi } from "../api/rest";
 import ghlOAuthRouter from "../api/routes/ghl-oauth";
+import ghlWebhookRouter from "../api/routes/ghl-webhooks";
 
 // Initialize Sentry as early as possible
 initSentry();
@@ -137,6 +138,7 @@ export async function createApp() {
   app.use("/api/webhooks/stripe", stripeWebhookRouter);
   // GHL OAuth routes (AI-2877)
   app.use("/api/ghl/oauth", ghlOAuthRouter);
+  app.use("/api/ghl/webhooks", ghlWebhookRouter);
 
   // Mount REST API v1 routes (includes /api/v1/health, /api/v1/tasks, etc.)
   const restApi = createRestApi();

--- a/server/api/routers/ghl.ts
+++ b/server/api/routers/ghl.ts
@@ -8,7 +8,9 @@
  * - Campaign/drip management (list, add/remove contacts)
  * - Workflow listing
  *
- * Linear: AI-2877, AI-2881, AI-3461
+ * - Messaging (send SMS, send email, delivery status, templates)
+ *
+ * Linear: AI-2877, AI-2881, AI-3461, AI-5149
  */
 
 import { z } from "zod";
@@ -644,6 +646,106 @@ export const ghlRouter = router({
       try {
         const service = await getServiceForUser(ctx.user.id, input?.locationId);
         const result = await service.listWorkflows();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Messaging / Communication (AI-5149)
+  // ----------------------------------------
+
+  sendSMS: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        message: z.string().min(1).max(1600),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.sendSMS(input.contactId, input.message);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  sendEmail: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        subject: z.string().min(1).max(998),
+        html: z.string().min(1),
+        emailFrom: z.string().email().optional(),
+        emailTo: z.string().email().optional(),
+        emailReplyTo: z.string().email().optional(),
+        templateId: z.string().optional(),
+        attachments: z
+          .array(
+            z.object({
+              url: z.string().url(),
+              name: z.string().optional(),
+            })
+          )
+          .optional(),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { contactId, locationId, ...emailData } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.sendEmail(contactId, emailData);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  getMessageStatus: protectedProcedure
+    .input(
+      z.object({
+        messageId: z.string().min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.getMessageStatus(input.messageId);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  listTemplates: protectedProcedure
+    .input(
+      z
+        .object({
+          locationId: z.string().optional(),
+          type: z.enum(["sms", "email", "whatsapp"]).optional(),
+          limit: z.number().int().min(1).max(100).default(20),
+          offset: z.number().int().min(0).default(0),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listTemplates({
+          type: input?.type,
+          limit: input?.limit,
+          offset: input?.offset,
+        });
         return result.data;
       } catch (err) {
         if (err instanceof TRPCError) throw err;

--- a/server/api/routers/ghl.ts
+++ b/server/api/routers/ghl.ts
@@ -2,17 +2,13 @@
  * GHL tRPC Router
  *
  * Provides typed RPC endpoints for GHL integration management:
- * - ghl.status — connection health check per location
- * - ghl.listLocations — list all authorized GHL locations
- * - ghl.disconnect — revoke and clean up
- * - ghl.configStatus — check OAuth configuration
- * - ghl.getActiveLocation — get user's currently selected location
- * - ghl.setActiveLocation — switch active location
- * - ghl.getLocationConfig — get per-location config
- * - ghl.updateLocationConfig — update per-location config
- * - ghl.updateLocationDetails — update location name/metadata
+ * - Connection management (status, list, disconnect, config)
+ * - Contact/lead management (search, create, update, tag)
+ * - Pipeline/opportunity management (list, search, create, update)
+ * - Campaign/drip management (list, add/remove contacts)
+ * - Workflow listing
  *
- * Linear: AI-2877, AI-2881
+ * Linear: AI-2877, AI-2881, AI-3461
  */
 
 import { z } from "zod";
@@ -22,6 +18,57 @@ import { GHLService, GHLError } from "../../services/ghl.service";
 import { getDb } from "../../db";
 import { ghlLocations, ghlActiveLocation } from "../../../drizzle/schema-ghl-locations";
 import { eq, and } from "drizzle-orm";
+
+// ========================================
+// HELPERS
+// ========================================
+
+function ghlErrorToTRPC(err: unknown): never {
+  if (err instanceof GHLError) {
+    throw new TRPCError({
+      code:
+        err.category === "auth"
+          ? "UNAUTHORIZED"
+          : err.category === "rate_limit"
+            ? "TOO_MANY_REQUESTS"
+            : "INTERNAL_SERVER_ERROR",
+      message: err.message,
+    });
+  }
+  throw new TRPCError({
+    code: "INTERNAL_SERVER_ERROR",
+    message: err instanceof Error ? err.message : "GHL operation failed",
+  });
+}
+
+/** Get a GHL service for the user's active location, or a specified one. */
+async function getServiceForUser(
+  userId: number,
+  locationId?: string
+): Promise<GHLService> {
+  if (locationId) {
+    return new GHLService(locationId, userId);
+  }
+
+  // Fall back to active location
+  const db = await getDb();
+  if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+
+  const [active] = await db
+    .select()
+    .from(ghlActiveLocation)
+    .where(eq(ghlActiveLocation.userId, userId))
+    .limit(1);
+
+  if (!active) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "No active GHL location. Connect and select a location first.",
+    });
+  }
+
+  return new GHLService(active.locationId, userId);
+}
 
 const locationConfigSchema = z.object({
   automationsEnabled: z.boolean().optional(),
@@ -36,51 +83,29 @@ const locationConfigSchema = z.object({
   tags: z.array(z.string()).optional(),
 });
 
+// ========================================
+// ROUTER
+// ========================================
+
 export const ghlRouter = router({
-  /**
-   * Get connection status for a specific GHL location.
-   */
+  // ----------------------------------------
+  // Connection Management (existing)
+  // ----------------------------------------
+
   status: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1, "locationId is required"),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       try {
         const service = new GHLService(input.locationId, ctx.user.id);
-        const status = await service.getConnectionStatus();
-        return status;
+        return await service.getConnectionStatus();
       } catch (err) {
-        if (err instanceof GHLError) {
-          throw new TRPCError({
-            code:
-              err.category === "auth"
-                ? "UNAUTHORIZED"
-                : err.category === "rate_limit"
-                  ? "TOO_MANY_REQUESTS"
-                  : "INTERNAL_SERVER_ERROR",
-            message: err.message,
-          });
-        }
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message:
-            err instanceof Error ? err.message : "Failed to check GHL status",
-        });
+        ghlErrorToTRPC(err);
       }
     }),
 
-  /**
-   * List all authorized GHL locations for the current user.
-   * Merges data from integrations table + ghl_locations table.
-   */
   listLocations: protectedProcedure.query(async ({ ctx }) => {
     try {
-      // Get OAuth-connected locations from integrations table
       const oauthLocations = await GHLService.listLocations(ctx.user.id);
-
-      // Get enriched location data from ghl_locations table
       const db = await getDb();
       if (!db) return oauthLocations;
 
@@ -94,12 +119,10 @@ export const ghlRouter = router({
           )
         );
 
-      // Build lookup map of enriched data
       const enrichedMap = new Map(
         locationRows.map((row) => [row.locationId, row])
       );
 
-      // Merge: OAuth data + enriched metadata
       return oauthLocations.map((loc) => {
         const enriched = enrichedMap.get(loc.locationId);
         return {
@@ -118,31 +141,17 @@ export const ghlRouter = router({
         };
       });
     } catch (err) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message:
-          err instanceof Error
-            ? err.message
-            : "Failed to list GHL locations",
-      });
+      ghlErrorToTRPC(err);
     }
   }),
 
-  /**
-   * Disconnect a GHL location (revoke tokens and mark inactive).
-   */
   disconnect: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1, "locationId is required"),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       try {
         const service = new GHLService(input.locationId, ctx.user.id);
         await service.disconnect();
 
-        // Also deactivate in ghl_locations table
         const db = await getDb();
         if (db) {
           await db
@@ -155,7 +164,6 @@ export const ghlRouter = router({
               )
             );
 
-          // If this was the active location, clear it
           const [active] = await db
             .select()
             .from(ghlActiveLocation)
@@ -169,33 +177,12 @@ export const ghlRouter = router({
           }
         }
 
-        return {
-          success: true,
-          message: `Disconnected GHL location ${input.locationId}`,
-        };
+        return { success: true, message: `Disconnected GHL location ${input.locationId}` };
       } catch (err) {
-        if (err instanceof GHLError) {
-          throw new TRPCError({
-            code:
-              err.category === "auth"
-                ? "UNAUTHORIZED"
-                : "INTERNAL_SERVER_ERROR",
-            message: err.message,
-          });
-        }
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message:
-            err instanceof Error
-              ? err.message
-              : "Failed to disconnect GHL location",
-        });
+        ghlErrorToTRPC(err);
       }
     }),
 
-  /**
-   * Get the GHL OAuth configuration status (whether client ID/secret are set).
-   */
   configStatus: protectedProcedure.query(async () => {
     return {
       configured: !!process.env.GHL_CLIENT_ID && !!process.env.GHL_CLIENT_SECRET,
@@ -204,9 +191,6 @@ export const ghlRouter = router({
     };
   }),
 
-  /**
-   * Get the user's currently active/selected GHL location.
-   */
   getActiveLocation: protectedProcedure.query(async ({ ctx }) => {
     const db = await getDb();
     if (!db) return null;
@@ -219,7 +203,6 @@ export const ghlRouter = router({
 
     if (!active) return null;
 
-    // Fetch enriched details
     const [location] = await db
       .select()
       .from(ghlLocations)
@@ -240,22 +223,12 @@ export const ghlRouter = router({
     };
   }),
 
-  /**
-   * Set the active/selected GHL location for the current user.
-   */
   setActiveLocation: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1, "locationId is required"),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
-      }
+      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
 
-      // Verify this location exists and belongs to user
       const [location] = await db
         .select()
         .from(ghlLocations)
@@ -269,13 +242,9 @@ export const ghlRouter = router({
         .limit(1);
 
       if (!location) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `GHL location ${input.locationId} not found or not connected`,
-        });
+        throw new TRPCError({ code: "NOT_FOUND", message: `GHL location ${input.locationId} not found` });
       }
 
-      // Upsert active location
       const [existing] = await db
         .select()
         .from(ghlActiveLocation)
@@ -295,22 +264,11 @@ export const ghlRouter = router({
         });
       }
 
-      return {
-        success: true,
-        locationId: input.locationId,
-        name: location.name,
-      };
+      return { success: true, locationId: input.locationId, name: location.name };
     }),
 
-  /**
-   * Get per-location configuration.
-   */
   getLocationConfig: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const db = await getDb();
       if (!db) return null;
@@ -334,23 +292,12 @@ export const ghlRouter = router({
       };
     }),
 
-  /**
-   * Update per-location configuration.
-   */
   updateLocationConfig: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1),
-        config: locationConfigSchema,
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1), config: locationConfigSchema }))
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
-      }
+      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
 
-      // Get current config and merge
       const [location] = await db
         .select()
         .from(ghlLocations)
@@ -362,12 +309,7 @@ export const ghlRouter = router({
         )
         .limit(1);
 
-      if (!location) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `GHL location ${input.locationId} not found`,
-        });
-      }
+      if (!location) throw new TRPCError({ code: "NOT_FOUND", message: `Location not found` });
 
       const mergedConfig = { ...(location.config || {}), ...input.config };
 
@@ -384,9 +326,6 @@ export const ghlRouter = router({
       return { success: true, config: mergedConfig };
     }),
 
-  /**
-   * Update location display name and metadata.
-   */
   updateLocationDetails: protectedProcedure
     .input(
       z.object({
@@ -400,18 +339,12 @@ export const ghlRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
-      }
+      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
 
       const { locationId, ...updates } = input;
-
-      // Filter out undefined values
       const setValues: Record<string, unknown> = { updatedAt: new Date() };
       for (const [key, value] of Object.entries(updates)) {
-        if (value !== undefined) {
-          setValues[key] = value || null;
-        }
+        if (value !== undefined) setValues[key] = value || null;
       }
 
       await db
@@ -425,5 +358,296 @@ export const ghlRouter = router({
         );
 
       return { success: true };
+    }),
+
+  // ----------------------------------------
+  // Contact / Lead Management (AI-3461)
+  // ----------------------------------------
+
+  searchContacts: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        query: z.string().optional(),
+        limit: z.number().int().min(1).max(100).default(20),
+        offset: z.number().int().min(0).default(0),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.searchContacts({
+          query: input.query,
+          limit: input.limit,
+          offset: input.offset,
+        });
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  getContact: protectedProcedure
+    .input(z.object({ contactId: z.string().min(1), locationId: z.string().optional() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.getContact(input.contactId);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  createContact: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        firstName: z.string().optional(),
+        lastName: z.string().optional(),
+        email: z.string().email().optional(),
+        phone: z.string().optional(),
+        tags: z.array(z.string()).optional(),
+        source: z.string().optional(),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { locationId, ...contactData } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.createContact(contactData);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  updateContact: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        locationId: z.string().optional(),
+        firstName: z.string().optional(),
+        lastName: z.string().optional(),
+        email: z.string().email().optional(),
+        phone: z.string().optional(),
+        tags: z.array(z.string()).optional(),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { contactId, locationId, ...updateData } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.updateContact(contactId, updateData);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  addContactTags: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        tags: z.array(z.string().min(1)).min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.addContactTags(input.contactId, input.tags);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  removeContactTags: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        tags: z.array(z.string().min(1)).min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        await service.removeContactTags(input.contactId, input.tags);
+        return { success: true };
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Pipeline / Opportunity Management (AI-3461)
+  // ----------------------------------------
+
+  listPipelines: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listPipelines();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  searchOpportunities: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        pipelineId: z.string().optional(),
+        stageId: z.string().optional(),
+        status: z.enum(["open", "won", "lost", "abandoned", "all"]).default("open"),
+        query: z.string().optional(),
+        limit: z.number().int().min(1).max(100).default(20),
+        offset: z.number().int().min(0).default(0),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const { locationId, ...params } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.searchOpportunities(params);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  createOpportunity: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        pipelineId: z.string().min(1),
+        stageId: z.string().min(1),
+        contactId: z.string().min(1),
+        name: z.string().min(1),
+        monetaryValue: z.number().optional(),
+        status: z.enum(["open", "won", "lost", "abandoned"]).default("open"),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { locationId, ...data } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.createOpportunity(data);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  updateOpportunity: protectedProcedure
+    .input(
+      z.object({
+        opportunityId: z.string().min(1),
+        locationId: z.string().optional(),
+        stageId: z.string().optional(),
+        status: z.enum(["open", "won", "lost", "abandoned"]).optional(),
+        monetaryValue: z.number().optional(),
+        name: z.string().optional(),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { opportunityId, locationId, ...data } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.updateOpportunity(opportunityId, data);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Campaign / Drip Management (AI-3461)
+  // ----------------------------------------
+
+  listCampaigns: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listCampaigns();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  addContactToCampaign: protectedProcedure
+    .input(
+      z.object({
+        campaignId: z.string().min(1),
+        contactId: z.string().min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        await service.addContactToCampaign(input.campaignId, input.contactId);
+        return { success: true };
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  removeContactFromCampaign: protectedProcedure
+    .input(
+      z.object({
+        campaignId: z.string().min(1),
+        contactId: z.string().min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        await service.removeContactFromCampaign(input.campaignId, input.contactId);
+        return { success: true };
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Workflows (AI-3461)
+  // ----------------------------------------
+
+  listWorkflows: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listWorkflows();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
     }),
 });

--- a/server/api/routes/ghl-webhooks.ts
+++ b/server/api/routes/ghl-webhooks.ts
@@ -1,21 +1,36 @@
 /**
- * GHL Webhook Receiver
+ * GHL Webhook Receiver -- Production-Grade
  *
  * Express routes for receiving inbound webhooks from GoHighLevel.
  * Handles contact events, opportunity events, and campaign events
- * for lead routing and data flow synchronization.
+ * with real DB sync, event deduplication, dead letter queue,
+ * structured logging, and workflow engine integration.
  *
  * Routes:
- *   POST /api/ghl/webhooks/inbound — receive GHL webhook events
- *   GET  /api/ghl/webhooks/health  — health check
+ *   POST /api/ghl/webhooks/inbound  -- receive GHL webhook events
+ *   GET  /api/ghl/webhooks/health   -- health check
+ *   GET  /api/ghl/webhooks/dlq      -- view dead letter queue
+ *   POST /api/ghl/webhooks/dlq/:id/retry -- retry a dead letter
  *
- * Linear: AI-3461
+ * Linear: AI-5147
  */
 
 import express, { Request, Response } from "express";
 import crypto from "crypto";
+import { eq, and, desc } from "drizzle-orm";
+import { getDb } from "../../db";
+import { ghlLocations } from "../../../drizzle/schema-ghl-locations";
+import {
+  ghlContacts,
+  ghlOpportunities,
+  ghlWebhookEvents,
+  ghlWebhookDeadLetters,
+} from "../../../drizzle/schema-ghl-webhooks";
+import { addWorkflowExecutionJob, REDIS_AVAILABLE } from "../../_core/queue";
+import { logger } from "../../lib/logger";
 
 const webhookRouter = express.Router();
+const log = logger.child({ service: "ghl-webhooks" });
 
 // ========================================
 // TYPES
@@ -24,6 +39,8 @@ const webhookRouter = express.Router();
 interface GHLWebhookEvent {
   type: string;
   locationId?: string;
+  /** GHL-provided event ID for deduplication */
+  id?: string;
   // Contact events
   contact?: {
     id: string;
@@ -54,75 +71,371 @@ interface GHLWebhookEvent {
   timestamp?: string;
 }
 
-type WebhookHandler = (event: GHLWebhookEvent) => Promise<void>;
+type WebhookHandler = (event: GHLWebhookEvent, userId: number) => Promise<void>;
+
+// ========================================
+// HELPERS
+// ========================================
+
+/**
+ * Resolve the userId that owns a given GHL locationId.
+ * Returns null if the location is not connected.
+ */
+async function resolveUserForLocation(locationId: string): Promise<number | null> {
+  const db = await getDb();
+  if (!db || !locationId) return null;
+
+  const rows = await db
+    .select({ userId: ghlLocations.userId })
+    .from(ghlLocations)
+    .where(and(eq(ghlLocations.locationId, locationId), eq(ghlLocations.isActive, true)))
+    .limit(1);
+
+  return rows.length > 0 ? rows[0].userId : null;
+}
+
+/**
+ * Generate a deterministic event ID when GHL does not provide one.
+ * Uses type + locationId + contactId/opportunityId + timestamp.
+ */
+function deriveEventId(event: GHLWebhookEvent): string {
+  if (event.id) return event.id;
+  const parts = [
+    event.type,
+    event.locationId || "",
+    event.contact?.id || event.opportunity?.id || event.contactId || "",
+    event.timestamp || "",
+  ];
+  return crypto.createHash("sha256").update(parts.join("|")).digest("hex").slice(0, 64);
+}
+
+/**
+ * Check if this event has already been processed (dedup).
+ */
+async function isDuplicateEvent(eventId: string): Promise<boolean> {
+  const db = await getDb();
+  if (!db) return false;
+
+  const rows = await db
+    .select({ id: ghlWebhookEvents.id })
+    .from(ghlWebhookEvents)
+    .where(eq(ghlWebhookEvents.eventId, eventId))
+    .limit(1);
+
+  return rows.length > 0;
+}
+
+/**
+ * Record a processed event for future dedup.
+ */
+async function recordEvent(eventId: string, eventType: string, locationId: string | undefined, success: boolean): Promise<void> {
+  const db = await getDb();
+  if (!db) return;
+
+  await db.insert(ghlWebhookEvents).values({
+    eventId,
+    eventType,
+    locationId: locationId || null,
+    success,
+  }).onConflictDoNothing();
+}
+
+/**
+ * Push a failed event into the dead letter queue.
+ */
+async function pushToDeadLetterQueue(
+  event: GHLWebhookEvent,
+  eventId: string,
+  error: string
+): Promise<void> {
+  const db = await getDb();
+  if (!db) return;
+
+  await db.insert(ghlWebhookDeadLetters).values({
+    eventId,
+    eventType: event.type,
+    locationId: event.locationId || null,
+    payload: event as unknown as Record<string, unknown>,
+    error,
+  });
+
+  log.warn({ eventId, eventType: event.type, error }, "Event pushed to dead letter queue");
+}
+
+/**
+ * Fire a workflow execution job if Redis + workflow queue is available.
+ */
+async function triggerWorkflow(userId: number, event: GHLWebhookEvent): Promise<void> {
+  if (!REDIS_AVAILABLE) return;
+
+  try {
+    await addWorkflowExecutionJob({
+      userId: String(userId),
+      workflowId: `ghl-webhook-${event.type}`,
+      triggerId: event.id || deriveEventId(event),
+      context: {
+        source: "ghl-webhook",
+        eventType: event.type,
+        locationId: event.locationId,
+        contactId: event.contact?.id || event.contactId,
+        opportunityId: event.opportunity?.id,
+        campaignId: event.campaign?.id,
+        timestamp: event.timestamp || new Date().toISOString(),
+      },
+    });
+
+    log.debug({ eventType: event.type, userId }, "Workflow job enqueued");
+  } catch (err) {
+    log.warn({ err, eventType: event.type }, "Failed to enqueue workflow job (non-fatal)");
+  }
+}
 
 // ========================================
 // EVENT HANDLERS
 // ========================================
 
 const eventHandlers: Record<string, WebhookHandler> = {
-  "ContactCreate": async (event) => {
-    console.log("[GHL Webhook] New contact created:", {
-      contactId: event.contact?.id,
-      name: `${event.contact?.firstName || ""} ${event.contact?.lastName || ""}`.trim(),
-      email: event.contact?.email,
-      source: event.contact?.source,
-      locationId: event.locationId,
+  ContactCreate: async (event, userId) => {
+    const c = event.contact;
+    if (!c?.id) throw new Error("Missing contact.id in ContactCreate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlContacts).values({
+      userId,
+      ghlContactId: c.id,
+      locationId: event.locationId || "",
+      firstName: c.firstName || null,
+      lastName: c.lastName || null,
+      email: c.email || null,
+      phone: c.phone || null,
+      tags: c.tags || null,
+      source: c.source || null,
+      customFields: c.customFields || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+      set: {
+        firstName: c.firstName || null,
+        lastName: c.lastName || null,
+        email: c.email || null,
+        phone: c.phone || null,
+        tags: c.tags || null,
+        source: c.source || null,
+        customFields: c.customFields || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
-    // Lead routing logic: tag-based routing happens in GHL workflows,
-    // but we log and can trigger internal automations here
+
+    log.info({
+      contactId: c.id,
+      email: c.email,
+      locationId: event.locationId,
+    }, "Contact created/upserted");
   },
 
-  "ContactUpdate": async (event) => {
-    console.log("[GHL Webhook] Contact updated:", {
-      contactId: event.contact?.id,
-      locationId: event.locationId,
+  ContactUpdate: async (event, userId) => {
+    const c = event.contact;
+    if (!c?.id) throw new Error("Missing contact.id in ContactUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlContacts).values({
+      userId,
+      ghlContactId: c.id,
+      locationId: event.locationId || "",
+      firstName: c.firstName || null,
+      lastName: c.lastName || null,
+      email: c.email || null,
+      phone: c.phone || null,
+      tags: c.tags || null,
+      source: c.source || null,
+      customFields: c.customFields || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+      set: {
+        firstName: c.firstName || null,
+        lastName: c.lastName || null,
+        email: c.email || null,
+        phone: c.phone || null,
+        tags: c.tags || null,
+        source: c.source || null,
+        customFields: c.customFields || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({ contactId: c.id, locationId: event.locationId }, "Contact updated");
   },
 
-  "ContactTagUpdate": async (event) => {
-    console.log("[GHL Webhook] Contact tags changed:", {
-      contactId: event.contact?.id,
-      tags: event.contact?.tags,
-      locationId: event.locationId,
+  ContactTagUpdate: async (event, userId) => {
+    const c = event.contact;
+    if (!c?.id) throw new Error("Missing contact.id in ContactTagUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlContacts).values({
+      userId,
+      ghlContactId: c.id,
+      locationId: event.locationId || "",
+      tags: c.tags || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+      set: {
+        tags: c.tags || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({ contactId: c.id, tags: c.tags, locationId: event.locationId }, "Contact tags updated");
   },
 
-  "OpportunityCreate": async (event) => {
-    console.log("[GHL Webhook] New opportunity:", {
-      opportunityId: event.opportunity?.id,
-      name: event.opportunity?.name,
-      pipelineId: event.opportunity?.pipelineId,
-      stageId: event.opportunity?.pipelineStageId,
-      contactId: event.opportunity?.contactId,
-      value: event.opportunity?.monetaryValue,
-      locationId: event.locationId,
+  OpportunityCreate: async (event, userId) => {
+    const o = event.opportunity;
+    if (!o?.id) throw new Error("Missing opportunity.id in OpportunityCreate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlOpportunities).values({
+      userId,
+      ghlOpportunityId: o.id,
+      locationId: event.locationId || "",
+      name: o.name || null,
+      pipelineId: o.pipelineId || null,
+      pipelineStageId: o.pipelineStageId || null,
+      status: o.status || null,
+      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+      ghlContactId: o.contactId || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+      set: {
+        name: o.name || null,
+        pipelineId: o.pipelineId || null,
+        pipelineStageId: o.pipelineStageId || null,
+        status: o.status || null,
+        monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+        ghlContactId: o.contactId || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({
+      opportunityId: o.id,
+      pipeline: o.pipelineId,
+      stage: o.pipelineStageId,
+      value: o.monetaryValue,
+      locationId: event.locationId,
+    }, "Opportunity created/upserted");
   },
 
-  "OpportunityStageUpdate": async (event) => {
-    console.log("[GHL Webhook] Opportunity stage changed:", {
-      opportunityId: event.opportunity?.id,
-      newStage: event.opportunity?.pipelineStageId,
-      status: event.opportunity?.status,
-      locationId: event.locationId,
+  OpportunityStageUpdate: async (event, userId) => {
+    const o = event.opportunity;
+    if (!o?.id) throw new Error("Missing opportunity.id in OpportunityStageUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlOpportunities).values({
+      userId,
+      ghlOpportunityId: o.id,
+      locationId: event.locationId || "",
+      name: o.name || null,
+      pipelineId: o.pipelineId || null,
+      pipelineStageId: o.pipelineStageId || null,
+      status: o.status || null,
+      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+      ghlContactId: o.contactId || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+      set: {
+        pipelineStageId: o.pipelineStageId || null,
+        status: o.status || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({
+      opportunityId: o.id,
+      newStage: o.pipelineStageId,
+      status: o.status,
+      locationId: event.locationId,
+    }, "Opportunity stage updated");
   },
 
-  "OpportunityStatusUpdate": async (event) => {
-    console.log("[GHL Webhook] Opportunity status changed:", {
-      opportunityId: event.opportunity?.id,
-      status: event.opportunity?.status,
-      locationId: event.locationId,
+  OpportunityStatusUpdate: async (event, userId) => {
+    const o = event.opportunity;
+    if (!o?.id) throw new Error("Missing opportunity.id in OpportunityStatusUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlOpportunities).values({
+      userId,
+      ghlOpportunityId: o.id,
+      locationId: event.locationId || "",
+      name: o.name || null,
+      pipelineId: o.pipelineId || null,
+      pipelineStageId: o.pipelineStageId || null,
+      status: o.status || null,
+      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+      ghlContactId: o.contactId || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+      set: {
+        status: o.status || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({
+      opportunityId: o.id,
+      status: o.status,
+      locationId: event.locationId,
+    }, "Opportunity status updated");
   },
 
-  "CampaignStatusUpdate": async (event) => {
-    console.log("[GHL Webhook] Campaign status update:", {
+  CampaignStatusUpdate: async (event, _userId) => {
+    // Campaign events are logged and forwarded to workflow engine.
+    // No dedicated table -- these trigger internal automations.
+    log.info({
       campaignId: event.campaign?.id,
+      campaignName: event.campaign?.name,
       contactId: event.contactId,
       locationId: event.locationId,
-    });
+    }, "Campaign status update received");
   },
 };
 
@@ -157,7 +470,7 @@ webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Reques
 
   // Verify signature if secret is configured
   if (webhookSecret && !verifyWebhookSignature(rawBody, signature, webhookSecret)) {
-    console.warn("[GHL Webhook] Invalid signature, rejecting");
+    log.warn({ ip: req.ip }, "Invalid webhook signature, rejecting");
     res.status(401).json({ error: "Invalid webhook signature" });
     return;
   }
@@ -166,36 +479,73 @@ webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Reques
   try {
     event = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
   } catch {
-    console.error("[GHL Webhook] Failed to parse body");
+    log.error("Failed to parse webhook body");
     res.status(400).json({ error: "Invalid JSON body" });
     return;
   }
 
   const eventType = event.type;
   if (!eventType) {
-    console.warn("[GHL Webhook] Missing event type");
+    log.warn("Missing event type in webhook payload");
     res.status(400).json({ error: "Missing event type" });
     return;
   }
 
-  console.log(`[GHL Webhook] Received event: ${eventType}`, {
+  const eventId = deriveEventId(event);
+
+  log.info({
+    eventId,
+    eventType,
     locationId: event.locationId,
     timestamp: event.timestamp || new Date().toISOString(),
-  });
+  }, "Webhook received");
 
   // Respond immediately (GHL expects quick 200)
-  res.status(200).json({ received: true, type: eventType });
+  res.status(200).json({ received: true, type: eventType, eventId });
 
-  // Process event asynchronously
+  // ---- Async processing below ----
+
+  // 1. Dedup check
+  try {
+    if (await isDuplicateEvent(eventId)) {
+      log.info({ eventId, eventType }, "Duplicate event, skipping");
+      return;
+    }
+  } catch (err) {
+    log.warn({ err, eventId }, "Dedup check failed, processing anyway");
+  }
+
+  // 2. Resolve user from locationId
+  let userId: number | null = null;
+  if (event.locationId) {
+    userId = await resolveUserForLocation(event.locationId);
+  }
+
+  if (!userId) {
+    log.warn({ locationId: event.locationId, eventType }, "No user found for location, using DLQ");
+    await pushToDeadLetterQueue(event, eventId, `No user found for locationId: ${event.locationId || "missing"}`);
+    await recordEvent(eventId, eventType, event.locationId, false);
+    return;
+  }
+
+  // 3. Process event
   const handler = eventHandlers[eventType];
   if (handler) {
     try {
-      await handler(event);
+      await handler(event, userId);
+      await recordEvent(eventId, eventType, event.locationId, true);
+
+      // 4. Trigger workflow engine
+      await triggerWorkflow(userId, event);
     } catch (err) {
-      console.error(`[GHL Webhook] Error handling ${eventType}:`, err);
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      log.error({ err, eventId, eventType, locationId: event.locationId }, "Handler failed");
+      await pushToDeadLetterQueue(event, eventId, errorMsg);
+      await recordEvent(eventId, eventType, event.locationId, false);
     }
   } else {
-    console.log(`[GHL Webhook] No handler for event type: ${eventType}`);
+    log.info({ eventType }, "No handler registered for event type");
+    await recordEvent(eventId, eventType, event.locationId, true);
   }
 });
 
@@ -203,14 +553,152 @@ webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Reques
 // HEALTH CHECK
 // ========================================
 
-webhookRouter.get("/health", (_req: Request, res: Response) => {
+webhookRouter.get("/health", async (_req: Request, res: Response) => {
+  const db = await getDb();
+  let dlqCount = 0;
+
+  if (db) {
+    try {
+      const rows = await db
+        .select({ id: ghlWebhookDeadLetters.id })
+        .from(ghlWebhookDeadLetters)
+        .where(eq(ghlWebhookDeadLetters.resolved, false));
+      dlqCount = rows.length;
+    } catch {
+      // DB may not have the table yet
+    }
+  }
+
   res.json({
     status: "ok",
     service: "ghl-webhooks",
     configured: !!process.env.GHL_WEBHOOK_SECRET,
     supportedEvents: Object.keys(eventHandlers),
+    deadLetterCount: dlqCount,
+    workflowQueueAvailable: REDIS_AVAILABLE,
     timestamp: new Date().toISOString(),
   });
+});
+
+// ========================================
+// DLQ MANAGEMENT
+// ========================================
+
+webhookRouter.get("/dlq", async (_req: Request, res: Response) => {
+  const db = await getDb();
+  if (!db) {
+    res.status(503).json({ error: "Database not available" });
+    return;
+  }
+
+  try {
+    const items = await db
+      .select()
+      .from(ghlWebhookDeadLetters)
+      .where(eq(ghlWebhookDeadLetters.resolved, false))
+      .orderBy(desc(ghlWebhookDeadLetters.createdAt))
+      .limit(100);
+
+    res.json({ count: items.length, items });
+  } catch (err) {
+    log.error({ err }, "Failed to fetch DLQ items");
+    res.status(500).json({ error: "Failed to fetch dead letter queue" });
+  }
+});
+
+webhookRouter.post("/dlq/:id/retry", async (req: Request, res: Response) => {
+  const db = await getDb();
+  if (!db) {
+    res.status(503).json({ error: "Database not available" });
+    return;
+  }
+
+  const dlqId = parseInt(req.params.id, 10);
+  if (isNaN(dlqId)) {
+    res.status(400).json({ error: "Invalid DLQ entry ID" });
+    return;
+  }
+
+  try {
+    const rows = await db
+      .select()
+      .from(ghlWebhookDeadLetters)
+      .where(eq(ghlWebhookDeadLetters.id, dlqId))
+      .limit(1);
+
+    if (rows.length === 0) {
+      res.status(404).json({ error: "DLQ entry not found" });
+      return;
+    }
+
+    const entry = rows[0];
+    if (entry.resolved) {
+      res.status(400).json({ error: "DLQ entry already resolved" });
+      return;
+    }
+
+    if (entry.retryCount >= entry.maxRetries) {
+      res.status(400).json({ error: "Max retries exceeded" });
+      return;
+    }
+
+    const event = entry.payload as unknown as GHLWebhookEvent;
+    const eventType = event.type || entry.eventType;
+
+    // Re-resolve user
+    let userId: number | null = null;
+    if (event.locationId) {
+      userId = await resolveUserForLocation(event.locationId);
+    }
+
+    if (!userId) {
+      await db.update(ghlWebhookDeadLetters).set({
+        retryCount: entry.retryCount + 1,
+        lastRetriedAt: new Date(),
+        error: `Retry failed: No user found for locationId: ${event.locationId || "missing"}`,
+        updatedAt: new Date(),
+      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+
+      res.status(422).json({ error: "No user found for location on retry" });
+      return;
+    }
+
+    const handler = eventHandlers[eventType];
+    if (!handler) {
+      res.status(422).json({ error: `No handler for event type: ${eventType}` });
+      return;
+    }
+
+    try {
+      await handler(event, userId);
+      await triggerWorkflow(userId, event);
+
+      // Mark resolved
+      await db.update(ghlWebhookDeadLetters).set({
+        resolved: true,
+        retryCount: entry.retryCount + 1,
+        lastRetriedAt: new Date(),
+        updatedAt: new Date(),
+      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+
+      log.info({ dlqId, eventType }, "DLQ entry retried successfully");
+      res.json({ success: true, message: "Event reprocessed successfully" });
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      await db.update(ghlWebhookDeadLetters).set({
+        retryCount: entry.retryCount + 1,
+        lastRetriedAt: new Date(),
+        error: `Retry failed: ${errorMsg}`,
+        updatedAt: new Date(),
+      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+
+      log.error({ err, dlqId, eventType }, "DLQ retry failed");
+      res.status(500).json({ error: "Retry failed", detail: errorMsg });
+    }
+  } catch (err) {
+    log.error({ err }, "Failed to process DLQ retry");
+    res.status(500).json({ error: "Failed to process retry" });
+  }
 });
 
 export default webhookRouter;

--- a/server/api/routes/ghl-webhooks.ts
+++ b/server/api/routes/ghl-webhooks.ts
@@ -1,0 +1,216 @@
+/**
+ * GHL Webhook Receiver
+ *
+ * Express routes for receiving inbound webhooks from GoHighLevel.
+ * Handles contact events, opportunity events, and campaign events
+ * for lead routing and data flow synchronization.
+ *
+ * Routes:
+ *   POST /api/ghl/webhooks/inbound — receive GHL webhook events
+ *   GET  /api/ghl/webhooks/health  — health check
+ *
+ * Linear: AI-3461
+ */
+
+import express, { Request, Response } from "express";
+import crypto from "crypto";
+
+const webhookRouter = express.Router();
+
+// ========================================
+// TYPES
+// ========================================
+
+interface GHLWebhookEvent {
+  type: string;
+  locationId?: string;
+  // Contact events
+  contact?: {
+    id: string;
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phone?: string;
+    tags?: string[];
+    source?: string;
+    customFields?: Array<{ id: string; value: string }>;
+  };
+  // Opportunity events
+  opportunity?: {
+    id: string;
+    name: string;
+    pipelineId: string;
+    pipelineStageId: string;
+    status: string;
+    monetaryValue?: number;
+    contactId: string;
+  };
+  // Campaign events
+  campaign?: {
+    id: string;
+    name: string;
+  };
+  contactId?: string;
+  timestamp?: string;
+}
+
+type WebhookHandler = (event: GHLWebhookEvent) => Promise<void>;
+
+// ========================================
+// EVENT HANDLERS
+// ========================================
+
+const eventHandlers: Record<string, WebhookHandler> = {
+  "ContactCreate": async (event) => {
+    console.log("[GHL Webhook] New contact created:", {
+      contactId: event.contact?.id,
+      name: `${event.contact?.firstName || ""} ${event.contact?.lastName || ""}`.trim(),
+      email: event.contact?.email,
+      source: event.contact?.source,
+      locationId: event.locationId,
+    });
+    // Lead routing logic: tag-based routing happens in GHL workflows,
+    // but we log and can trigger internal automations here
+  },
+
+  "ContactUpdate": async (event) => {
+    console.log("[GHL Webhook] Contact updated:", {
+      contactId: event.contact?.id,
+      locationId: event.locationId,
+    });
+  },
+
+  "ContactTagUpdate": async (event) => {
+    console.log("[GHL Webhook] Contact tags changed:", {
+      contactId: event.contact?.id,
+      tags: event.contact?.tags,
+      locationId: event.locationId,
+    });
+  },
+
+  "OpportunityCreate": async (event) => {
+    console.log("[GHL Webhook] New opportunity:", {
+      opportunityId: event.opportunity?.id,
+      name: event.opportunity?.name,
+      pipelineId: event.opportunity?.pipelineId,
+      stageId: event.opportunity?.pipelineStageId,
+      contactId: event.opportunity?.contactId,
+      value: event.opportunity?.monetaryValue,
+      locationId: event.locationId,
+    });
+  },
+
+  "OpportunityStageUpdate": async (event) => {
+    console.log("[GHL Webhook] Opportunity stage changed:", {
+      opportunityId: event.opportunity?.id,
+      newStage: event.opportunity?.pipelineStageId,
+      status: event.opportunity?.status,
+      locationId: event.locationId,
+    });
+  },
+
+  "OpportunityStatusUpdate": async (event) => {
+    console.log("[GHL Webhook] Opportunity status changed:", {
+      opportunityId: event.opportunity?.id,
+      status: event.opportunity?.status,
+      locationId: event.locationId,
+    });
+  },
+
+  "CampaignStatusUpdate": async (event) => {
+    console.log("[GHL Webhook] Campaign status update:", {
+      campaignId: event.campaign?.id,
+      contactId: event.contactId,
+      locationId: event.locationId,
+    });
+  },
+};
+
+// ========================================
+// SIGNATURE VERIFICATION
+// ========================================
+
+function verifyWebhookSignature(
+  body: string,
+  signature: string | undefined,
+  secret: string
+): boolean {
+  if (!signature || !secret) return !secret; // Skip if no secret configured
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(body)
+    .digest("hex");
+  return crypto.timingSafeEqual(
+    Buffer.from(signature),
+    Buffer.from(expected)
+  );
+}
+
+// ========================================
+// POST /api/ghl/webhooks/inbound
+// ========================================
+
+webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Request, res: Response) => {
+  const webhookSecret = process.env.GHL_WEBHOOK_SECRET;
+  const signature = req.headers["x-ghl-signature"] as string | undefined;
+  const rawBody = typeof req.body === "string" ? req.body : JSON.stringify(req.body);
+
+  // Verify signature if secret is configured
+  if (webhookSecret && !verifyWebhookSignature(rawBody, signature, webhookSecret)) {
+    console.warn("[GHL Webhook] Invalid signature, rejecting");
+    res.status(401).json({ error: "Invalid webhook signature" });
+    return;
+  }
+
+  let event: GHLWebhookEvent;
+  try {
+    event = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+  } catch {
+    console.error("[GHL Webhook] Failed to parse body");
+    res.status(400).json({ error: "Invalid JSON body" });
+    return;
+  }
+
+  const eventType = event.type;
+  if (!eventType) {
+    console.warn("[GHL Webhook] Missing event type");
+    res.status(400).json({ error: "Missing event type" });
+    return;
+  }
+
+  console.log(`[GHL Webhook] Received event: ${eventType}`, {
+    locationId: event.locationId,
+    timestamp: event.timestamp || new Date().toISOString(),
+  });
+
+  // Respond immediately (GHL expects quick 200)
+  res.status(200).json({ received: true, type: eventType });
+
+  // Process event asynchronously
+  const handler = eventHandlers[eventType];
+  if (handler) {
+    try {
+      await handler(event);
+    } catch (err) {
+      console.error(`[GHL Webhook] Error handling ${eventType}:`, err);
+    }
+  } else {
+    console.log(`[GHL Webhook] No handler for event type: ${eventType}`);
+  }
+});
+
+// ========================================
+// HEALTH CHECK
+// ========================================
+
+webhookRouter.get("/health", (_req: Request, res: Response) => {
+  res.json({
+    status: "ok",
+    service: "ghl-webhooks",
+    configured: !!process.env.GHL_WEBHOOK_SECRET,
+    supportedEvents: Object.keys(eventHandlers),
+    timestamp: new Date().toISOString(),
+  });
+});
+
+export default webhookRouter;

--- a/server/services/ghl.service.ts
+++ b/server/services/ghl.service.ts
@@ -187,6 +187,37 @@ export interface GHLWorkflow {
   locationId: string;
 }
 
+export interface GHLMessage {
+  id: string;
+  conversationId: string;
+  contactId: string;
+  locationId: string;
+  body?: string;
+  type: "SMS" | "Email" | "TYPE_CALL" | "TYPE_LIVE_CHAT" | "TYPE_ACTIVITY_CONTACT";
+  direction: "inbound" | "outbound";
+  status: "pending" | "sent" | "delivered" | "read" | "failed" | "undelivered";
+  dateAdded?: string;
+  messageType?: string;
+  source?: string;
+  contentType?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface GHLEmailAttachment {
+  url: string;
+  name?: string;
+}
+
+export interface GHLTemplate {
+  id: string;
+  name: string;
+  type: "sms" | "email" | "whatsapp";
+  body?: string;
+  subject?: string;
+  locationId: string;
+  dateAdded?: string;
+}
+
 // ========================================
 // TOKEN BUCKET RATE LIMITER
 // ========================================
@@ -1018,6 +1049,88 @@ export class GHLService {
       method: "GET",
       endpoint: "/workflows/",
       params: { locationId: this.locationId },
+    });
+  }
+
+  // ----------------------------------------
+  // Messaging / Communication (AI-5149)
+  // ----------------------------------------
+
+  /**
+   * Send an SMS message to a contact via GHL Conversations API.
+   */
+  async sendSMS(
+    contactId: string,
+    message: string
+  ): Promise<GHLApiResponse<{ messageId: string; message: GHLMessage }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/conversations/messages",
+      data: {
+        type: "SMS",
+        contactId,
+        message,
+      },
+    });
+  }
+
+  /**
+   * Send an email to a contact via GHL Conversations API.
+   */
+  async sendEmail(
+    contactId: string,
+    data: {
+      subject: string;
+      html: string;
+      emailFrom?: string;
+      emailTo?: string;
+      emailReplyTo?: string;
+      templateId?: string;
+      attachments?: GHLEmailAttachment[];
+    }
+  ): Promise<GHLApiResponse<{ messageId: string; message: GHLMessage }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/conversations/messages",
+      data: {
+        type: "Email",
+        contactId,
+        ...data,
+      },
+    });
+  }
+
+  /**
+   * Get message delivery status by message ID.
+   */
+  async getMessageStatus(
+    messageId: string
+  ): Promise<GHLApiResponse<{ message: GHLMessage }>> {
+    return this.request({
+      method: "GET",
+      endpoint: `/conversations/messages/${messageId}`,
+    });
+  }
+
+  /**
+   * List email/SMS templates for this location.
+   */
+  async listTemplates(params?: {
+    type?: "sms" | "email" | "whatsapp";
+    limit?: number;
+    offset?: number;
+  }): Promise<GHLApiResponse<{ templates: GHLTemplate[]; total: number }>> {
+    const searchParams: Record<string, string> = {
+      locationId: this.locationId,
+      ...(params?.type ? { type: params.type } : {}),
+      ...(params?.limit ? { limit: String(params.limit) } : {}),
+      ...(params?.offset ? { offset: String(params.offset) } : {}),
+    };
+
+    return this.request({
+      method: "GET",
+      endpoint: "/conversations/templates",
+      params: searchParams,
     });
   }
 

--- a/server/services/ghl.service.ts
+++ b/server/services/ghl.service.ts
@@ -134,6 +134,59 @@ export interface GHLLocation {
   email?: string;
 }
 
+export interface GHLContact {
+  id: string;
+  locationId: string;
+  firstName?: string;
+  lastName?: string;
+  name?: string;
+  email?: string;
+  phone?: string;
+  tags?: string[];
+  source?: string;
+  dateAdded?: string;
+  customFields?: Array<{ id: string; value: string }>;
+}
+
+export interface GHLPipeline {
+  id: string;
+  name: string;
+  locationId: string;
+  stages: Array<{
+    id: string;
+    name: string;
+    position: number;
+  }>;
+}
+
+export interface GHLOpportunity {
+  id: string;
+  name: string;
+  pipelineId: string;
+  pipelineStageId: string;
+  status: "open" | "won" | "lost" | "abandoned";
+  monetaryValue?: number;
+  contactId: string;
+  locationId: string;
+  createdAt?: string;
+  updatedAt?: string;
+  customFields?: Array<{ id: string; value: string }>;
+}
+
+export interface GHLCampaign {
+  id: string;
+  name: string;
+  status: string;
+  locationId: string;
+}
+
+export interface GHLWorkflow {
+  id: string;
+  name: string;
+  status: string;
+  locationId: string;
+}
+
 // ========================================
 // TOKEN BUCKET RATE LIMITER
 // ========================================
@@ -716,6 +769,256 @@ export class GHLService {
     console.log(
       `[GHL] Disconnected location ${this.locationId} for user ${this.userId}`
     );
+  }
+
+  // ----------------------------------------
+  // Contact / Lead Management
+  // ----------------------------------------
+
+  /**
+   * Search contacts with optional filters.
+   */
+  async searchContacts(params: {
+    query?: string;
+    limit?: number;
+    offset?: number;
+    filters?: Record<string, string>;
+  }): Promise<GHLApiResponse<{ contacts: GHLContact[]; total: number }>> {
+    const searchParams: Record<string, string> = {
+      locationId: this.locationId,
+      ...(params.query ? { query: params.query } : {}),
+      ...(params.limit ? { limit: String(params.limit) } : {}),
+      ...(params.offset ? { startAfter: String(params.offset) } : {}),
+      ...(params.filters || {}),
+    };
+
+    return this.request({
+      method: "GET",
+      endpoint: "/contacts/",
+      params: searchParams,
+    });
+  }
+
+  /**
+   * Get a single contact by ID.
+   */
+  async getContact(contactId: string): Promise<GHLApiResponse<{ contact: GHLContact }>> {
+    return this.request({
+      method: "GET",
+      endpoint: `/contacts/${contactId}`,
+    });
+  }
+
+  /**
+   * Create a new contact in GHL.
+   */
+  async createContact(data: {
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phone?: string;
+    tags?: string[];
+    customFields?: Array<{ id: string; value: string }>;
+    source?: string;
+  }): Promise<GHLApiResponse<{ contact: GHLContact }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/contacts/",
+      data: {
+        ...data,
+        locationId: this.locationId,
+      },
+    });
+  }
+
+  /**
+   * Update an existing contact.
+   */
+  async updateContact(
+    contactId: string,
+    data: {
+      firstName?: string;
+      lastName?: string;
+      email?: string;
+      phone?: string;
+      tags?: string[];
+      customFields?: Array<{ id: string; value: string }>;
+    }
+  ): Promise<GHLApiResponse<{ contact: GHLContact }>> {
+    return this.request({
+      method: "PUT",
+      endpoint: `/contacts/${contactId}`,
+      data,
+    });
+  }
+
+  /**
+   * Add tags to a contact (used for lead routing).
+   */
+  async addContactTags(
+    contactId: string,
+    tags: string[]
+  ): Promise<GHLApiResponse<{ tags: string[] }>> {
+    return this.request({
+      method: "POST",
+      endpoint: `/contacts/${contactId}/tags`,
+      data: { tags },
+    });
+  }
+
+  /**
+   * Remove tags from a contact.
+   */
+  async removeContactTags(
+    contactId: string,
+    tags: string[]
+  ): Promise<GHLApiResponse<unknown>> {
+    return this.request({
+      method: "DELETE",
+      endpoint: `/contacts/${contactId}/tags`,
+      data: { tags },
+    });
+  }
+
+  // ----------------------------------------
+  // Pipeline / Opportunity Management
+  // ----------------------------------------
+
+  /**
+   * List all pipelines for this location.
+   */
+  async listPipelines(): Promise<GHLApiResponse<{ pipelines: GHLPipeline[] }>> {
+    return this.request({
+      method: "GET",
+      endpoint: "/opportunities/pipelines",
+      params: { locationId: this.locationId },
+    });
+  }
+
+  /**
+   * Search opportunities (deals) with filters.
+   */
+  async searchOpportunities(params: {
+    pipelineId?: string;
+    stageId?: string;
+    status?: "open" | "won" | "lost" | "abandoned" | "all";
+    query?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<GHLApiResponse<{ opportunities: GHLOpportunity[]; meta: { total: number } }>> {
+    const searchParams: Record<string, string> = {
+      location_id: this.locationId,
+      ...(params.pipelineId ? { pipeline_id: params.pipelineId } : {}),
+      ...(params.stageId ? { stage_id: params.stageId } : {}),
+      ...(params.status && params.status !== "all" ? { status: params.status } : {}),
+      ...(params.query ? { q: params.query } : {}),
+      ...(params.limit ? { limit: String(params.limit) } : {}),
+      ...(params.offset ? { startAfter: String(params.offset) } : {}),
+    };
+
+    return this.request({
+      method: "GET",
+      endpoint: "/opportunities/search",
+      params: searchParams,
+    });
+  }
+
+  /**
+   * Create a new opportunity (deal/showing request).
+   */
+  async createOpportunity(data: {
+    pipelineId: string;
+    stageId: string;
+    contactId: string;
+    name: string;
+    monetaryValue?: number;
+    status?: "open" | "won" | "lost" | "abandoned";
+    customFields?: Array<{ id: string; value: string }>;
+  }): Promise<GHLApiResponse<{ opportunity: GHLOpportunity }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/opportunities/",
+      data: {
+        ...data,
+        locationId: this.locationId,
+      },
+    });
+  }
+
+  /**
+   * Update an opportunity (move stage, change status, etc.).
+   */
+  async updateOpportunity(
+    opportunityId: string,
+    data: {
+      stageId?: string;
+      status?: "open" | "won" | "lost" | "abandoned";
+      monetaryValue?: number;
+      name?: string;
+      customFields?: Array<{ id: string; value: string }>;
+    }
+  ): Promise<GHLApiResponse<{ opportunity: GHLOpportunity }>> {
+    return this.request({
+      method: "PUT",
+      endpoint: `/opportunities/${opportunityId}`,
+      data,
+    });
+  }
+
+  // ----------------------------------------
+  // Campaign / Drip Management
+  // ----------------------------------------
+
+  /**
+   * List all campaigns for this location.
+   */
+  async listCampaigns(): Promise<GHLApiResponse<{ campaigns: GHLCampaign[] }>> {
+    return this.request({
+      method: "GET",
+      endpoint: "/campaigns/",
+      params: { locationId: this.locationId },
+    });
+  }
+
+  /**
+   * Add a contact to a campaign (drip sequence).
+   */
+  async addContactToCampaign(
+    campaignId: string,
+    contactId: string
+  ): Promise<GHLApiResponse<unknown>> {
+    return this.request({
+      method: "POST",
+      endpoint: `/campaigns/${campaignId}/contacts/${contactId}`,
+    });
+  }
+
+  /**
+   * Remove a contact from a campaign.
+   */
+  async removeContactFromCampaign(
+    campaignId: string,
+    contactId: string
+  ): Promise<GHLApiResponse<unknown>> {
+    return this.request({
+      method: "DELETE",
+      endpoint: `/campaigns/${campaignId}/contacts/${contactId}`,
+    });
+  }
+
+  // ----------------------------------------
+  // Workflow Triggers
+  // ----------------------------------------
+
+  /**
+   * List available workflows for this location.
+   */
+  async listWorkflows(): Promise<GHLApiResponse<{ workflows: GHLWorkflow[] }>> {
+    return this.request({
+      method: "GET",
+      endpoint: "/workflows/",
+      params: { locationId: this.locationId },
+    });
   }
 
   // ----------------------------------------


### PR DESCRIPTION
## Summary
- **GHL Contacts** (`/dashboard/ghl/contacts`) — search, filter, view details, inline edit, tag add/remove
- **GHL Pipeline** (`/dashboard/ghl/pipeline`) — Kanban board grouped by stage, move opportunities, create new deals
- **GHL Campaigns** (`/dashboard/ghl/campaigns`) — list campaigns, add/remove contacts from campaigns
- **Webhook Event Log** (`/dashboard/ghl/webhooks`) — health status dashboard, dead letter queue viewer with retry

All screens wired to existing `ghl.*` tRPC endpoints. Sidebar navigation added. Vite build passes clean.

## Verification
- Navigate to `/dashboard/ghl/contacts` — should show contact search + table
- Navigate to `/dashboard/ghl/pipeline` — should show Kanban board (requires active GHL location with pipelines)
- Navigate to `/dashboard/ghl/campaigns` — should list campaigns from GHL
- Navigate to `/dashboard/ghl/webhooks` — should show webhook health + DLQ
- Sidebar should show 4 new GHL navigation items

Linear: AI-5214

🤖 Generated with [Claude Code](https://claude.com/claude-code)