### PR TITLE
feat: GHL CRM integration + Orgo compute provider

### DIFF
--- a/client/src/components/DashboardLayout.tsx
+++ b/client/src/components/DashboardLayout.tsx
@@ -35,7 +35,10 @@ import {
   LifeBuoy,
   Shield,
   Bot,
-  GraduationCap
+  GraduationCap,
+  Contact,
+  Kanban,
+  Webhook,
 } from "lucide-react";
 import { CSSProperties, useEffect, useRef, useState } from "react";
 import { useLocation } from "wouter";
@@ -53,6 +56,10 @@ const menuItems = [
   { icon: Users, label: "Lead Lists", path: "/dashboard/lead-lists" },
   { icon: Megaphone, label: "AI Campaigns", path: "/dashboard/ai-campaigns" },
   { icon: CreditCard, label: "Credits", path: "/dashboard/credits" },
+  { icon: Contact, label: "GHL Contacts", path: "/dashboard/ghl/contacts" },
+  { icon: Kanban, label: "GHL Pipeline", path: "/dashboard/ghl/pipeline" },
+  { icon: Megaphone, label: "GHL Campaigns", path: "/dashboard/ghl/campaigns" },
+  { icon: Webhook, label: "Webhook Log", path: "/dashboard/ghl/webhooks" },
   { icon: Settings, label: "Settings", path: "/dashboard/settings" },
 ];
 

--- a/client/src/components/Routes.tsx
+++ b/client/src/components/Routes.tsx
@@ -17,6 +17,10 @@ import AICampaigns from '@/pages/AICampaigns';
 import CampaignDetails from '@/pages/CampaignDetails';
 import CreditPurchase from '@/pages/CreditPurchase';
 import Training from '@/pages/Training';
+import GHLContacts from '@/pages/GHLContacts';
+import GHLPipeline from '@/pages/GHLPipeline';
+import GHLCampaigns from '@/pages/GHLCampaigns';
+import GHLWebhookLog from '@/pages/GHLWebhookLog';
 import { AdminDashboard } from '@/pages/admin/AdminDashboard';
 import { UserManagement } from '@/pages/admin/UserManagement';
 import { SystemHealth } from '@/pages/admin/SystemHealth';
@@ -51,6 +55,11 @@ export function Routes() {
           <Route path="/dashboard/ai-campaigns/:id" component={CampaignDetails} />
           <Route path="/dashboard/credits" component={CreditPurchase} />
           <Route path="/dashboard/training" component={Training} />
+          {/* GHL CRM routes */}
+          <Route path="/dashboard/ghl/contacts" component={GHLContacts} />
+          <Route path="/dashboard/ghl/pipeline" component={GHLPipeline} />
+          <Route path="/dashboard/ghl/campaigns" component={GHLCampaigns} />
+          <Route path="/dashboard/ghl/webhooks" component={GHLWebhookLog} />
           {/* Admin routes */}
           <Route path="/dashboard/admin" component={AdminDashboard} />
           <Route path="/dashboard/admin/users" component={UserManagement} />

--- a/client/src/pages/GHLCampaigns.tsx
+++ b/client/src/pages/GHLCampaigns.tsx
@@ -1,0 +1,240 @@
+/**
+ * GHL Campaign List
+ *
+ * View campaigns, add/remove contacts, see campaign status.
+ * Wired to ghl.listCampaigns / addContactToCampaign / removeContactFromCampaign.
+ *
+ * Linear: AI-5214
+ */
+
+import { useState } from 'react';
+import { trpc } from '@/lib/trpc';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  RefreshCw,
+  Megaphone,
+  UserPlus,
+  UserMinus,
+  Search,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+export default function GHLCampaigns() {
+  const [search, setSearch] = useState('');
+  const [addContactDialog, setAddContactDialog] = useState<string | null>(null);
+  const [removeContactDialog, setRemoveContactDialog] = useState<string | null>(null);
+  const [contactId, setContactId] = useState('');
+
+  const {
+    data: campaignsData,
+    isLoading,
+    refetch,
+  } = trpc.ghl.listCampaigns.useQuery();
+
+  const addContactMutation = trpc.ghl.addContactToCampaign.useMutation({
+    onSuccess: () => {
+      toast.success('Contact added to campaign');
+      setAddContactDialog(null);
+      setContactId('');
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const removeContactMutation = trpc.ghl.removeContactFromCampaign.useMutation({
+    onSuccess: () => {
+      toast.success('Contact removed from campaign');
+      setRemoveContactDialog(null);
+      setContactId('');
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const campaigns = (campaignsData as any)?.campaigns ?? campaignsData ?? [];
+  const filteredCampaigns = search
+    ? (campaigns as any[]).filter((c: any) =>
+        c.name?.toLowerCase().includes(search.toLowerCase())
+      )
+    : (campaigns as any[]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+            <Megaphone className="h-6 w-6" /> GHL Campaigns
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            View campaigns and manage contact enrollment
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetch()}>
+          <RefreshCw className="h-4 w-4 mr-1" /> Refresh
+        </Button>
+      </div>
+
+      {/* Search */}
+      <div className="relative max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Filter campaigns..."
+          className="pl-9"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </div>
+
+      {/* Campaign list */}
+      <Card>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="p-6 space-y-3">
+              {[1, 2, 3, 4].map((i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : filteredCampaigns.length === 0 ? (
+            <div className="p-12 text-center text-muted-foreground">
+              {search ? 'No campaigns match your filter.' : 'No campaigns found. Set up campaigns in GHL first.'}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Campaign Name</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredCampaigns.map((campaign: any) => (
+                  <TableRow key={campaign.id}>
+                    <TableCell className="font-medium">{campaign.name}</TableCell>
+                    <TableCell>
+                      <Badge
+                        variant={campaign.status === 'published' || campaign.status === 'active' ? 'default' : 'secondary'}
+                        className="text-xs"
+                      >
+                        {campaign.status || 'unknown'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex gap-1 justify-end">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            setAddContactDialog(campaign.id);
+                            setContactId('');
+                          }}
+                        >
+                          <UserPlus className="h-3.5 w-3.5 mr-1" /> Add Contact
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            setRemoveContactDialog(campaign.id);
+                            setContactId('');
+                          }}
+                        >
+                          <UserMinus className="h-3.5 w-3.5 mr-1" /> Remove
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Add Contact to Campaign Dialog */}
+      <Dialog open={!!addContactDialog} onOpenChange={(open) => !open && setAddContactDialog(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Contact to Campaign</DialogTitle>
+          </DialogHeader>
+          <div>
+            <label className="text-sm font-medium">Contact ID</label>
+            <Input
+              placeholder="Enter GHL Contact ID"
+              value={contactId}
+              onChange={(e) => setContactId(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Find contact IDs on the Contacts page
+            </p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddContactDialog(null)}>Cancel</Button>
+            <Button
+              disabled={addContactMutation.isPending || !contactId.trim()}
+              onClick={() =>
+                addContactDialog &&
+                addContactMutation.mutate({
+                  campaignId: addContactDialog,
+                  contactId: contactId.trim(),
+                })
+              }
+            >
+              {addContactMutation.isPending ? 'Adding...' : 'Add to Campaign'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Remove Contact from Campaign Dialog */}
+      <Dialog open={!!removeContactDialog} onOpenChange={(open) => !open && setRemoveContactDialog(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove Contact from Campaign</DialogTitle>
+          </DialogHeader>
+          <div>
+            <label className="text-sm font-medium">Contact ID</label>
+            <Input
+              placeholder="Enter GHL Contact ID"
+              value={contactId}
+              onChange={(e) => setContactId(e.target.value)}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRemoveContactDialog(null)}>Cancel</Button>
+            <Button
+              variant="destructive"
+              disabled={removeContactMutation.isPending || !contactId.trim()}
+              onClick={() =>
+                removeContactDialog &&
+                removeContactMutation.mutate({
+                  campaignId: removeContactDialog,
+                  contactId: contactId.trim(),
+                })
+              }
+            >
+              {removeContactMutation.isPending ? 'Removing...' : 'Remove from Campaign'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/src/pages/GHLContacts.tsx
+++ b/client/src/pages/GHLContacts.tsx
@@ -1,0 +1,489 @@
+/**
+ * GHL Contact Browser
+ *
+ * Search, filter, view details, edit contacts, and manage tags.
+ * Wired to ghl.searchContacts / getContact / updateContact / addContactTags / removeContactTags.
+ *
+ * Linear: AI-5214
+ */
+
+import { useState } from 'react';
+import { trpc } from '@/lib/trpc';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Search,
+  ChevronLeft,
+  ChevronRight,
+  UserPlus,
+  Tag,
+  X,
+  Mail,
+  Phone,
+  Edit2,
+  RefreshCw,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+const PAGE_SIZE = 20;
+
+export default function GHLContacts() {
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [page, setPage] = useState(0);
+  const [selectedContact, setSelectedContact] = useState<any>(null);
+  const [editOpen, setEditOpen] = useState(false);
+  const [editForm, setEditForm] = useState({ firstName: '', lastName: '', email: '', phone: '' });
+  const [tagInput, setTagInput] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createForm, setCreateForm] = useState({ firstName: '', lastName: '', email: '', phone: '' });
+
+  // Debounced search
+  const [searchTimeout, setSearchTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
+  const handleSearch = (value: string) => {
+    setSearch(value);
+    if (searchTimeout) clearTimeout(searchTimeout);
+    setSearchTimeout(setTimeout(() => {
+      setDebouncedSearch(value);
+      setPage(0);
+    }, 400));
+  };
+
+  const {
+    data: contactsData,
+    isLoading,
+    refetch,
+  } = trpc.ghl.searchContacts.useQuery({
+    query: debouncedSearch || undefined,
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+  });
+
+  const { data: contactDetail, refetch: refetchDetail } = trpc.ghl.getContact.useQuery(
+    { contactId: selectedContact?.id ?? '' },
+    { enabled: !!selectedContact?.id }
+  );
+
+  const updateMutation = trpc.ghl.updateContact.useMutation({
+    onSuccess: () => {
+      toast.success('Contact updated');
+      setEditOpen(false);
+      refetch();
+      refetchDetail();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const createMutation = trpc.ghl.createContact.useMutation({
+    onSuccess: () => {
+      toast.success('Contact created');
+      setCreateOpen(false);
+      setCreateForm({ firstName: '', lastName: '', email: '', phone: '' });
+      refetch();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const addTagMutation = trpc.ghl.addContactTags.useMutation({
+    onSuccess: () => {
+      toast.success('Tag added');
+      setTagInput('');
+      refetchDetail();
+      refetch();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const removeTagMutation = trpc.ghl.removeContactTags.useMutation({
+    onSuccess: () => {
+      toast.success('Tag removed');
+      refetchDetail();
+      refetch();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const contacts = contactsData?.contacts ?? contactsData ?? [];
+  const totalCount = (contactsData as any)?.total ?? (contacts as any[]).length;
+
+  const openEdit = (contact: any) => {
+    setEditForm({
+      firstName: contact.firstName || '',
+      lastName: contact.lastName || '',
+      email: contact.email || '',
+      phone: contact.phone || '',
+    });
+    setEditOpen(true);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">GHL Contacts</h1>
+          <p className="text-muted-foreground text-sm">
+            Browse, search, and manage GoHighLevel contacts
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            <RefreshCw className="h-4 w-4 mr-1" /> Refresh
+          </Button>
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <UserPlus className="h-4 w-4 mr-1" /> Add Contact
+          </Button>
+        </div>
+      </div>
+
+      {/* Search bar */}
+      <div className="relative max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Search contacts by name, email, phone..."
+          className="pl-9"
+          value={search}
+          onChange={(e) => handleSearch(e.target.value)}
+        />
+      </div>
+
+      {/* Contacts table */}
+      <Card>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="p-6 space-y-3">
+              {[1, 2, 3, 4, 5].map((i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : (contacts as any[]).length === 0 ? (
+            <div className="p-12 text-center text-muted-foreground">
+              {debouncedSearch ? 'No contacts found matching your search.' : 'No contacts found. Connect a GHL location first.'}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Phone</TableHead>
+                  <TableHead>Tags</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead className="w-[80px]">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(contacts as any[]).map((contact: any) => (
+                  <TableRow
+                    key={contact.id}
+                    className="cursor-pointer hover:bg-muted/50"
+                    onClick={() => setSelectedContact(contact)}
+                  >
+                    <TableCell className="font-medium">
+                      {contact.firstName || ''} {contact.lastName || ''}
+                      {!contact.firstName && !contact.lastName && (
+                        <span className="text-muted-foreground italic">No name</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {contact.email ? (
+                        <span className="flex items-center gap-1">
+                          <Mail className="h-3 w-3 text-muted-foreground" />
+                          {contact.email}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {contact.phone ? (
+                        <span className="flex items-center gap-1">
+                          <Phone className="h-3 w-3 text-muted-foreground" />
+                          {contact.phone}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1 max-w-[200px]">
+                        {(contact.tags ?? []).slice(0, 3).map((tag: string) => (
+                          <Badge key={tag} variant="secondary" className="text-xs">
+                            {tag}
+                          </Badge>
+                        ))}
+                        {(contact.tags ?? []).length > 3 && (
+                          <Badge variant="outline" className="text-xs">
+                            +{(contact.tags as string[]).length - 3}
+                          </Badge>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {contact.source || '—'}
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedContact(contact);
+                          openEdit(contact);
+                        }}
+                      >
+                        <Edit2 className="h-4 w-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Pagination */}
+      {(contacts as any[]).length > 0 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Showing {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, totalCount)} of {totalCount}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page === 0}
+              onClick={() => setPage((p) => p - 1)}
+            >
+              <ChevronLeft className="h-4 w-4" /> Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={(page + 1) * PAGE_SIZE >= totalCount}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Contact Detail Dialog */}
+      <Dialog open={!!selectedContact && !editOpen} onOpenChange={(open) => !open && setSelectedContact(null)}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {selectedContact?.firstName || ''} {selectedContact?.lastName || 'Contact Details'}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <p className="text-muted-foreground">Email</p>
+                <p>{(contactDetail as any)?.contact?.email || selectedContact?.email || '—'}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Phone</p>
+                <p>{(contactDetail as any)?.contact?.phone || selectedContact?.phone || '—'}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Source</p>
+                <p>{(contactDetail as any)?.contact?.source || selectedContact?.source || '—'}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Date Added</p>
+                <p>{(contactDetail as any)?.contact?.dateAdded ? new Date((contactDetail as any).contact.dateAdded).toLocaleDateString() : '—'}</p>
+              </div>
+            </div>
+
+            {/* Tags */}
+            <div>
+              <p className="text-sm font-medium mb-2 flex items-center gap-1">
+                <Tag className="h-3.5 w-3.5" /> Tags
+              </p>
+              <div className="flex flex-wrap gap-1 mb-2">
+                {(((contactDetail as any)?.contact?.tags ?? selectedContact?.tags) || []).map((tag: string) => (
+                  <Badge key={tag} variant="secondary" className="text-xs pr-1">
+                    {tag}
+                    <button
+                      className="ml-1 hover:text-destructive"
+                      onClick={() =>
+                        selectedContact &&
+                        removeTagMutation.mutate({ contactId: selectedContact.id, tags: [tag] })
+                      }
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+              <div className="flex gap-2">
+                <Input
+                  placeholder="Add tag..."
+                  className="h-8 text-sm"
+                  value={tagInput}
+                  onChange={(e) => setTagInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && tagInput.trim() && selectedContact) {
+                      addTagMutation.mutate({ contactId: selectedContact.id, tags: [tagInput.trim()] });
+                    }
+                  }}
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-8"
+                  disabled={!tagInput.trim()}
+                  onClick={() =>
+                    selectedContact &&
+                    tagInput.trim() &&
+                    addTagMutation.mutate({ contactId: selectedContact.id, tags: [tagInput.trim()] })
+                  }
+                >
+                  Add
+                </Button>
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="outline" onClick={() => setSelectedContact(null)}>
+                Close
+              </Button>
+              <Button onClick={() => openEdit(selectedContact)}>
+                <Edit2 className="h-4 w-4 mr-1" /> Edit
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Contact Dialog */}
+      <Dialog open={editOpen} onOpenChange={(open) => !open && setEditOpen(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Contact</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-sm font-medium">First Name</label>
+                <Input
+                  value={editForm.firstName}
+                  onChange={(e) => setEditForm((f) => ({ ...f, firstName: e.target.value }))}
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Last Name</label>
+                <Input
+                  value={editForm.lastName}
+                  onChange={(e) => setEditForm((f) => ({ ...f, lastName: e.target.value }))}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Email</label>
+              <Input
+                type="email"
+                value={editForm.email}
+                onChange={(e) => setEditForm((f) => ({ ...f, email: e.target.value }))}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Phone</label>
+              <Input
+                value={editForm.phone}
+                onChange={(e) => setEditForm((f) => ({ ...f, phone: e.target.value }))}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditOpen(false)}>Cancel</Button>
+            <Button
+              disabled={updateMutation.isPending}
+              onClick={() =>
+                selectedContact &&
+                updateMutation.mutate({
+                  contactId: selectedContact.id,
+                  ...editForm,
+                })
+              }
+            >
+              {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Create Contact Dialog */}
+      <Dialog open={createOpen} onOpenChange={(open) => !open && setCreateOpen(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Contact</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-sm font-medium">First Name</label>
+                <Input
+                  value={createForm.firstName}
+                  onChange={(e) => setCreateForm((f) => ({ ...f, firstName: e.target.value }))}
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium">Last Name</label>
+                <Input
+                  value={createForm.lastName}
+                  onChange={(e) => setCreateForm((f) => ({ ...f, lastName: e.target.value }))}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Email</label>
+              <Input
+                type="email"
+                value={createForm.email}
+                onChange={(e) => setCreateForm((f) => ({ ...f, email: e.target.value }))}
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Phone</label>
+              <Input
+                value={createForm.phone}
+                onChange={(e) => setCreateForm((f) => ({ ...f, phone: e.target.value }))}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+            <Button
+              disabled={createMutation.isPending}
+              onClick={() => createMutation.mutate(createForm)}
+            >
+              {createMutation.isPending ? 'Creating...' : 'Create Contact'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/src/pages/GHLPipeline.tsx
+++ b/client/src/pages/GHLPipeline.tsx
@@ -1,0 +1,392 @@
+/**
+ * GHL Pipeline Board
+ *
+ * Kanban-style view of opportunities grouped by pipeline stage.
+ * Supports moving opportunities between stages and creating new ones.
+ *
+ * Linear: AI-5214
+ */
+
+import { useState, useMemo } from 'react';
+import { trpc } from '@/lib/trpc';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  DollarSign,
+  Plus,
+  ArrowRight,
+  RefreshCw,
+  Kanban,
+  User,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+export default function GHLPipeline() {
+  const [selectedPipelineId, setSelectedPipelineId] = useState<string>('');
+  const [statusFilter, setStatusFilter] = useState<'open' | 'won' | 'lost' | 'abandoned' | 'all'>('open');
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createForm, setCreateForm] = useState({
+    name: '',
+    contactId: '',
+    stageId: '',
+    monetaryValue: '',
+  });
+  const [moveDialog, setMoveDialog] = useState<{ opp: any; targetStageId: string } | null>(null);
+
+  const { data: pipelines, isLoading: pipelinesLoading } = trpc.ghl.listPipelines.useQuery();
+
+  // Auto-select first pipeline
+  const activePipelineId = selectedPipelineId || (pipelines as any)?.pipelines?.[0]?.id || '';
+  const activePipeline = (pipelines as any)?.pipelines?.find((p: any) => p.id === activePipelineId);
+
+  const {
+    data: oppsData,
+    isLoading: oppsLoading,
+    refetch,
+  } = trpc.ghl.searchOpportunities.useQuery(
+    {
+      pipelineId: activePipelineId,
+      status: statusFilter,
+      limit: 100,
+    },
+    { enabled: !!activePipelineId }
+  );
+
+  const updateMutation = trpc.ghl.updateOpportunity.useMutation({
+    onSuccess: () => {
+      toast.success('Opportunity updated');
+      setMoveDialog(null);
+      refetch();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const createMutation = trpc.ghl.createOpportunity.useMutation({
+    onSuccess: () => {
+      toast.success('Opportunity created');
+      setCreateOpen(false);
+      setCreateForm({ name: '', contactId: '', stageId: '', monetaryValue: '' });
+      refetch();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const opportunities = (oppsData as any)?.opportunities ?? oppsData ?? [];
+  const stages = activePipeline?.stages ?? [];
+
+  // Group opportunities by stage
+  const oppsByStage = useMemo(() => {
+    const grouped: Record<string, any[]> = {};
+    for (const stage of stages) {
+      grouped[stage.id] = [];
+    }
+    for (const opp of opportunities as any[]) {
+      const stageId = opp.pipelineStageId || opp.stageId;
+      if (grouped[stageId]) {
+        grouped[stageId].push(opp);
+      } else {
+        // Unmatched stage — put in first column
+        const firstStageId = stages[0]?.id;
+        if (firstStageId && grouped[firstStageId]) {
+          grouped[firstStageId].push(opp);
+        }
+      }
+    }
+    return grouped;
+  }, [opportunities, stages]);
+
+  const formatCurrency = (val: number | string | null | undefined) => {
+    if (val == null) return null;
+    const num = typeof val === 'string' ? parseFloat(val) : val;
+    if (isNaN(num)) return null;
+    return `$${num.toLocaleString()}`;
+  };
+
+  if (pipelinesLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-10 w-64" />
+        <div className="flex gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-96 w-72" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+            <Kanban className="h-6 w-6" /> Pipeline Board
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Manage opportunities across pipeline stages
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            <RefreshCw className="h-4 w-4 mr-1" /> Refresh
+          </Button>
+          <Button
+            size="sm"
+            disabled={!activePipelineId}
+            onClick={() => {
+              setCreateForm((f) => ({ ...f, stageId: stages[0]?.id || '' }));
+              setCreateOpen(true);
+            }}
+          >
+            <Plus className="h-4 w-4 mr-1" /> New Opportunity
+          </Button>
+        </div>
+      </div>
+
+      {/* Pipeline & status selector */}
+      <div className="flex gap-3 items-center">
+        <Select value={activePipelineId} onValueChange={setSelectedPipelineId}>
+          <SelectTrigger className="w-64">
+            <SelectValue placeholder="Select pipeline" />
+          </SelectTrigger>
+          <SelectContent>
+            {((pipelines as any)?.pipelines ?? []).map((p: any) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as any)}>
+          <SelectTrigger className="w-40">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="open">Open</SelectItem>
+            <SelectItem value="won">Won</SelectItem>
+            <SelectItem value="lost">Lost</SelectItem>
+            <SelectItem value="abandoned">Abandoned</SelectItem>
+            <SelectItem value="all">All</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Kanban board */}
+      {!activePipelineId ? (
+        <Card>
+          <CardContent className="p-12 text-center text-muted-foreground">
+            No pipelines found. Connect a GHL location with active pipelines.
+          </CardContent>
+        </Card>
+      ) : oppsLoading ? (
+        <div className="flex gap-4 overflow-x-auto pb-4">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-96 w-72 shrink-0" />
+          ))}
+        </div>
+      ) : (
+        <div className="flex gap-4 overflow-x-auto pb-4">
+          {stages.map((stage: any) => {
+            const stageOpps = oppsByStage[stage.id] || [];
+            const totalValue = stageOpps.reduce((sum: number, o: any) => {
+              const val = parseFloat(o.monetaryValue ?? '0');
+              return sum + (isNaN(val) ? 0 : val);
+            }, 0);
+
+            return (
+              <div key={stage.id} className="w-72 shrink-0">
+                <div className="mb-3 px-1">
+                  <div className="flex items-center justify-between">
+                    <h3 className="font-semibold text-sm">{stage.name}</h3>
+                    <Badge variant="secondary" className="text-xs">
+                      {stageOpps.length}
+                    </Badge>
+                  </div>
+                  {totalValue > 0 && (
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {formatCurrency(totalValue)} total
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2 min-h-[200px] bg-muted/30 rounded-lg p-2">
+                  {stageOpps.length === 0 ? (
+                    <p className="text-xs text-muted-foreground text-center py-8">
+                      No opportunities
+                    </p>
+                  ) : (
+                    stageOpps.map((opp: any) => (
+                      <Card key={opp.id} className="shadow-sm">
+                        <CardContent className="p-3 space-y-2">
+                          <p className="font-medium text-sm leading-tight">{opp.name}</p>
+                          {opp.monetaryValue && (
+                            <p className="text-sm font-semibold text-emerald-600 flex items-center gap-1">
+                              <DollarSign className="h-3 w-3" />
+                              {formatCurrency(opp.monetaryValue)}
+                            </p>
+                          )}
+                          {opp.contact && (
+                            <p className="text-xs text-muted-foreground flex items-center gap-1">
+                              <User className="h-3 w-3" />
+                              {opp.contact.firstName} {opp.contact.lastName}
+                            </p>
+                          )}
+                          <div className="flex items-center justify-between pt-1">
+                            <Badge
+                              variant={
+                                opp.status === 'won' ? 'default' :
+                                opp.status === 'lost' ? 'destructive' :
+                                'secondary'
+                              }
+                              className="text-xs"
+                            >
+                              {opp.status}
+                            </Badge>
+                            {/* Move to next stage button */}
+                            {stages.indexOf(stage) < stages.length - 1 && (
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-6 w-6"
+                                title="Move to next stage"
+                                onClick={() =>
+                                  setMoveDialog({
+                                    opp,
+                                    targetStageId: stages[stages.indexOf(stage) + 1].id,
+                                  })
+                                }
+                              >
+                                <ArrowRight className="h-3 w-3" />
+                              </Button>
+                            )}
+                          </div>
+                        </CardContent>
+                      </Card>
+                    ))
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Move Confirmation Dialog */}
+      <Dialog open={!!moveDialog} onOpenChange={(open) => !open && setMoveDialog(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Move Opportunity</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Move <strong>{moveDialog?.opp?.name}</strong> to{' '}
+            <strong>{stages.find((s: any) => s.id === moveDialog?.targetStageId)?.name}</strong>?
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setMoveDialog(null)}>Cancel</Button>
+            <Button
+              disabled={updateMutation.isPending}
+              onClick={() =>
+                moveDialog &&
+                updateMutation.mutate({
+                  opportunityId: moveDialog.opp.id,
+                  stageId: moveDialog.targetStageId,
+                })
+              }
+            >
+              {updateMutation.isPending ? 'Moving...' : 'Move'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Create Opportunity Dialog */}
+      <Dialog open={createOpen} onOpenChange={(open) => !open && setCreateOpen(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New Opportunity</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div>
+              <label className="text-sm font-medium">Name</label>
+              <Input
+                value={createForm.name}
+                onChange={(e) => setCreateForm((f) => ({ ...f, name: e.target.value }))}
+                placeholder="Deal name"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Contact ID</label>
+              <Input
+                value={createForm.contactId}
+                onChange={(e) => setCreateForm((f) => ({ ...f, contactId: e.target.value }))}
+                placeholder="GHL Contact ID"
+              />
+            </div>
+            <div>
+              <label className="text-sm font-medium">Stage</label>
+              <Select
+                value={createForm.stageId}
+                onValueChange={(v) => setCreateForm((f) => ({ ...f, stageId: v }))}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select stage" />
+                </SelectTrigger>
+                <SelectContent>
+                  {stages.map((s: any) => (
+                    <SelectItem key={s.id} value={s.id}>
+                      {s.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="text-sm font-medium">Value ($)</label>
+              <Input
+                type="number"
+                value={createForm.monetaryValue}
+                onChange={(e) => setCreateForm((f) => ({ ...f, monetaryValue: e.target.value }))}
+                placeholder="0"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+            <Button
+              disabled={createMutation.isPending || !createForm.name || !createForm.contactId || !createForm.stageId}
+              onClick={() =>
+                createMutation.mutate({
+                  pipelineId: activePipelineId,
+                  stageId: createForm.stageId,
+                  contactId: createForm.contactId,
+                  name: createForm.name,
+                  monetaryValue: createForm.monetaryValue ? parseFloat(createForm.monetaryValue) : undefined,
+                })
+              }
+            >
+              {createMutation.isPending ? 'Creating...' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/client/src/pages/GHLWebhookLog.tsx
+++ b/client/src/pages/GHLWebhookLog.tsx
@@ -1,0 +1,342 @@
+/**
+ * GHL Webhook Event Log
+ *
+ * View recent inbound webhook events and their processing status.
+ * Includes dead letter queue management for failed events.
+ * Uses direct fetch to the webhook REST endpoints since these aren't on tRPC.
+ *
+ * Linear: AI-5214
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  RefreshCw,
+  Webhook,
+  CheckCircle2,
+  XCircle,
+  AlertTriangle,
+  RotateCcw,
+  Eye,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+interface WebhookHealth {
+  status: string;
+  configured: boolean;
+  supportedEvents: string[];
+  deadLetterCount: number;
+  workflowQueueAvailable: boolean;
+  timestamp: string;
+}
+
+interface DLQEntry {
+  id: number;
+  eventId: string | null;
+  eventType: string;
+  locationId: string | null;
+  payload: any;
+  error: string;
+  retryCount: number;
+  maxRetries: number;
+  lastRetriedAt: string | null;
+  resolved: boolean;
+  createdAt: string;
+}
+
+export default function GHLWebhookLog() {
+  const [health, setHealth] = useState<WebhookHealth | null>(null);
+  const [dlqItems, setDlqItems] = useState<DLQEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dlqLoading, setDlqLoading] = useState(true);
+  const [selectedPayload, setSelectedPayload] = useState<any>(null);
+  const [retryingId, setRetryingId] = useState<number | null>(null);
+
+  const fetchHealth = useCallback(async () => {
+    try {
+      const res = await fetch('/api/ghl/webhooks/health');
+      if (res.ok) {
+        setHealth(await res.json());
+      }
+    } catch {
+      // Health endpoint not available
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchDLQ = useCallback(async () => {
+    setDlqLoading(true);
+    try {
+      const res = await fetch('/api/ghl/webhooks/dlq');
+      if (res.ok) {
+        const data = await res.json();
+        setDlqItems(data.items || []);
+      }
+    } catch {
+      // DLQ endpoint not available
+    } finally {
+      setDlqLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHealth();
+    fetchDLQ();
+  }, [fetchHealth, fetchDLQ]);
+
+  const retryDLQEntry = async (id: number) => {
+    setRetryingId(id);
+    try {
+      const res = await fetch(`/api/ghl/webhooks/dlq/${id}/retry`, { method: 'POST' });
+      if (res.ok) {
+        toast.success('Event reprocessed successfully');
+        fetchDLQ();
+        fetchHealth();
+      } else {
+        const data = await res.json();
+        toast.error(data.error || 'Retry failed');
+      }
+    } catch {
+      toast.error('Failed to retry event');
+    } finally {
+      setRetryingId(null);
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleString();
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+            <Webhook className="h-6 w-6" /> Webhook Event Log
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Monitor GHL webhook events and failed event queue
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            fetchHealth();
+            fetchDLQ();
+          }}
+        >
+          <RefreshCw className="h-4 w-4 mr-1" /> Refresh
+        </Button>
+      </div>
+
+      {/* Health Overview */}
+      {loading ? (
+        <div className="grid grid-cols-4 gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Skeleton key={i} className="h-24" />
+          ))}
+        </div>
+      ) : health ? (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-muted-foreground">Status</p>
+                <Badge variant={health.status === 'ok' ? 'default' : 'destructive'}>
+                  {health.status}
+                </Badge>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-muted-foreground">Configured</p>
+                {health.configured ? (
+                  <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                ) : (
+                  <XCircle className="h-5 w-5 text-red-500" />
+                )}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-muted-foreground">Failed Events</p>
+                <span className={`text-lg font-bold ${health.deadLetterCount > 0 ? 'text-red-500' : 'text-emerald-500'}`}>
+                  {health.deadLetterCount}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="pt-6">
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-muted-foreground">Queue Available</p>
+                {health.workflowQueueAvailable ? (
+                  <CheckCircle2 className="h-5 w-5 text-emerald-500" />
+                ) : (
+                  <XCircle className="h-5 w-5 text-amber-500" />
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      ) : (
+        <Card>
+          <CardContent className="p-8 text-center text-muted-foreground">
+            Webhook endpoint not reachable. Ensure the server is running.
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Supported Events */}
+      {health?.supportedEvents && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-medium">Supported Event Types</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-2">
+              {health.supportedEvents.map((evt) => (
+                <Badge key={evt} variant="outline" className="text-xs">
+                  {evt}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Dead Letter Queue */}
+      <Tabs defaultValue="dlq">
+        <TabsList>
+          <TabsTrigger value="dlq" className="flex items-center gap-1">
+            <AlertTriangle className="h-3.5 w-3.5" />
+            Dead Letter Queue
+            {dlqItems.length > 0 && (
+              <Badge variant="destructive" className="ml-1 text-xs h-5 min-w-5 px-1">
+                {dlqItems.length}
+              </Badge>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="dlq">
+          <Card>
+            <CardContent className="p-0">
+              {dlqLoading ? (
+                <div className="p-6 space-y-3">
+                  {[1, 2, 3].map((i) => (
+                    <Skeleton key={i} className="h-12 w-full" />
+                  ))}
+                </div>
+              ) : dlqItems.length === 0 ? (
+                <div className="p-12 text-center text-muted-foreground">
+                  <CheckCircle2 className="h-8 w-8 mx-auto mb-2 text-emerald-500" />
+                  No failed events. All webhooks processed successfully.
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Event Type</TableHead>
+                      <TableHead>Error</TableHead>
+                      <TableHead>Retries</TableHead>
+                      <TableHead>Created</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {dlqItems.map((entry) => (
+                      <TableRow key={entry.id}>
+                        <TableCell>
+                          <Badge variant="outline" className="text-xs">
+                            {entry.eventType}
+                          </Badge>
+                          {entry.locationId && (
+                            <p className="text-xs text-muted-foreground mt-1">
+                              Location: {entry.locationId.slice(0, 12)}...
+                            </p>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <p className="text-sm text-destructive max-w-[300px] truncate" title={entry.error}>
+                            {entry.error}
+                          </p>
+                        </TableCell>
+                        <TableCell>
+                          <span className="text-sm">
+                            {entry.retryCount} / {entry.maxRetries}
+                          </span>
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
+                          {formatDate(entry.createdAt)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex gap-1 justify-end">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              title="View payload"
+                              onClick={() => setSelectedPayload(entry.payload)}
+                            >
+                              <Eye className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              disabled={entry.retryCount >= entry.maxRetries || retryingId === entry.id}
+                              onClick={() => retryDLQEntry(entry.id)}
+                            >
+                              <RotateCcw className="h-3.5 w-3.5 mr-1" />
+                              {retryingId === entry.id ? 'Retrying...' : 'Retry'}
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      {/* Payload Viewer Dialog */}
+      <Dialog open={!!selectedPayload} onOpenChange={(open) => !open && setSelectedPayload(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh]">
+          <DialogHeader>
+            <DialogTitle>Event Payload</DialogTitle>
+          </DialogHeader>
+          <pre className="bg-muted rounded-lg p-4 text-xs overflow-auto max-h-[60vh]">
+            {JSON.stringify(selectedPayload, null, 2)}
+          </pre>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/drizzle/0008_ghl_webhook_processing.sql
+++ b/drizzle/0008_ghl_webhook_processing.sql
@@ -1,0 +1,82 @@
+-- GHL Webhook Processing: contacts, opportunities, event dedup, dead letter queue
+-- Linear: AI-5147
+
+-- Synced contacts from GHL webhooks
+CREATE TABLE IF NOT EXISTS "ghl_contacts" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "userId" integer NOT NULL REFERENCES "users"("id"),
+  "ghlContactId" varchar(128) NOT NULL,
+  "locationId" varchar(128) NOT NULL,
+  "firstName" text,
+  "lastName" text,
+  "email" varchar(320),
+  "phone" varchar(30),
+  "tags" jsonb,
+  "source" varchar(128),
+  "customFields" jsonb,
+  "lastWebhookAt" timestamp NOT NULL,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ghl_contacts_ghl_id_idx" ON "ghl_contacts" ("ghlContactId", "locationId");
+CREATE INDEX IF NOT EXISTS "ghl_contacts_user_idx" ON "ghl_contacts" ("userId");
+CREATE INDEX IF NOT EXISTS "ghl_contacts_location_idx" ON "ghl_contacts" ("locationId");
+CREATE INDEX IF NOT EXISTS "ghl_contacts_email_idx" ON "ghl_contacts" ("email");
+
+-- Synced opportunities from GHL webhooks
+CREATE TABLE IF NOT EXISTS "ghl_opportunities" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "userId" integer NOT NULL REFERENCES "users"("id"),
+  "ghlOpportunityId" varchar(128) NOT NULL,
+  "locationId" varchar(128) NOT NULL,
+  "name" text,
+  "pipelineId" varchar(128),
+  "pipelineStageId" varchar(128),
+  "status" varchar(64),
+  "monetaryValue" numeric(12, 2),
+  "ghlContactId" varchar(128),
+  "lastWebhookAt" timestamp NOT NULL,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ghl_opportunities_ghl_id_idx" ON "ghl_opportunities" ("ghlOpportunityId", "locationId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_user_idx" ON "ghl_opportunities" ("userId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_location_idx" ON "ghl_opportunities" ("locationId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_pipeline_idx" ON "ghl_opportunities" ("pipelineId");
+CREATE INDEX IF NOT EXISTS "ghl_opportunities_status_idx" ON "ghl_opportunities" ("status");
+
+-- Webhook event log for deduplication
+CREATE TABLE IF NOT EXISTS "ghl_webhook_events" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "eventId" varchar(256) NOT NULL UNIQUE,
+  "eventType" varchar(128) NOT NULL,
+  "locationId" varchar(128),
+  "processedAt" timestamp DEFAULT now() NOT NULL,
+  "success" boolean NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ghl_webhook_events_event_id_idx" ON "ghl_webhook_events" ("eventId");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_events_type_idx" ON "ghl_webhook_events" ("eventType");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_events_processed_at_idx" ON "ghl_webhook_events" ("processedAt");
+
+-- Dead letter queue for failed webhook events
+CREATE TABLE IF NOT EXISTS "ghl_webhook_dead_letters" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "eventId" varchar(256),
+  "eventType" varchar(128) NOT NULL,
+  "locationId" varchar(128),
+  "payload" jsonb NOT NULL,
+  "error" text NOT NULL,
+  "retryCount" integer DEFAULT 0 NOT NULL,
+  "maxRetries" integer DEFAULT 3 NOT NULL,
+  "lastRetriedAt" timestamp,
+  "resolved" boolean DEFAULT false NOT NULL,
+  "createdAt" timestamp DEFAULT now() NOT NULL,
+  "updatedAt" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "ghl_webhook_dlq_resolved_idx" ON "ghl_webhook_dead_letters" ("resolved");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_dlq_type_idx" ON "ghl_webhook_dead_letters" ("eventType");
+CREATE INDEX IF NOT EXISTS "ghl_webhook_dlq_created_at_idx" ON "ghl_webhook_dead_letters" ("createdAt");

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,18297 @@
+{
+  "id": "662ceac9-431a-4bc3-b54a-968ce8a426b0",
+  "prevId": "457460a5-557a-46c7-a019-d013ad84c2f6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ad_analyses": {
+      "name": "ad_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adId": {
+          "name": "adId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshotUrl": {
+          "name": "screenshotUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ctr": {
+          "name": "ctr",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spend": {
+          "name": "spend",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversions": {
+          "name": "conversions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roas": {
+          "name": "roas",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insights": {
+          "name": "insights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rawAnalysis": {
+          "name": "rawAnalysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_analyses_userId_users_id_fk": {
+          "name": "ad_analyses_userId_users_id_fk",
+          "tableFrom": "ad_analyses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_automation_history": {
+      "name": "ad_automation_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jobId": {
+          "name": "jobId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actionType": {
+          "name": "actionType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adId": {
+          "name": "adId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adSetId": {
+          "name": "adSetId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "campaignId": {
+          "name": "campaignId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugUrl": {
+          "name": "debugUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordingUrl": {
+          "name": "recordingUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_automation_history_userId_users_id_fk": {
+          "name": "ad_automation_history_userId_users_id_fk",
+          "tableFrom": "ad_automation_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_copy_variations": {
+      "name": "ad_copy_variations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalAdId": {
+          "name": "originalAdId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primaryText": {
+          "name": "primaryText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "callToAction": {
+          "name": "callToAction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variationNumber": {
+          "name": "variationNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetAudience": {
+          "name": "targetAudience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tone": {
+          "name": "tone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "testAdId": {
+          "name": "testAdId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performanceMetrics": {
+          "name": "performanceMetrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_copy_variations_userId_users_id_fk": {
+          "name": "ad_copy_variations_userId_users_id_fk",
+          "tableFrom": "ad_copy_variations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_recommendations": {
+      "name": "ad_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysisId": {
+          "name": "analysisId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adId": {
+          "name": "adId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expectedImpact": {
+          "name": "expectedImpact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actionable": {
+          "name": "actionable",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'true'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "appliedAt": {
+          "name": "appliedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appliedBy": {
+          "name": "appliedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resultMetrics": {
+          "name": "resultMetrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ad_recommendations_userId_users_id_fk": {
+          "name": "ad_recommendations_userId_users_id_fk",
+          "tableFrom": "ad_recommendations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ad_recommendations_analysisId_ad_analyses_id_fk": {
+          "name": "ad_recommendations_analysisId_ad_analyses_id_fk",
+          "tableFrom": "ad_recommendations",
+          "tableTo": "ad_analyses",
+          "columnsFrom": [
+            "analysisId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ad_recommendations_appliedBy_users_id_fk": {
+          "name": "ad_recommendations_appliedBy_users_id_fk",
+          "tableFrom": "ad_recommendations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "appliedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agency_tasks": {
+      "name": "agency_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskUuid": {
+          "name": "taskUuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceWebhookId": {
+          "name": "sourceWebhookId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceMessageId": {
+          "name": "sourceMessageId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalMessage": {
+          "name": "originalMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "taskType": {
+          "name": "taskType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "statusReason": {
+          "name": "statusReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignedToBot": {
+          "name": "assignedToBot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "requiresHumanReview": {
+          "name": "requiresHumanReview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "humanReviewedBy": {
+          "name": "humanReviewedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "humanReviewedAt": {
+          "name": "humanReviewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionType": {
+          "name": "executionType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'automatic'"
+        },
+        "executionConfig": {
+          "name": "executionConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledFor": {
+          "name": "scheduledFor",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependsOn": {
+          "name": "dependsOn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedBy": {
+          "name": "blockedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resultSummary": {
+          "name": "resultSummary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorCount": {
+          "name": "errorCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "maxRetries": {
+          "name": "maxRetries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "notifyOnComplete": {
+          "name": "notifyOnComplete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notifyOnFailure": {
+          "name": "notifyOnFailure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notificationsSent": {
+          "name": "notificationsSent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queuedAt": {
+          "name": "queuedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agency_tasks_user_id_idx": {
+          "name": "agency_tasks_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agency_tasks_uuid_idx": {
+          "name": "agency_tasks_uuid_idx",
+          "columns": [
+            {
+              "expression": "taskUuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agency_tasks_status_idx": {
+          "name": "agency_tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agency_tasks_priority_idx": {
+          "name": "agency_tasks_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agency_tasks_task_type_idx": {
+          "name": "agency_tasks_task_type_idx",
+          "columns": [
+            {
+              "expression": "taskType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agency_tasks_scheduled_for_idx": {
+          "name": "agency_tasks_scheduled_for_idx",
+          "columns": [
+            {
+              "expression": "scheduledFor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agency_tasks_conversation_id_idx": {
+          "name": "agency_tasks_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agency_tasks_user_status_idx": {
+          "name": "agency_tasks_user_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agency_tasks_pending_bot_idx": {
+          "name": "agency_tasks_pending_bot_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignedToBot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduledFor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agency_tasks_userId_users_id_fk": {
+          "name": "agency_tasks_userId_users_id_fk",
+          "tableFrom": "agency_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agency_tasks_sourceWebhookId_user_webhooks_id_fk": {
+          "name": "agency_tasks_sourceWebhookId_user_webhooks_id_fk",
+          "tableFrom": "agency_tasks",
+          "tableTo": "user_webhooks",
+          "columnsFrom": [
+            "sourceWebhookId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agency_tasks_sourceMessageId_inbound_messages_id_fk": {
+          "name": "agency_tasks_sourceMessageId_inbound_messages_id_fk",
+          "tableFrom": "agency_tasks",
+          "tableTo": "inbound_messages",
+          "columnsFrom": [
+            "sourceMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agency_tasks_conversationId_bot_conversations_id_fk": {
+          "name": "agency_tasks_conversationId_bot_conversations_id_fk",
+          "tableFrom": "agency_tasks",
+          "tableTo": "bot_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agency_tasks_humanReviewedBy_users_id_fk": {
+          "name": "agency_tasks_humanReviewedBy_users_id_fk",
+          "tableFrom": "agency_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "humanReviewedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agency_tasks_blockedBy_agency_tasks_id_fk": {
+          "name": "agency_tasks_blockedBy_agency_tasks_id_fk",
+          "tableFrom": "agency_tasks",
+          "tableTo": "agency_tasks",
+          "columnsFrom": [
+            "blockedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agency_tasks_taskUuid_unique": {
+          "name": "agency_tasks_taskUuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskUuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_add_ons": {
+      "name": "agent_add_ons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additionalAgents": {
+          "name": "additionalAgents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthlyPriceCents": {
+          "name": "monthlyPriceCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minTierId": {
+          "name": "minTierId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxPerUser": {
+          "name": "maxPerUser",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_add_ons_minTierId_subscription_tiers_id_fk": {
+          "name": "agent_add_ons_minTierId_subscription_tiers_id_fk",
+          "tableFrom": "agent_add_ons",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "minTierId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_add_ons_slug_unique": {
+          "name": "agent_add_ons_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_call_campaigns": {
+      "name": "ai_call_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "callsMade": {
+          "name": "callsMade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "callsSuccessful": {
+          "name": "callsSuccessful",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "callsFailed": {
+          "name": "callsFailed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "callsAnswered": {
+          "name": "callsAnswered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalDuration": {
+          "name": "totalDuration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "costInCredits": {
+          "name": "costInCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_call_campaigns_userId_users_id_fk": {
+          "name": "ai_call_campaigns_userId_users_id_fk",
+          "tableFrom": "ai_call_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_call_campaigns_listId_lead_lists_id_fk": {
+          "name": "ai_call_campaigns_listId_lead_lists_id_fk",
+          "tableFrom": "ai_call_campaigns",
+          "tableTo": "lead_lists",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_calls": {
+      "name": "ai_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaignId": {
+          "name": "campaignId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leadId": {
+          "name": "leadId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phoneNumber": {
+          "name": "phoneNumber",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vapiCallId": {
+          "name": "vapiCallId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordingUrl": {
+          "name": "recordingUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creditsUsed": {
+          "name": "creditsUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calledAt": {
+          "name": "calledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "answeredAt": {
+          "name": "answeredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_calls_campaignId_ai_call_campaigns_id_fk": {
+          "name": "ai_calls_campaignId_ai_call_campaigns_id_fk",
+          "tableFrom": "ai_calls",
+          "tableTo": "ai_call_campaigns",
+          "columnsFrom": [
+            "campaignId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_calls_userId_users_id_fk": {
+          "name": "ai_calls_userId_users_id_fk",
+          "tableFrom": "ai_calls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ai_calls_leadId_leads_id_fk": {
+          "name": "ai_calls_leadId_leads_id_fk",
+          "tableFrom": "ai_calls",
+          "tableTo": "leads",
+          "columnsFrom": [
+            "leadId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_delivery_queue": {
+      "name": "alert_delivery_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "alertHistoryId": {
+          "name": "alertHistoryId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "maxAttempts": {
+          "name": "maxAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "scheduledFor": {
+          "name": "scheduledFor",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_delivery_queue_alertHistoryId_alert_history_id_fk": {
+          "name": "alert_delivery_queue_alertHistoryId_alert_history_id_fk",
+          "tableFrom": "alert_delivery_queue",
+          "tableTo": "alert_history",
+          "columnsFrom": [
+            "alertHistoryId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_history": {
+      "name": "alert_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ruleId": {
+          "name": "ruleId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alertType": {
+          "name": "alertType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channels": {
+          "name": "channels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveryStatus": {
+          "name": "deliveryStatus",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "triggeredAt": {
+          "name": "triggeredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledgedAt": {
+          "name": "acknowledgedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledgedBy": {
+          "name": "acknowledgedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_history_ruleId_alert_rules_id_fk": {
+          "name": "alert_history_ruleId_alert_rules_id_fk",
+          "tableFrom": "alert_history",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "ruleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alert_history_userId_users_id_fk": {
+          "name": "alert_history_userId_users_id_fk",
+          "tableFrom": "alert_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_history_acknowledgedBy_users_id_fk": {
+          "name": "alert_history_acknowledgedBy_users_id_fk",
+          "tableFrom": "alert_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "acknowledgedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alert_rules": {
+      "name": "alert_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ruleType": {
+          "name": "ruleType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetType": {
+          "name": "targetType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all_tasks'"
+        },
+        "targetTaskIds": {
+          "name": "targetTaskIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetTags": {
+          "name": "targetTags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationChannels": {
+          "name": "notificationChannels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cooldownMinutes": {
+          "name": "cooldownMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "aggregationEnabled": {
+          "name": "aggregationEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "maxAlertsPerHour": {
+          "name": "maxAlertsPerHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isPaused": {
+          "name": "isPaused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastAlertSentAt": {
+          "name": "lastAlertSentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alertsThisHour": {
+          "name": "alertsThisHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hourlyResetAt": {
+          "name": "hourlyResetAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastModifiedBy": {
+          "name": "lastModifiedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_rules_userId_users_id_fk": {
+          "name": "alert_rules_userId_users_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_rules_createdBy_users_id_fk": {
+          "name": "alert_rules_createdBy_users_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "alert_rules_lastModifiedBy_users_id_fk": {
+          "name": "alert_rules_lastModifiedBy_users_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "lastModifiedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "targetRoles": {
+          "name": "targetRoles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetUsers": {
+          "name": "targetUsers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startsAt": {
+          "name": "startsAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endsAt": {
+          "name": "endsAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDismissible": {
+          "name": "isDismissible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "linkUrl": {
+          "name": "linkUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkText": {
+          "name": "linkText",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcements_createdBy_users_id_fk": {
+          "name": "announcements_createdBy_users_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyPrefix": {
+          "name": "keyPrefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rateLimitPerMinute": {
+          "name": "rateLimitPerMinute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "rateLimitPerHour": {
+          "name": "rateLimitPerHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "rateLimitPerDay": {
+          "name": "rateLimitPerDay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalRequests": {
+          "name": "totalRequests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_userId_users_id_fk": {
+          "name": "api_keys_userId_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_keyHash_unique": {
+          "name": "api_keys_keyHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "keyHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_request_logs": {
+      "name": "api_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "apiKeyId": {
+          "name": "apiKeyId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "statusCode": {
+          "name": "statusCode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referer": {
+          "name": "referer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestBody": {
+          "name": "requestBody",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_request_logs_apiKeyId_api_keys_id_fk": {
+          "name": "api_request_logs_apiKeyId_api_keys_id_fk",
+          "tableFrom": "api_request_logs",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "apiKeyId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "api_request_logs_userId_users_id_fk": {
+          "name": "api_request_logs_userId_users_id_fk",
+          "tableFrom": "api_request_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_token_usage": {
+      "name": "api_token_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputTokens": {
+          "name": "inputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outputTokens": {
+          "name": "outputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cacheCreationTokens": {
+          "name": "cacheCreationTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cacheReadTokens": {
+          "name": "cacheReadTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputCost": {
+          "name": "inputCost",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outputCost": {
+          "name": "outputCost",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cacheCost": {
+          "name": "cacheCost",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "totalCost": {
+          "name": "totalCost",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promptType": {
+          "name": "promptType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolsUsed": {
+          "name": "toolsUsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopReason": {
+          "name": "stopReason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_token_usage_user_id_idx": {
+          "name": "api_token_usage_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_token_usage_execution_id_idx": {
+          "name": "api_token_usage_execution_id_idx",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_token_usage_model_idx": {
+          "name": "api_token_usage_model_idx",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_token_usage_created_at_idx": {
+          "name": "api_token_usage_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_token_usage_user_created_idx": {
+          "name": "api_token_usage_user_created_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_token_usage_userId_users_id_fk": {
+          "name": "api_token_usage_userId_users_id_fk",
+          "tableFrom": "api_token_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_token_usage_executionId_task_executions_id_fk": {
+          "name": "api_token_usage_executionId_task_executions_id_fk",
+          "tableFrom": "api_token_usage",
+          "tableTo": "task_executions",
+          "columnsFrom": [
+            "executionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityType": {
+          "name": "entityType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entityId": {
+          "name": "entityId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oldValues": {
+          "name": "oldValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValues": {
+          "name": "newValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_userId_users_id_fk": {
+          "name": "audit_logs_userId_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_templates": {
+      "name": "automation_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'General'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automation_workflows": {
+      "name": "automation_workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'custom'"
+        },
+        "isTemplate": {
+          "name": "isTemplate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "executionCount": {
+          "name": "executionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastExecutedAt": {
+          "name": "lastExecutedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "automation_workflows_userId_users_id_fk": {
+          "name": "automation_workflows_userId_users_id_fk",
+          "tableFrom": "automation_workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.backlinks": {
+      "name": "backlinks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUrl": {
+          "name": "targetUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceUrl": {
+          "name": "sourceUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceDomain": {
+          "name": "sourceDomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchorText": {
+          "name": "anchorText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDoFollow": {
+          "name": "isDoFollow",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "domainRating": {
+          "name": "domainRating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "domainAuthority": {
+          "name": "domainAuthority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pageAuthority": {
+          "name": "pageAuthority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "isToxic": {
+          "name": "isToxic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "firstSeen": {
+          "name": "firstSeen",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSeen": {
+          "name": "lastSeen",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastChecked": {
+          "name": "lastChecked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "backlinks_userId_users_id_fk": {
+          "name": "backlinks_userId_users_id_fk",
+          "tableFrom": "backlinks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_conversations": {
+      "name": "bot_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookId": {
+          "name": "webhookId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationUuid": {
+          "name": "conversationUuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "participantIdentifier": {
+          "name": "participantIdentifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "topic": {
+          "name": "topic",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contextSummary": {
+          "name": "contextSummary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contextMemory": {
+          "name": "contextMemory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiPersonality": {
+          "name": "aiPersonality",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'professional'"
+        },
+        "autoCreateTasks": {
+          "name": "autoCreateTasks",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "requireConfirmation": {
+          "name": "requireConfirmation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "messageCount": {
+          "name": "messageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tasksCreated": {
+          "name": "tasksCreated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bot_conversations_user_id_idx": {
+          "name": "bot_conversations_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_conversations_webhook_id_idx": {
+          "name": "bot_conversations_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "webhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_conversations_uuid_idx": {
+          "name": "bot_conversations_uuid_idx",
+          "columns": [
+            {
+              "expression": "conversationUuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_conversations_participant_idx": {
+          "name": "bot_conversations_participant_idx",
+          "columns": [
+            {
+              "expression": "participantIdentifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_conversations_status_idx": {
+          "name": "bot_conversations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bot_conversations_user_participant_idx": {
+          "name": "bot_conversations_user_participant_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "participantIdentifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bot_conversations_userId_users_id_fk": {
+          "name": "bot_conversations_userId_users_id_fk",
+          "tableFrom": "bot_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bot_conversations_webhookId_user_webhooks_id_fk": {
+          "name": "bot_conversations_webhookId_user_webhooks_id_fk",
+          "tableFrom": "bot_conversations",
+          "tableTo": "user_webhooks",
+          "columnsFrom": [
+            "webhookId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bot_conversations_conversationUuid_unique": {
+          "name": "bot_conversations_conversationUuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversationUuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_sessions": {
+      "name": "browser_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugUrl": {
+          "name": "debugUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordingUrl": {
+          "name": "recordingUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "browser_sessions_userId_users_id_fk": {
+          "name": "browser_sessions_userId_users_id_fk",
+          "tableFrom": "browser_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "browser_sessions_sessionId_unique": {
+          "name": "browser_sessions_sessionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sessionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browserbase_costs": {
+      "name": "browserbase_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectId": {
+          "name": "projectId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durationMinutes": {
+          "name": "durationMinutes",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costPerMinute": {
+          "name": "costPerMinute",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.01'"
+        },
+        "totalCost": {
+          "name": "totalCost",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "debugUrl": {
+          "name": "debugUrl",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordingUrl": {
+          "name": "recordingUrl",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasRecording": {
+          "name": "hasRecording",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "recordingCost": {
+          "name": "recordingCost",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "screenshotCount": {
+          "name": "screenshotCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "screenshotCost": {
+          "name": "screenshotCost",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "browserbase_costs_user_id_idx": {
+          "name": "browserbase_costs_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "browserbase_costs_execution_id_idx": {
+          "name": "browserbase_costs_execution_id_idx",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "browserbase_costs_session_id_idx": {
+          "name": "browserbase_costs_session_id_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "browserbase_costs_status_idx": {
+          "name": "browserbase_costs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "browserbase_costs_created_at_idx": {
+          "name": "browserbase_costs_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "browserbase_costs_user_created_idx": {
+          "name": "browserbase_costs_user_created_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "browserbase_costs_userId_users_id_fk": {
+          "name": "browserbase_costs_userId_users_id_fk",
+          "tableFrom": "browserbase_costs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "browserbase_costs_executionId_task_executions_id_fk": {
+          "name": "browserbase_costs_executionId_task_executions_id_fk",
+          "tableFrom": "browserbase_costs",
+          "tableTo": "task_executions",
+          "columnsFrom": [
+            "executionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "browserbase_costs_sessionId_unique": {
+          "name": "browserbase_costs_sessionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sessionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_profiles": {
+      "name": "client_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subaccountName": {
+          "name": "subaccountName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subaccountId": {
+          "name": "subaccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brandVoice": {
+          "name": "brandVoice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryGoal": {
+          "name": "primaryGoal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seoConfig": {
+          "name": "seoConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assets": {
+          "name": "assets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "client_profiles_userId_users_id_fk": {
+          "name": "client_profiles_userId_users_id_fk",
+          "tableFrom": "client_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cost_budgets": {
+      "name": "cost_budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dailyBudget": {
+          "name": "dailyBudget",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weeklyBudget": {
+          "name": "weeklyBudget",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlyBudget": {
+          "name": "monthlyBudget",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alertThreshold": {
+          "name": "alertThreshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 80
+        },
+        "currentDailySpend": {
+          "name": "currentDailySpend",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "currentWeeklySpend": {
+          "name": "currentWeeklySpend",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "currentMonthlySpend": {
+          "name": "currentMonthlySpend",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "autoStopOnLimit": {
+          "name": "autoStopOnLimit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastAlertSent": {
+          "name": "lastAlertSent",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alertsSentToday": {
+          "name": "alertsSentToday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dailyPeriodStart": {
+          "name": "dailyPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "weeklyPeriodStart": {
+          "name": "weeklyPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "monthlyPeriodStart": {
+          "name": "monthlyPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "cost_budgets_user_id_idx": {
+          "name": "cost_budgets_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cost_budgets_is_active_idx": {
+          "name": "cost_budgets_is_active_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cost_budgets_userId_users_id_fk": {
+          "name": "cost_budgets_userId_users_id_fk",
+          "tableFrom": "cost_budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cost_budgets_userId_unique": {
+          "name": "cost_budgets_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_packages": {
+      "name": "credit_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creditAmount": {
+          "name": "creditAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creditType": {
+          "name": "creditType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credit_transactions": {
+      "name": "credit_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creditType": {
+          "name": "creditType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transactionType": {
+          "name": "transactionType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balanceAfter": {
+          "name": "balanceAfter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenceType": {
+          "name": "referenceType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credit_transactions_userId_users_id_fk": {
+          "name": "credit_transactions_userId_users_id_fk",
+          "tableFrom": "credit_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_job_registry": {
+      "name": "cron_job_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jobId": {
+          "name": "jobId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jobName": {
+          "name": "jobName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "isRunning": {
+          "name": "isRunning",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastStartedAt": {
+          "name": "lastStartedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastCompletedAt": {
+          "name": "lastCompletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cron_job_registry_taskId_scheduled_browser_tasks_id_fk": {
+          "name": "cron_job_registry_taskId_scheduled_browser_tasks_id_fk",
+          "tableFrom": "cron_job_registry",
+          "tableTo": "scheduled_browser_tasks",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cron_job_registry_taskId_unique": {
+          "name": "cron_job_registry_taskId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId"
+          ]
+        },
+        "cron_job_registry_jobId_unique": {
+          "name": "cron_job_registry_jobId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jobId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_cost_summaries": {
+      "name": "daily_cost_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalApiCalls": {
+          "name": "totalApiCalls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalInputTokens": {
+          "name": "totalInputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalOutputTokens": {
+          "name": "totalOutputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalCacheTokens": {
+          "name": "totalCacheTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "apiCostUsd": {
+          "name": "apiCostUsd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "totalGeminiCalls": {
+          "name": "totalGeminiCalls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalGeminiInputTokens": {
+          "name": "totalGeminiInputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalGeminiOutputTokens": {
+          "name": "totalGeminiOutputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "geminiCostUsd": {
+          "name": "geminiCostUsd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "totalSessions": {
+          "name": "totalSessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalSessionMinutes": {
+          "name": "totalSessionMinutes",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "browserbaseCostUsd": {
+          "name": "browserbaseCostUsd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "totalStorageOperations": {
+          "name": "totalStorageOperations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalStorageMb": {
+          "name": "totalStorageMb",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "storageCostUsd": {
+          "name": "storageCostUsd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "totalCostUsd": {
+          "name": "totalCostUsd",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costByModel": {
+          "name": "costByModel",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costByProvider": {
+          "name": "costByProvider",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_cost_summaries_user_id_idx": {
+          "name": "daily_cost_summaries_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "daily_cost_summaries_date_idx": {
+          "name": "daily_cost_summaries_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "daily_cost_summaries_user_date_idx": {
+          "name": "daily_cost_summaries_user_date_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_cost_summaries_userId_users_id_fk": {
+          "name": "daily_cost_summaries_userId_users_id_fk",
+          "tableFrom": "daily_cost_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embeddingId": {
+          "name": "embeddingId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "documents_userId_users_id_fk": {
+          "name": "documents_userId_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_connections": {
+      "name": "email_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCursor": {
+          "name": "syncCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_connections_userId_users_id_fk": {
+          "name": "email_connections_userId_users_id_fk",
+          "tableFrom": "email_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_drafts": {
+      "name": "email_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailId": {
+          "name": "emailId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bodyType": {
+          "name": "bodyType",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'html'"
+        },
+        "tone": {
+          "name": "tone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generatedAt": {
+          "name": "generatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_drafts_userId_users_id_fk": {
+          "name": "email_drafts_userId_users_id_fk",
+          "tableFrom": "email_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "email_drafts_emailId_synced_emails_id_fk": {
+          "name": "email_drafts_emailId_synced_emails_id_fk",
+          "tableFrom": "email_drafts",
+          "tableTo": "synced_emails",
+          "columnsFrom": [
+            "emailId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "email_drafts_connectionId_email_connections_id_fk": {
+          "name": "email_drafts_connectionId_email_connections_id_fk",
+          "tableFrom": "email_drafts",
+          "tableTo": "email_connections",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_sync_history": {
+      "name": "email_sync_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "jobId": {
+          "name": "jobId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "emailsFetched": {
+          "name": "emailsFetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "emailsProcessed": {
+          "name": "emailsProcessed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "draftsGenerated": {
+          "name": "draftsGenerated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_sync_history_userId_users_id_fk": {
+          "name": "email_sync_history_userId_users_id_fk",
+          "tableFrom": "email_sync_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "email_sync_history_connectionId_email_connections_id_fk": {
+          "name": "email_sync_history_connectionId_email_connections_id_fk",
+          "tableFrom": "email_sync_history",
+          "tableTo": "email_connections",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_user_id_idx": {
+          "name": "email_verification_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_verification_token_idx": {
+          "name": "email_verification_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_verification_expires_at_idx": {
+          "name": "email_verification_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_tokens_userId_users_id_fk": {
+          "name": "email_verification_tokens_userId_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_verification_tokens_token_unique": {
+          "name": "email_verification_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leads": {
+      "name": "leads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "listId": {
+          "name": "listId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrichedData": {
+          "name": "enrichedData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrichmentStatus": {
+          "name": "enrichmentStatus",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "creditsUsed": {
+          "name": "creditsUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "enrichedAt": {
+          "name": "enrichedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leads_listId_lead_lists_id_fk": {
+          "name": "leads_listId_lead_lists_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "lead_lists",
+          "columnsFrom": [
+            "listId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "leads_userId_users_id_fk": {
+          "name": "leads_userId_users_id_fk",
+          "tableFrom": "leads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_checkpoints": {
+      "name": "execution_checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checkpointId": {
+          "name": "checkpointId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phaseId": {
+          "name": "phaseId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phaseName": {
+          "name": "phaseName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stepIndex": {
+          "name": "stepIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "completedSteps": {
+          "name": "completedSteps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "completedPhases": {
+          "name": "completedPhases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "partialResults": {
+          "name": "partialResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "extractedData": {
+          "name": "extractedData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sessionState": {
+          "name": "sessionState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"url\":null,\"cookies\":[],\"localStorage\":{},\"sessionStorage\":{},\"authenticatedAs\":null}'::jsonb"
+        },
+        "browserContext": {
+          "name": "browserContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"pageState\":null,\"domSnapshot\":null,\"screenshotUrl\":null}'::jsonb"
+        },
+        "errorInfo": {
+          "name": "errorInfo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkpointReason": {
+          "name": "checkpointReason",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "canResume": {
+          "name": "canResume",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "resumeCount": {
+          "name": "resumeCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "execution_checkpoint_id_idx": {
+          "name": "execution_checkpoint_id_idx",
+          "columns": [
+            {
+              "expression": "checkpointId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "execution_checkpoint_execution_id_idx": {
+          "name": "execution_checkpoint_execution_id_idx",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "execution_checkpoint_user_id_idx": {
+          "name": "execution_checkpoint_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "execution_checkpoint_created_at_idx": {
+          "name": "execution_checkpoint_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "execution_checkpoint_expires_at_idx": {
+          "name": "execution_checkpoint_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "execution_checkpoints_userId_users_id_fk": {
+          "name": "execution_checkpoints_userId_users_id_fk",
+          "tableFrom": "execution_checkpoints",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "execution_checkpoints_checkpointId_unique": {
+          "name": "execution_checkpoints_checkpointId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "checkpointId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_packs": {
+      "name": "execution_packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionCount": {
+          "name": "executionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validForDays": {
+          "name": "validForDays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priceCents": {
+          "name": "priceCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minTierId": {
+          "name": "minTierId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxPerMonth": {
+          "name": "maxPerMonth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "execution_packs_minTierId_subscription_tiers_id_fk": {
+          "name": "execution_packs_minTierId_subscription_tiers_id_fk",
+          "tableFrom": "execution_packs",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "minTierId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "execution_packs_slug_unique": {
+          "name": "execution_packs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.extracted_data": {
+      "name": "extracted_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dataType": {
+          "name": "dataType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "extracted_data_sessionId_browser_sessions_id_fk": {
+          "name": "extracted_data_sessionId_browser_sessions_id_fk",
+          "tableFrom": "extracted_data",
+          "tableTo": "browser_sessions",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "extracted_data_executionId_workflow_executions_id_fk": {
+          "name": "extracted_data_executionId_workflow_executions_id_fk",
+          "tableFrom": "extracted_data",
+          "tableTo": "workflow_executions",
+          "columnsFrom": [
+            "executionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "extracted_data_userId_users_id_fk": {
+          "name": "extracted_data_userId_users_id_fk",
+          "tableFrom": "extracted_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rolloutPercentage": {
+          "name": "rolloutPercentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "userWhitelist": {
+          "name": "userWhitelist",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "feature_flags_name_unique": {
+          "name": "feature_flags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ghl_location_configs": {
+      "name": "ghl_location_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locationId": {
+          "name": "locationId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locationName": {
+          "name": "locationName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "companyId": {
+          "name": "companyId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "syncConfig": {
+          "name": "syncConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locationDetails": {
+          "name": "locationDetails",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ghl_location_configs_userId_users_id_fk": {
+          "name": "ghl_location_configs_userId_users_id_fk",
+          "tableFrom": "ghl_location_configs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.heatmap_events": {
+      "name": "heatmap_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "x": {
+          "name": "x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "y": {
+          "name": "y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scrollDepth": {
+          "name": "scrollDepth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scrollPercentage": {
+          "name": "scrollPercentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visitorId": {
+          "name": "visitorId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "heatmap_events_sessionId_heatmap_sessions_id_fk": {
+          "name": "heatmap_events_sessionId_heatmap_sessions_id_fk",
+          "tableFrom": "heatmap_events",
+          "tableTo": "heatmap_sessions",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.heatmap_sessions": {
+      "name": "heatmap_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trackingId": {
+          "name": "trackingId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalClicks": {
+          "name": "totalClicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "totalSessions": {
+          "name": "totalSessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "averageScrollDepth": {
+          "name": "averageScrollDepth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "bounceRate": {
+          "name": "bounceRate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "averageTimeOnPage": {
+          "name": "averageTimeOnPage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "heatmap_sessions_userId_users_id_fk": {
+          "name": "heatmap_sessions_userId_users_id_fk",
+          "tableFrom": "heatmap_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "heatmap_sessions_trackingId_unique": {
+          "name": "heatmap_sessions_trackingId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trackingId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.in_app_notifications": {
+      "name": "in_app_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alertHistoryId": {
+          "name": "alertHistoryId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isDismissed": {
+          "name": "isDismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actionUrl": {
+          "name": "actionUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actionLabel": {
+          "name": "actionLabel",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissedAt": {
+          "name": "dismissedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "in_app_notifications_userId_users_id_fk": {
+          "name": "in_app_notifications_userId_users_id_fk",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "in_app_notifications_alertHistoryId_alert_history_id_fk": {
+          "name": "in_app_notifications_alertHistoryId_alert_history_id_fk",
+          "tableFrom": "in_app_notifications",
+          "tableTo": "alert_history",
+          "columnsFrom": [
+            "alertHistoryId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbound_messages": {
+      "name": "inbound_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookId": {
+          "name": "webhookId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalMessageId": {
+          "name": "externalMessageId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "senderIdentifier": {
+          "name": "senderIdentifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderName": {
+          "name": "senderName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentParsed": {
+          "name": "contentParsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasAttachments": {
+          "name": "hasAttachments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingStatus": {
+          "name": "processingStatus",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "processingError": {
+          "name": "processingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPartOfThread": {
+          "name": "isPartOfThread",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "parentMessageId": {
+          "name": "parentMessageId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rawPayload": {
+          "name": "rawPayload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerMetadata": {
+          "name": "providerMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receivedAt": {
+          "name": "receivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbound_messages_webhook_id_idx": {
+          "name": "inbound_messages_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "webhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_messages_user_id_idx": {
+          "name": "inbound_messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_messages_sender_idx": {
+          "name": "inbound_messages_sender_idx",
+          "columns": [
+            {
+              "expression": "senderIdentifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_messages_status_idx": {
+          "name": "inbound_messages_status_idx",
+          "columns": [
+            {
+              "expression": "processingStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_messages_conversation_idx": {
+          "name": "inbound_messages_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_messages_received_at_idx": {
+          "name": "inbound_messages_received_at_idx",
+          "columns": [
+            {
+              "expression": "receivedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbound_messages_user_webhook_idx": {
+          "name": "inbound_messages_user_webhook_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "webhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbound_messages_webhookId_user_webhooks_id_fk": {
+          "name": "inbound_messages_webhookId_user_webhooks_id_fk",
+          "tableFrom": "inbound_messages",
+          "tableTo": "user_webhooks",
+          "columnsFrom": [
+            "webhookId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_messages_userId_users_id_fk": {
+          "name": "inbound_messages_userId_users_id_fk",
+          "tableFrom": "inbound_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "inbound_messages_parentMessageId_inbound_messages_id_fk": {
+          "name": "inbound_messages_parentMessageId_inbound_messages_id_fk",
+          "tableFrom": "inbound_messages",
+          "tableTo": "inbound_messages",
+          "columnsFrom": [
+            "parentMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integrations": {
+      "name": "integrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'true'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "integrations_userId_users_id_fk": {
+          "name": "integrations_userId_users_id_fk",
+          "tableFrom": "integrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jobs": {
+      "name": "jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_rankings": {
+      "name": "keyword_rankings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousPosition": {
+          "name": "previousPosition",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change": {
+          "name": "change",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "searchEngine": {
+          "name": "searchEngine",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'google'"
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'United States'"
+        },
+        "pageTitle": {
+          "name": "pageTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageUrl": {
+          "name": "pageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkedAt": {
+          "name": "checkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "keyword_rankings_userId_users_id_fk": {
+          "name": "keyword_rankings_userId_users_id_fk",
+          "tableFrom": "keyword_rankings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.keyword_research": {
+      "name": "keyword_research",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "searchVolume": {
+          "name": "searchVolume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "cpc": {
+          "name": "cpc",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "trend": {
+          "name": "trend",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'stable'"
+        },
+        "relatedKeywords": {
+          "name": "relatedKeywords",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ai'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "keyword_research_userId_users_id_fk": {
+          "name": "keyword_research_userId_users_id_fk",
+          "tableFrom": "keyword_research",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lead_lists": {
+      "name": "lead_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploading'"
+        },
+        "totalLeads": {
+          "name": "totalLeads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "enrichedLeads": {
+          "name": "enrichedLeads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failedLeads": {
+          "name": "failedLeads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "costInCredits": {
+          "name": "costInCredits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploadedAt": {
+          "name": "uploadedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processingStartedAt": {
+          "name": "processingStartedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lead_lists_userId_users_id_fk": {
+          "name": "lead_lists_userId_users_id_fk",
+          "tableFrom": "lead_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.login_attempts": {
+      "name": "login_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attemptedAt": {
+          "name": "attemptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "login_attempts_email_idx": {
+          "name": "login_attempts_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "login_attempts_ip_idx": {
+          "name": "login_attempts_ip_idx",
+          "columns": [
+            {
+              "expression": "ipAddress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "login_attempts_email_attempted_at_idx": {
+          "name": "login_attempts_email_attempted_at_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attemptedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "login_attempts_attempted_at_idx": {
+          "name": "login_attempts_attempted_at_idx",
+          "columns": [
+            {
+              "expression": "attemptedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_ad_accounts": {
+      "name": "meta_ad_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountName": {
+          "name": "accountName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountStatus": {
+          "name": "accountStatus",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'true'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meta_ad_accounts_userId_users_id_fk": {
+          "name": "meta_ad_accounts_userId_users_id_fk",
+          "tableFrom": "meta_ad_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meta_ad_accounts_accountId_unique": {
+          "name": "meta_ad_accounts_accountId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "accountId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_ad_sets": {
+      "name": "meta_ad_sets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaignId": {
+          "name": "campaignId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adSetId": {
+          "name": "adSetId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adSetName": {
+          "name": "adSetName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyBudget": {
+          "name": "dailyBudget",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifetimeBudget": {
+          "name": "lifetimeBudget",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetingDescription": {
+          "name": "targetingDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targeting": {
+          "name": "targeting",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meta_ad_sets_userId_users_id_fk": {
+          "name": "meta_ad_sets_userId_users_id_fk",
+          "tableFrom": "meta_ad_sets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meta_ad_sets_campaignId_meta_campaigns_id_fk": {
+          "name": "meta_ad_sets_campaignId_meta_campaigns_id_fk",
+          "tableFrom": "meta_ad_sets",
+          "tableTo": "meta_campaigns",
+          "columnsFrom": [
+            "campaignId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meta_ad_sets_adSetId_unique": {
+          "name": "meta_ad_sets_adSetId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "adSetId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_ads": {
+      "name": "meta_ads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adSetId": {
+          "name": "adSetId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adId": {
+          "name": "adId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adName": {
+          "name": "adName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headline": {
+          "name": "headline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primaryText": {
+          "name": "primaryText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videoUrl": {
+          "name": "videoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "callToAction": {
+          "name": "callToAction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creative": {
+          "name": "creative",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latestMetrics": {
+          "name": "latestMetrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meta_ads_userId_users_id_fk": {
+          "name": "meta_ads_userId_users_id_fk",
+          "tableFrom": "meta_ads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meta_ads_adSetId_meta_ad_sets_id_fk": {
+          "name": "meta_ads_adSetId_meta_ad_sets_id_fk",
+          "tableFrom": "meta_ads",
+          "tableTo": "meta_ad_sets",
+          "columnsFrom": [
+            "adSetId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meta_ads_adId_unique": {
+          "name": "meta_ads_adId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "adId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meta_campaigns": {
+      "name": "meta_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaignId": {
+          "name": "campaignId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaignName": {
+          "name": "campaignName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyBudget": {
+          "name": "dailyBudget",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifetimeBudget": {
+          "name": "lifetimeBudget",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meta_campaigns_userId_users_id_fk": {
+          "name": "meta_campaigns_userId_users_id_fk",
+          "tableFrom": "meta_campaigns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "meta_campaigns_accountId_meta_ad_accounts_id_fk": {
+          "name": "meta_campaigns_accountId_meta_ad_accounts_id_fk",
+          "tableFrom": "meta_campaigns",
+          "tableTo": "meta_ad_accounts",
+          "columnsFrom": [
+            "accountId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "meta_campaigns_campaignId_unique": {
+          "name": "meta_campaigns_campaignId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "campaignId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outbound_messages": {
+      "name": "outbound_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "webhookId": {
+          "name": "webhookId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inboundMessageId": {
+          "name": "inboundMessageId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientIdentifier": {
+          "name": "recipientIdentifier",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientName": {
+          "name": "recipientName",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryStatus": {
+          "name": "deliveryStatus",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "deliveryError": {
+          "name": "deliveryError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "externalMessageId": {
+          "name": "externalMessageId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "providerResponse": {
+          "name": "providerResponse",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledFor": {
+          "name": "scheduledFor",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "outbound_messages_webhook_id_idx": {
+          "name": "outbound_messages_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "webhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbound_messages_user_id_idx": {
+          "name": "outbound_messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbound_messages_task_id_idx": {
+          "name": "outbound_messages_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbound_messages_conversation_id_idx": {
+          "name": "outbound_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbound_messages_delivery_status_idx": {
+          "name": "outbound_messages_delivery_status_idx",
+          "columns": [
+            {
+              "expression": "deliveryStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbound_messages_scheduled_for_idx": {
+          "name": "outbound_messages_scheduled_for_idx",
+          "columns": [
+            {
+              "expression": "scheduledFor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "outbound_messages_pending_idx": {
+          "name": "outbound_messages_pending_idx",
+          "columns": [
+            {
+              "expression": "deliveryStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduledFor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outbound_messages_webhookId_user_webhooks_id_fk": {
+          "name": "outbound_messages_webhookId_user_webhooks_id_fk",
+          "tableFrom": "outbound_messages",
+          "tableTo": "user_webhooks",
+          "columnsFrom": [
+            "webhookId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "outbound_messages_userId_users_id_fk": {
+          "name": "outbound_messages_userId_users_id_fk",
+          "tableFrom": "outbound_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "outbound_messages_inboundMessageId_inbound_messages_id_fk": {
+          "name": "outbound_messages_inboundMessageId_inbound_messages_id_fk",
+          "tableFrom": "outbound_messages",
+          "tableTo": "inbound_messages",
+          "columnsFrom": [
+            "inboundMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "outbound_messages_taskId_agency_tasks_id_fk": {
+          "name": "outbound_messages_taskId_agency_tasks_id_fk",
+          "tableFrom": "outbound_messages",
+          "tableTo": "agency_tasks",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "outbound_messages_conversationId_bot_conversations_id_fk": {
+          "name": "outbound_messages_conversationId_bot_conversations_id_fk",
+          "tableFrom": "outbound_messages",
+          "tableTo": "bot_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "password_reset_user_id_idx": {
+          "name": "password_reset_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_token_idx": {
+          "name": "password_reset_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "password_reset_expires_at_idx": {
+          "name": "password_reset_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "password_reset_tokens_userId_users_id_fk": {
+          "name": "password_reset_tokens_userId_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "password_reset_tokens_token_unique": {
+          "name": "password_reset_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_attempts": {
+      "name": "quiz_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quizId": {
+          "name": "quizId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "answers": {
+          "name": "answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "percentage": {
+          "name": "percentage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeSpent": {
+          "name": "timeSpent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attemptNumber": {
+          "name": "attemptNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gradedBy": {
+          "name": "gradedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submittedAt": {
+          "name": "submittedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gradedAt": {
+          "name": "gradedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_attempts_quizId_quizzes_id_fk": {
+          "name": "quiz_attempts_quizId_quizzes_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "quizzes",
+          "columnsFrom": [
+            "quizId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quiz_attempts_userId_users_id_fk": {
+          "name": "quiz_attempts_userId_users_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quiz_attempts_gradedBy_users_id_fk": {
+          "name": "quiz_attempts_gradedBy_users_id_fk",
+          "tableFrom": "quiz_attempts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "gradedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_questions": {
+      "name": "quiz_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quizId": {
+          "name": "quizId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "questionText": {
+          "name": "questionText",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "questionType": {
+          "name": "questionType",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "correctAnswer": {
+          "name": "correctAnswer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hint": {
+          "name": "hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_questions_quizId_quizzes_id_fk": {
+          "name": "quiz_questions_quizId_quizzes_id_fk",
+          "tableFrom": "quiz_questions",
+          "tableTo": "quizzes",
+          "columnsFrom": [
+            "quizId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quizzes": {
+      "name": "quizzes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'medium'"
+        },
+        "timeLimit": {
+          "name": "timeLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passingScore": {
+          "name": "passingScore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 70
+        },
+        "isPublished": {
+          "name": "isPublished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attemptsAllowed": {
+          "name": "attemptsAllowed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quizzes_userId_users_id_fk": {
+          "name": "quizzes_userId_users_id_fk",
+          "tableFrom": "quizzes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_browser_tasks": {
+      "name": "scheduled_browser_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automationType": {
+          "name": "automationType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automationConfig": {
+          "name": "automationConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduleType": {
+          "name": "scheduleType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "nextRun": {
+          "name": "nextRun",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRun": {
+          "name": "lastRun",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunStatus": {
+          "name": "lastRunStatus",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunError": {
+          "name": "lastRunError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunDuration": {
+          "name": "lastRunDuration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionCount": {
+          "name": "executionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "successCount": {
+          "name": "successCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failureCount": {
+          "name": "failureCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "averageDuration": {
+          "name": "averageDuration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retryOnFailure": {
+          "name": "retryOnFailure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "maxRetries": {
+          "name": "maxRetries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "retryDelay": {
+          "name": "retryDelay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "notifyOnSuccess": {
+          "name": "notifyOnSuccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notifyOnFailure": {
+          "name": "notifyOnFailure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notificationChannels": {
+          "name": "notificationChannels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "keepExecutionHistory": {
+          "name": "keepExecutionHistory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "maxHistoryRecords": {
+          "name": "maxHistoryRecords",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastModifiedBy": {
+          "name": "lastModifiedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_browser_tasks_userId_users_id_fk": {
+          "name": "scheduled_browser_tasks_userId_users_id_fk",
+          "tableFrom": "scheduled_browser_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scheduled_browser_tasks_createdBy_users_id_fk": {
+          "name": "scheduled_browser_tasks_createdBy_users_id_fk",
+          "tableFrom": "scheduled_browser_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "scheduled_browser_tasks_lastModifiedBy_users_id_fk": {
+          "name": "scheduled_browser_tasks_lastModifiedBy_users_id_fk",
+          "tableFrom": "scheduled_browser_tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "lastModifiedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_seo_reports": {
+      "name": "scheduled_seo_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reportOptions": {
+          "name": "reportOptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_seo_reports_userId_users_id_fk": {
+          "name": "scheduled_seo_reports_userId_users_id_fk",
+          "tableFrom": "scheduled_seo_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_task_executions": {
+      "name": "scheduled_task_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attemptNumber": {
+          "name": "attemptNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logs": {
+          "name": "logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugUrl": {
+          "name": "debugUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordingUrl": {
+          "name": "recordingUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scheduled_task_executions_taskId_scheduled_browser_tasks_id_fk": {
+          "name": "scheduled_task_executions_taskId_scheduled_browser_tasks_id_fk",
+          "tableFrom": "scheduled_task_executions",
+          "tableTo": "scheduled_browser_tasks",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_tasks": {
+      "name": "scheduled_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "lastRun": {
+          "name": "lastRun",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextRun": {
+          "name": "nextRun",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.security_events": {
+      "name": "security_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'low'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geoLocation": {
+          "name": "geoLocation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "resolvedBy": {
+          "name": "resolvedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "security_events_userId_users_id_fk": {
+          "name": "security_events_userId_users_id_fk",
+          "tableFrom": "security_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "security_events_resolvedBy_users_id_fk": {
+          "name": "security_events_resolvedBy_users_id_fk",
+          "tableFrom": "security_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolvedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seo_competitors": {
+      "name": "seo_competitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userUrl": {
+          "name": "userUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competitorUrl": {
+          "name": "competitorUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "competitorName": {
+          "name": "competitorName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastScore": {
+          "name": "lastScore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDomainAuthority": {
+          "name": "lastDomainAuthority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastBacklinkCount": {
+          "name": "lastBacklinkCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastKeywordCount": {
+          "name": "lastKeywordCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastChecked": {
+          "name": "lastChecked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seo_competitors_userId_users_id_fk": {
+          "name": "seo_competitors_userId_users_id_fk",
+          "tableFrom": "seo_competitors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seo_reports": {
+      "name": "seo_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'completed'"
+        },
+        "metaDescription": {
+          "name": "metaDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metaKeywords": {
+          "name": "metaKeywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headings": {
+          "name": "headings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "performance": {
+          "name": "performance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "technicalSEO": {
+          "name": "technicalSEO",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentAnalysis": {
+          "name": "contentAnalysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiInsights": {
+          "name": "aiInsights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdfUrl": {
+          "name": "pdfUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reportType": {
+          "name": "reportType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'full'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seo_reports_userId_users_id_fk": {
+          "name": "seo_reports_userId_users_id_fk",
+          "tableFrom": "seo_reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_tiers": {
+      "name": "subscription_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlyPriceCents": {
+          "name": "monthlyPriceCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "setupFeeCents": {
+          "name": "setupFeeCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "weeklyPremiumPercent": {
+          "name": "weeklyPremiumPercent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "sixMonthDiscountPercent": {
+          "name": "sixMonthDiscountPercent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "annualDiscountPercent": {
+          "name": "annualDiscountPercent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "maxAgents": {
+          "name": "maxAgents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maxConcurrentAgents": {
+          "name": "maxConcurrentAgents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monthlyExecutionLimit": {
+          "name": "monthlyExecutionLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maxExecutionDurationMinutes": {
+          "name": "maxExecutionDurationMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60
+        },
+        "maxGhlAccounts": {
+          "name": "maxGhlAccounts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "allowedStrategies": {
+          "name": "allowedStrategies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"auto\"]'::jsonb"
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isPopular": {
+          "name": "isPopular",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscription_tiers_slug_unique": {
+          "name": "subscription_tiers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription_usage_records": {
+      "name": "subscription_usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tierId": {
+          "name": "tierId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executionLimit": {
+          "name": "executionLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentLimit": {
+          "name": "agentLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executionsUsed": {
+          "name": "executionsUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "peakConcurrentAgents": {
+          "name": "peakConcurrentAgents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "additionalExecutionsPurchased": {
+          "name": "additionalExecutionsPurchased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "additionalExecutionsUsed": {
+          "name": "additionalExecutionsUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "overageExecutions": {
+          "name": "overageExecutions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "overageChargedCents": {
+          "name": "overageChargedCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscription_usage_records_userId_users_id_fk": {
+          "name": "subscription_usage_records_userId_users_id_fk",
+          "tableFrom": "subscription_usage_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subscription_usage_records_tierId_subscription_tiers_id_fk": {
+          "name": "subscription_usage_records_tierId_subscription_tiers_id_fk",
+          "tableFrom": "subscription_usage_records",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tierId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.support_tickets": {
+      "name": "support_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "assignedTo": {
+          "name": "assignedTo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "support_tickets_userId_users_id_fk": {
+          "name": "support_tickets_userId_users_id_fk",
+          "tableFrom": "support_tickets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "support_tickets_assignedTo_users_id_fk": {
+          "name": "support_tickets_assignedTo_users_id_fk",
+          "tableFrom": "support_tickets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assignedTo"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_emails": {
+      "name": "synced_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threadId": {
+          "name": "threadId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from": {
+          "name": "from",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc": {
+          "name": "cc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyTo": {
+          "name": "replyTo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bodyType": {
+          "name": "bodyType",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isStarred": {
+          "name": "isStarred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hasAttachments": {
+          "name": "hasAttachments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentimentScore": {
+          "name": "sentimentScore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importance": {
+          "name": "importance",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresResponse": {
+          "name": "requiresResponse",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "synced_emails_userId_users_id_fk": {
+          "name": "synced_emails_userId_users_id_fk",
+          "tableFrom": "synced_emails",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "synced_emails_connectionId_email_connections_id_fk": {
+          "name": "synced_emails_connectionId_email_connections_id_fk",
+          "tableFrom": "synced_emails",
+          "tableTo": "email_connections",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "synced_emails_messageId_unique": {
+          "name": "synced_emails_messageId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "messageId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_config": {
+      "name": "system_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "system_config_updatedBy_users_id_fk": {
+          "name": "system_config_updatedBy_users_id_fk",
+          "tableFrom": "system_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "system_config_key_unique": {
+          "name": "system_config_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_executions": {
+      "name": "task_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executionUuid": {
+          "name": "executionUuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attemptNumber": {
+          "name": "attemptNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'started'"
+        },
+        "triggeredBy": {
+          "name": "triggeredBy",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggeredByUserId": {
+          "name": "triggeredByUserId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browserSessionId": {
+          "name": "browserSessionId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debugUrl": {
+          "name": "debugUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordingUrl": {
+          "name": "recordingUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stepsTotal": {
+          "name": "stepsTotal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stepsCompleted": {
+          "name": "stepsCompleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currentStep": {
+          "name": "currentStep",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stepResults": {
+          "name": "stepResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logs": {
+          "name": "logs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorCode": {
+          "name": "errorCode",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorStack": {
+          "name": "errorStack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resourceUsage": {
+          "name": "resourceUsage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_executions_task_id_idx": {
+          "name": "task_executions_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_executions_uuid_idx": {
+          "name": "task_executions_uuid_idx",
+          "columns": [
+            {
+              "expression": "executionUuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_executions_status_idx": {
+          "name": "task_executions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_executions_started_at_idx": {
+          "name": "task_executions_started_at_idx",
+          "columns": [
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_executions_browser_session_idx": {
+          "name": "task_executions_browser_session_idx",
+          "columns": [
+            {
+              "expression": "browserSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_executions_taskId_agency_tasks_id_fk": {
+          "name": "task_executions_taskId_agency_tasks_id_fk",
+          "tableFrom": "task_executions",
+          "tableTo": "agency_tasks",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_executions_triggeredByUserId_users_id_fk": {
+          "name": "task_executions_triggeredByUserId_users_id_fk",
+          "tableFrom": "task_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggeredByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_executions_executionUuid_unique": {
+          "name": "task_executions_executionUuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "executionUuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_success_patterns": {
+      "name": "task_success_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "patternId": {
+          "name": "patternId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskType": {
+          "name": "taskType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskName": {
+          "name": "taskName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successfulApproach": {
+          "name": "successfulApproach",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selectors": {
+          "name": "selectors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "contextConditions": {
+          "name": "contextConditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "requiredState": {
+          "name": "requiredState",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "avgExecutionTime": {
+          "name": "avgExecutionTime",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "successRate": {
+          "name": "successRate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "usageCount": {
+          "name": "usageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.8
+        },
+        "adaptations": {
+          "name": "adaptations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "reasoningPatternId": {
+          "name": "reasoningPatternId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "task_success_user_id_idx": {
+          "name": "task_success_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_success_task_type_idx": {
+          "name": "task_success_task_type_idx",
+          "columns": [
+            {
+              "expression": "taskType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_success_success_rate_idx": {
+          "name": "task_success_success_rate_idx",
+          "columns": [
+            {
+              "expression": "successRate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_success_confidence_idx": {
+          "name": "task_success_confidence_idx",
+          "columns": [
+            {
+              "expression": "confidence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_success_patterns_userId_users_id_fk": {
+          "name": "task_success_patterns_userId_users_id_fk",
+          "tableFrom": "task_success_patterns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_success_patterns_patternId_unique": {
+          "name": "task_success_patterns_patternId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "patternId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ticket_messages": {
+      "name": "ticket_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ticketId": {
+          "name": "ticketId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isInternal": {
+          "name": "isInternal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ticket_messages_ticketId_support_tickets_id_fk": {
+          "name": "ticket_messages_ticketId_support_tickets_id_fk",
+          "tableFrom": "ticket_messages",
+          "tableTo": "support_tickets",
+          "columnsFrom": [
+            "ticketId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "ticket_messages_senderId_users_id_fk": {
+          "name": "ticket_messages_senderId_users_id_fk",
+          "tableFrom": "ticket_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_agent_add_ons": {
+      "name": "user_agent_add_ons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addOnId": {
+          "name": "addOnId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "stripeSubscriptionItemId": {
+          "name": "stripeSubscriptionItemId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_agent_add_ons_userId_users_id_fk": {
+          "name": "user_agent_add_ons_userId_users_id_fk",
+          "tableFrom": "user_agent_add_ons",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_agent_add_ons_addOnId_agent_add_ons_id_fk": {
+          "name": "user_agent_add_ons_addOnId_agent_add_ons_id_fk",
+          "tableFrom": "user_agent_add_ons",
+          "tableTo": "agent_add_ons",
+          "columnsFrom": [
+            "addOnId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_execution_packs": {
+      "name": "user_execution_packs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packId": {
+          "name": "packId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executionsIncluded": {
+          "name": "executionsIncluded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionsRemaining": {
+          "name": "executionsRemaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchasedAt": {
+          "name": "purchasedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricePaidCents": {
+          "name": "pricePaidCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePaymentIntentId": {
+          "name": "stripePaymentIntentId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_execution_packs_userId_users_id_fk": {
+          "name": "user_execution_packs_userId_users_id_fk",
+          "tableFrom": "user_execution_packs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_execution_packs_packId_execution_packs_id_fk": {
+          "name": "user_execution_packs_packId_execution_packs_id_fk",
+          "tableFrom": "user_execution_packs",
+          "tableTo": "execution_packs",
+          "columnsFrom": [
+            "packId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_feedback": {
+      "name": "user_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feedbackId": {
+          "name": "feedbackId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedbackType": {
+          "name": "feedbackType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalAction": {
+          "name": "originalAction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correctedAction": {
+          "name": "correctedAction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impact": {
+          "name": "impact",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed": {
+          "name": "processed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "appliedToPattern": {
+          "name": "appliedToPattern",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_feedback_user_id_idx": {
+          "name": "user_feedback_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_feedback_execution_id_idx": {
+          "name": "user_feedback_execution_id_idx",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_feedback_processed_idx": {
+          "name": "user_feedback_processed_idx",
+          "columns": [
+            {
+              "expression": "processed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_feedback_type_idx": {
+          "name": "user_feedback_type_idx",
+          "columns": [
+            {
+              "expression": "feedbackType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_feedback_userId_users_id_fk": {
+          "name": "user_feedback_userId_users_id_fk",
+          "tableFrom": "user_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_feedback_feedbackId_unique": {
+          "name": "user_feedback_feedbackId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feedbackId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_memory": {
+      "name": "user_memory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"actionSpeed\":\"normal\",\"approvalRequired\":true,\"favoriteStrategies\":[],\"autoApprovePatterns\":[],\"defaultTimeout\":30000,\"maxRetries\":3}'::jsonb"
+        },
+        "taskHistory": {
+          "name": "taskHistory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "learnedPatterns": {
+          "name": "learnedPatterns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"ghlSelectors\":{},\"commonWorkflows\":[],\"errorRecovery\":[],\"customCommands\":[]}'::jsonb"
+        },
+        "userCorrections": {
+          "name": "userCorrections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"totalExecutions\":0,\"successfulExecutions\":0,\"avgExecutionTime\":0,\"mostUsedTasks\":{},\"preferredApproaches\":{}}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_memory_user_id_idx": {
+          "name": "user_memory_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_memory_userId_users_id_fk": {
+          "name": "user_memory_userId_users_id_fk",
+          "tableFrom": "user_memory",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defaultBrowserConfig": {
+          "name": "defaultBrowserConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defaultWorkflowSettings": {
+          "name": "defaultWorkflowSettings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apiKeys": {
+          "name": "apiKeys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'light'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_userId_users_id_fk": {
+          "name": "user_preferences_userId_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_userId_unique": {
+          "name": "user_preferences_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "companyName": {
+          "name": "companyName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlyRevenue": {
+          "name": "monthlyRevenue",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "employeeCount": {
+          "name": "employeeCount",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentTools": {
+          "name": "currentTools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referralSource": {
+          "name": "referralSource",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ghlApiKey": {
+          "name": "ghlApiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_userId_users_id_fk": {
+          "name": "user_profiles_userId_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_profiles_userId_unique": {
+          "name": "user_profiles_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_subscriptions": {
+      "name": "user_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tierId": {
+          "name": "tierId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "paymentFrequency": {
+          "name": "paymentFrequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionsUsedThisPeriod": {
+          "name": "executionsUsedThisPeriod",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agentsSpawnedThisPeriod": {
+          "name": "agentsSpawnedThisPeriod",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "additionalAgentSlots": {
+          "name": "additionalAgentSlots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "additionalExecutions": {
+          "name": "additionalExecutions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trialEndsAt": {
+          "name": "trialEndsAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelledAt": {
+          "name": "cancelledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellationReason": {
+          "name": "cancellationReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_subscriptions_userId_users_id_fk": {
+          "name": "user_subscriptions_userId_users_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_subscriptions_tierId_subscription_tiers_id_fk": {
+          "name": "user_subscriptions_tierId_subscription_tiers_id_fk",
+          "tableFrom": "user_subscriptions",
+          "tableTo": "subscription_tiers",
+          "columnsFrom": [
+            "tierId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_subscriptions_userId_unique": {
+          "name": "user_subscriptions_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_webhooks": {
+      "name": "user_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookToken": {
+          "name": "webhookToken",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhookUrl": {
+          "name": "webhookUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channelType": {
+          "name": "channelType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channelName": {
+          "name": "channelName",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channelOrder": {
+          "name": "channelOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "providerConfig": {
+          "name": "providerConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outboundEnabled": {
+          "name": "outboundEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "outboundConfig": {
+          "name": "outboundConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isPrimary": {
+          "name": "isPrimary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isVerified": {
+          "name": "isVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verificationCode": {
+          "name": "verificationCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verificationCodeExpiresAt": {
+          "name": "verificationCodeExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenRotationRequired": {
+          "name": "tokenRotationRequired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "secretKey": {
+          "name": "secretKey",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rateLimitPerMinute": {
+          "name": "rateLimitPerMinute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 30
+        },
+        "rateLimitPerHour": {
+          "name": "rateLimitPerHour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 200
+        },
+        "totalMessagesReceived": {
+          "name": "totalMessagesReceived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalMessagesSent": {
+          "name": "totalMessagesSent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_webhooks_user_id_idx": {
+          "name": "user_webhooks_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_webhooks_token_idx": {
+          "name": "user_webhooks_token_idx",
+          "columns": [
+            {
+              "expression": "webhookToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_webhooks_channel_type_idx": {
+          "name": "user_webhooks_channel_type_idx",
+          "columns": [
+            {
+              "expression": "channelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_webhooks_is_active_idx": {
+          "name": "user_webhooks_is_active_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_webhooks_user_channel_idx": {
+          "name": "user_webhooks_user_channel_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channelType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_webhooks_userId_users_id_fk": {
+          "name": "user_webhooks_userId_users_id_fk",
+          "tableFrom": "user_webhooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_webhooks_webhookToken_unique": {
+          "name": "user_webhooks_webhookToken_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhookToken"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_credits": {
+      "name": "user_credits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creditType": {
+          "name": "creditType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalPurchased": {
+          "name": "totalPurchased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalUsed": {
+          "name": "totalUsed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_credits_userId_users_id_fk": {
+          "name": "user_credits_userId_users_id_fk",
+          "tableFrom": "user_credits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "openId": {
+          "name": "openId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "loginMethod": {
+          "name": "loginMethod",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "onboardingCompleted": {
+          "name": "onboardingCompleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "suspendedAt": {
+          "name": "suspendedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspensionReason": {
+          "name": "suspensionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastSignedIn": {
+          "name": "lastSignedIn",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_login_method_idx": {
+          "name": "users_login_method_idx",
+          "columns": [
+            {
+              "expression": "loginMethod",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_email_login_method_idx": {
+          "name": "users_email_login_method_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "loginMethod",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_openId_unique": {
+          "name": "users_openId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "openId"
+          ]
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "googleId"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_logs": {
+      "name": "webhook_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhookId": {
+          "name": "webhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POST'"
+        },
+        "requestHeaders": {
+          "name": "requestHeaders",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestBody": {
+          "name": "requestBody",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseStatus": {
+          "name": "responseStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseBody": {
+          "name": "responseBody",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "nextRetryAt": {
+          "name": "nextRetryAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorCode": {
+          "name": "errorCode",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webhook_logs_webhook_id_idx": {
+          "name": "webhook_logs_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "webhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_logs_user_id_idx": {
+          "name": "webhook_logs_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_logs_status_idx": {
+          "name": "webhook_logs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_logs_event_idx": {
+          "name": "webhook_logs_event_idx",
+          "columns": [
+            {
+              "expression": "event",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_logs_created_at_idx": {
+          "name": "webhook_logs_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_logs_next_retry_at_idx": {
+          "name": "webhook_logs_next_retry_at_idx",
+          "columns": [
+            {
+              "expression": "nextRetryAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_logs_user_webhook_idx": {
+          "name": "webhook_logs_user_webhook_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "webhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_logs_status_retry_idx": {
+          "name": "webhook_logs_status_retry_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRetryAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_logs_user_status_idx": {
+          "name": "webhook_logs_user_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_logs_userId_users_id_fk": {
+          "name": "webhook_logs_userId_users_id_fk",
+          "tableFrom": "webhook_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_executions": {
+      "name": "workflow_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stepResults": {
+          "name": "stepResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "workflow_executions_workflowId_automation_workflows_id_fk": {
+          "name": "workflow_executions_workflowId_automation_workflows_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "automation_workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_executions_sessionId_browser_sessions_id_fk": {
+          "name": "workflow_executions_sessionId_browser_sessions_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "browser_sessions",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflow_executions_userId_users_id_fk": {
+          "name": "workflow_executions_userId_users_id_fk",
+          "tableFrom": "workflow_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflow_patterns": {
+      "name": "workflow_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "patternId": {
+          "name": "patternId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variables": {
+          "name": "variables",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isSystemPattern": {
+          "name": "isSystemPattern",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usageCount": {
+          "name": "usageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "successRate": {
+          "name": "successRate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "avgExecutionTime": {
+          "name": "avgExecutionTime",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_pattern_user_id_idx": {
+          "name": "workflow_pattern_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_pattern_category_idx": {
+          "name": "workflow_pattern_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_pattern_public_idx": {
+          "name": "workflow_pattern_public_idx",
+          "columns": [
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_pattern_system_idx": {
+          "name": "workflow_pattern_system_idx",
+          "columns": [
+            {
+              "expression": "isSystemPattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_patterns_userId_users_id_fk": {
+          "name": "workflow_patterns_userId_users_id_fk",
+          "tableFrom": "workflow_patterns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflow_patterns_patternId_unique": {
+          "name": "workflow_patterns_patternId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "patternId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_executions": {
+      "name": "agent_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskDescription": {
+          "name": "taskDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phases": {
+          "name": "phases",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "currentPhaseIndex": {
+          "name": "currentPhaseIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thinkingSteps": {
+          "name": "thinkingSteps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "toolExecutions": {
+          "name": "toolExecutions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iterations": {
+          "name": "iterations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_executions_sessionId_agent_sessions_id_fk": {
+          "name": "agent_executions_sessionId_agent_sessions_id_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "agent_sessions",
+          "columnsFrom": [
+            "sessionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_executions_userId_users_id_fk": {
+          "name": "agent_executions_userId_users_id_fk",
+          "tableFrom": "agent_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_sessions": {
+      "name": "agent_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionUuid": {
+          "name": "sessionUuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinkingSteps": {
+          "name": "thinkingSteps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "toolHistory": {
+          "name": "toolHistory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentPhase": {
+          "name": "currentPhase",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iterationCount": {
+          "name": "iterationCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "maxIterations": {
+          "name": "maxIterations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_sessions_userId_users_id_fk": {
+          "name": "agent_sessions_userId_users_id_fk",
+          "tableFrom": "agent_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_sessions_sessionUuid_unique": {
+          "name": "agent_sessions_sessionUuid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sessionUuid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.generated_projects": {
+      "name": "generated_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "techStack": {
+          "name": "techStack",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'react'"
+        },
+        "features": {
+          "name": "features",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "filesSnapshot": {
+          "name": "filesSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "devServerPort": {
+          "name": "devServerPort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previewUrl": {
+          "name": "previewUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploymentUrl": {
+          "name": "deploymentUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "generated_projects_userId_users_id_fk": {
+          "name": "generated_projects_userId_users_id_fk",
+          "tableFrom": "generated_projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "generated_projects_executionId_agent_executions_id_fk": {
+          "name": "generated_projects_executionId_agent_executions_id_fk",
+          "tableFrom": "generated_projects",
+          "tableTo": "agent_executions",
+          "columnsFrom": [
+            "executionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_entries": {
+      "name": "knowledge_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "examples": {
+          "name": "examples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0'"
+        },
+        "usageCount": {
+          "name": "usageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_entries_userId_users_id_fk": {
+          "name": "knowledge_entries_userId_users_id_fk",
+          "tableFrom": "knowledge_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_executions": {
+      "name": "tool_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolName": {
+          "name": "toolName",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executedAt": {
+          "name": "executedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tool_executions_executionId_agent_executions_id_fk": {
+          "name": "tool_executions_executionId_agent_executions_id_fk",
+          "tableFrom": "tool_executions",
+          "tableTo": "agent_executions",
+          "columnsFrom": [
+            "executionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gemini_token_usage": {
+      "name": "gemini_token_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputTokens": {
+          "name": "inputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "outputTokens": {
+          "name": "outputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputCost": {
+          "name": "inputCost",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outputCost": {
+          "name": "outputCost",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalCost": {
+          "name": "totalCost",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promptType": {
+          "name": "promptType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolsUsed": {
+          "name": "toolsUsed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responseTime": {
+          "name": "responseTime",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finishReason": {
+          "name": "finishReason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gemini_token_usage_user_id_idx": {
+          "name": "gemini_token_usage_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gemini_token_usage_execution_id_idx": {
+          "name": "gemini_token_usage_execution_id_idx",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gemini_token_usage_model_idx": {
+          "name": "gemini_token_usage_model_idx",
+          "columns": [
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gemini_token_usage_created_at_idx": {
+          "name": "gemini_token_usage_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gemini_token_usage_user_created_idx": {
+          "name": "gemini_token_usage_user_created_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gemini_token_usage_userId_users_id_fk": {
+          "name": "gemini_token_usage_userId_users_id_fk",
+          "tableFrom": "gemini_token_usage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gemini_token_usage_executionId_task_executions_id_fk": {
+          "name": "gemini_token_usage_executionId_task_executions_id_fk",
+          "tableFrom": "gemini_token_usage",
+          "tableTo": "task_executions",
+          "columnsFrom": [
+            "executionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.storage_costs": {
+      "name": "storage_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operationId": {
+          "name": "operationId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operationType": {
+          "name": "operationType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objectKey": {
+          "name": "objectKey",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sizeMb": {
+          "name": "sizeMb",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "storageCostPerGb": {
+          "name": "storageCostPerGb",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.023'"
+        },
+        "transferCostPerGb": {
+          "name": "transferCostPerGb",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.09'"
+        },
+        "requestCost": {
+          "name": "requestCost",
+          "type": "numeric(10, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "totalCost": {
+          "name": "totalCost",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_costs_user_id_idx": {
+          "name": "storage_costs_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_costs_execution_id_idx": {
+          "name": "storage_costs_execution_id_idx",
+          "columns": [
+            {
+              "expression": "executionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_costs_provider_idx": {
+          "name": "storage_costs_provider_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_costs_operation_type_idx": {
+          "name": "storage_costs_operation_type_idx",
+          "columns": [
+            {
+              "expression": "operationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_costs_created_at_idx": {
+          "name": "storage_costs_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_costs_user_created_idx": {
+          "name": "storage_costs_user_created_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_costs_userId_users_id_fk": {
+          "name": "storage_costs_userId_users_id_fk",
+          "tableFrom": "storage_costs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_costs_executionId_task_executions_id_fk": {
+          "name": "storage_costs_executionId_task_executions_id_fk",
+          "tableFrom": "storage_costs",
+          "tableTo": "task_executions",
+          "columnsFrom": [
+            "executionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action_patterns": {
+      "name": "action_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_name": {
+          "name": "task_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_executed": {
+          "name": "last_executed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "action_patterns_task_type_idx": {
+          "name": "action_patterns_task_type_idx",
+          "columns": [
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "action_patterns_user_id_idx": {
+          "name": "action_patterns_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "action_patterns_user_id_users_id_fk": {
+          "name": "action_patterns_user_id_users_id_fk",
+          "tableFrom": "action_patterns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_feedback": {
+      "name": "agent_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "execution_id": {
+          "name": "execution_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback_type": {
+          "name": "feedback_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions_taken": {
+          "name": "actions_taken",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "corrections": {
+          "name": "corrections",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_feedback_user_id_idx": {
+          "name": "agent_feedback_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_feedback_task_type_idx": {
+          "name": "agent_feedback_task_type_idx",
+          "columns": [
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_feedback_rating_idx": {
+          "name": "agent_feedback_rating_idx",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_feedback_user_id_users_id_fk": {
+          "name": "agent_feedback_user_id_users_id_fk",
+          "tableFrom": "agent_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brand_voices": {
+      "name": "brand_voices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tone": {
+          "name": "tone",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "vocabulary": {
+          "name": "vocabulary",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avoid_words": {
+          "name": "avoid_words",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "examples": {
+          "name": "examples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "industry": {
+          "name": "industry",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_audience": {
+          "name": "target_audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "brand_voices_client_id_idx": {
+          "name": "brand_voices_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "brand_voices_user_id_idx": {
+          "name": "brand_voices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brand_voices_user_id_users_id_fk": {
+          "name": "brand_voices_user_id_users_id_fk",
+          "tableFrom": "brand_voices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_contexts": {
+      "name": "client_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_type": {
+          "name": "business_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "industry": {
+          "name": "industry",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_market": {
+          "name": "target_market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "products": {
+          "name": "products",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "services": {
+          "name": "services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "key_values": {
+          "name": "key_values",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "competitors": {
+          "name": "competitors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "unique_selling_points": {
+          "name": "unique_selling_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "customer_personas": {
+          "name": "customer_personas",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "custom_fields": {
+          "name": "custom_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "client_contexts_client_id_idx": {
+          "name": "client_contexts_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_contexts_user_id_idx": {
+          "name": "client_contexts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_contexts_industry_idx": {
+          "name": "client_contexts_industry_idx",
+          "columns": [
+            {
+              "expression": "industry",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "client_contexts_user_id_users_id_fk": {
+          "name": "client_contexts_user_id_users_id_fk",
+          "tableFrom": "client_contexts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.element_selectors": {
+      "name": "element_selectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_path": {
+          "name": "page_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "element_name": {
+          "name": "element_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_selector": {
+          "name": "primary_selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_selectors": {
+          "name": "fallback_selectors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "success_rate": {
+          "name": "success_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "total_attempts": {
+          "name": "total_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshot_ref": {
+          "name": "screenshot_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "element_selectors_page_path_idx": {
+          "name": "element_selectors_page_path_idx",
+          "columns": [
+            {
+              "expression": "page_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "element_selectors_element_name_idx": {
+          "name": "element_selectors_element_name_idx",
+          "columns": [
+            {
+              "expression": "element_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "element_selectors_user_id_idx": {
+          "name": "element_selectors_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "element_selectors_user_id_users_id_fk": {
+          "name": "element_selectors_user_id_users_id_fk",
+          "tableFrom": "element_selectors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.error_patterns": {
+      "name": "error_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_strategies": {
+          "name": "recovery_strategies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_count": {
+          "name": "resolved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_occurred": {
+          "name": "last_occurred",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "error_patterns_error_type_idx": {
+          "name": "error_patterns_error_type_idx",
+          "columns": [
+            {
+              "expression": "error_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_patterns_context_idx": {
+          "name": "error_patterns_context_idx",
+          "columns": [
+            {
+              "expression": "context",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "error_patterns_user_id_idx": {
+          "name": "error_patterns_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "error_patterns_user_id_users_id_fk": {
+          "name": "error_patterns_user_id_users_id_fk",
+          "tableFrom": "error_patterns",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documentation_chunks": {
+      "name": "documentation_chunks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chunkIndex": {
+          "name": "chunkIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenCount": {
+          "name": "tokenCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "documentation_chunks_sourceId_documentation_sources_id_fk": {
+          "name": "documentation_chunks_sourceId_documentation_sources_id_fk",
+          "tableFrom": "documentation_chunks",
+          "tableTo": "documentation_sources",
+          "columnsFrom": [
+            "sourceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documentation_sources": {
+      "name": "documentation_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceUrl": {
+          "name": "sourceUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "documentation_sources_userId_users_id_fk": {
+          "name": "documentation_sources_userId_users_id_fk",
+          "tableFrom": "documentation_sources",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_keywords": {
+      "name": "platform_keywords",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyword": {
+          "name": "keyword",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.action_approvals": {
+      "name": "action_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionType": {
+          "name": "actionType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionDescription": {
+          "name": "actionDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionParams": {
+          "name": "actionParams",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "riskLevel": {
+          "name": "riskLevel",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "riskFactors": {
+          "name": "riskFactors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screenshotUrl": {
+          "name": "screenshotUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approvedAt": {
+          "name": "approvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectedAt": {
+          "name": "rejectedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectionReason": {
+          "name": "rejectionReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeoutAction": {
+          "name": "timeoutAction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'reject'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "action_approvals_userId_users_id_fk": {
+          "name": "action_approvals_userId_users_id_fk",
+          "tableFrom": "action_approvals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.browser_contexts": {
+      "name": "browser_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextId": {
+          "name": "contextId",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isolationLevel": {
+          "name": "isolationLevel",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'strict'"
+        },
+        "encryptedStorage": {
+          "name": "encryptedStorage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageIv": {
+          "name": "storageIv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageAuthTag": {
+          "name": "storageAuthTag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeSessionCount": {
+          "name": "activeSessionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "browser_contexts_userId_users_id_fk": {
+          "name": "browser_contexts_userId_users_id_fk",
+          "tableFrom": "browser_contexts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "browser_contexts_contextId_unique": {
+          "name": "browser_contexts_contextId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contextId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedData": {
+          "name": "encryptedData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authTag": {
+          "name": "authTag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "useCount": {
+          "name": "useCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credentials_userId_users_id_fk": {
+          "name": "credentials_userId_users_id_fk",
+          "tableFrom": "credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execution_controls": {
+      "name": "execution_controls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "executionId": {
+          "name": "executionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "controlState": {
+          "name": "controlState",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stateReason": {
+          "name": "stateReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "injectedInstruction": {
+          "name": "injectedInstruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "injectedAt": {
+          "name": "injectedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkpointData": {
+          "name": "checkpointData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastStateChange": {
+          "name": "lastStateChange",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "execution_controls_userId_users_id_fk": {
+          "name": "execution_controls_userId_users_id_fk",
+          "tableFrom": "execution_controls",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "execution_controls_executionId_unique": {
+          "name": "execution_controls_executionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "executionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "security_audit_log_userId_users_id_fk": {
+          "name": "security_audit_log_userId_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_edit_history": {
+      "name": "knowledge_edit_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "knowledgeEntryId": {
+          "name": "knowledgeEntryId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changeType": {
+          "name": "changeType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousContent": {
+          "name": "previousContent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newContent": {
+          "name": "newContent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousCategory": {
+          "name": "previousCategory",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newCategory": {
+          "name": "newCategory",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousSnapshot": {
+          "name": "previousSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newSnapshot": {
+          "name": "newSnapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_edit_history_userId_users_id_fk": {
+          "name": "knowledge_edit_history_userId_users_id_fk",
+          "tableFrom": "knowledge_edit_history",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_feedback": {
+      "name": "knowledge_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "knowledgeEntryId": {
+          "name": "knowledgeEntryId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedbackType": {
+          "name": "feedbackType",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggestedCorrection": {
+          "name": "suggestedCorrection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionContext": {
+          "name": "executionContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolvedBy": {
+          "name": "resolvedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_feedback_userId_users_id_fk": {
+          "name": "knowledge_feedback_userId_users_id_fk",
+          "tableFrom": "knowledge_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "knowledge_feedback_resolvedBy_users_id_fk": {
+          "name": "knowledge_feedback_resolvedBy_users_id_fk",
+          "tableFrom": "knowledge_feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolvedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.knowledge_suggestions": {
+      "name": "knowledge_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestedContent": {
+          "name": "suggestedContent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceType": {
+          "name": "sourceType",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceContext": {
+          "name": "sourceContext",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(3, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.75'"
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reviewedBy": {
+          "name": "reviewedBy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewedAt": {
+          "name": "reviewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewNotes": {
+          "name": "reviewNotes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "knowledgeEntryId": {
+          "name": "knowledgeEntryId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "similarTo": {
+          "name": "similarTo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_suggestions_userId_users_id_fk": {
+          "name": "knowledge_suggestions_userId_users_id_fk",
+          "tableFrom": "knowledge_suggestions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "knowledge_suggestions_reviewedBy_users_id_fk": {
+          "name": "knowledge_suggestions_reviewedBy_users_id_fk",
+          "tableFrom": "knowledge_suggestions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sop_categories": {
+      "name": "sop_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sop_categories_userId_users_id_fk": {
+          "name": "sop_categories_userId_users_id_fk",
+          "tableFrom": "sop_categories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sop_documents": {
+      "name": "sop_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categoryId": {
+          "name": "categoryId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "applicableTo": {
+          "name": "applicableTo",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggers": {
+          "name": "triggers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimatedDuration": {
+          "name": "estimatedDuration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'medium'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiEnabled": {
+          "name": "aiEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "humanApprovalRequired": {
+          "name": "humanApprovalRequired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "automationLevel": {
+          "name": "automationLevel",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'semi'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastExecutedAt": {
+          "name": "lastExecutedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executionCount": {
+          "name": "executionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "successRate": {
+          "name": "successRate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sop_documents_userId_users_id_fk": {
+          "name": "sop_documents_userId_users_id_fk",
+          "tableFrom": "sop_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sop_documents_categoryId_sop_categories_id_fk": {
+          "name": "sop_documents_categoryId_sop_categories_id_fk",
+          "tableFrom": "sop_documents",
+          "tableTo": "sop_categories",
+          "columnsFrom": [
+            "categoryId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sop_executions": {
+      "name": "sop_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sopId": {
+          "name": "sopId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "executorType": {
+          "name": "executorType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentSessionId": {
+          "name": "agentSessionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "currentStepIndex": {
+          "name": "currentStepIndex",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stepResults": {
+          "name": "stepResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issues": {
+          "name": "issues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sop_executions_sopId_sop_documents_id_fk": {
+          "name": "sop_executions_sopId_sop_documents_id_fk",
+          "tableFrom": "sop_executions",
+          "tableTo": "sop_documents",
+          "columnsFrom": [
+            "sopId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sop_executions_userId_users_id_fk": {
+          "name": "sop_executions_userId_users_id_fk",
+          "tableFrom": "sop_executions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sop_steps": {
+      "name": "sop_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sopId": {
+          "name": "sopId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stepNumber": {
+          "name": "stepNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionType": {
+          "name": "actionType",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "actionConfig": {
+          "name": "actionConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alternatives": {
+          "name": "alternatives",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expectedOutcome": {
+          "name": "expectedOutcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "validationCriteria": {
+          "name": "validationCriteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errorHandling": {
+          "name": "errorHandling",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "examples": {
+          "name": "examples",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tips": {
+          "name": "tips",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimatedDuration": {
+          "name": "estimatedDuration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependsOn": {
+          "name": "dependsOn",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sop_steps_sopId_sop_documents_id_fk": {
+          "name": "sop_steps_sopId_sop_documents_id_fk",
+          "tableFrom": "sop_steps",
+          "tableTo": "sop_documents",
+          "columnsFrom": [
+            "sopId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sop_versions": {
+      "name": "sop_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sopId": {
+          "name": "sopId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changeType": {
+          "name": "changeType",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changeSummary": {
+          "name": "changeSummary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sop_versions_sopId_sop_documents_id_fk": {
+          "name": "sop_versions_sopId_sop_documents_id_fk",
+          "tableFrom": "sop_versions",
+          "tableTo": "sop_documents",
+          "columnsFrom": [
+            "sopId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sop_versions_userId_users_id_fk": {
+          "name": "sop_versions_userId_users_id_fk",
+          "tableFrom": "sop_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_template_categories": {
+      "name": "task_template_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sortOrder": {
+          "name": "sortOrder",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_template_categories_slug_unique": {
+          "name": "task_template_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_templates": {
+      "name": "task_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categorySlug": {
+          "name": "categorySlug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taskType": {
+          "name": "taskType",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "assignedToBot": {
+          "name": "assignedToBot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "requiresHumanReview": {
+          "name": "requiresHumanReview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "executionType": {
+          "name": "executionType",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'automatic'"
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'"
+        },
+        "executionConfig": {
+          "name": "executionConfig",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defaultTags": {
+          "name": "defaultTags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'"
+        },
+        "estimatedDuration": {
+          "name": "estimatedDuration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'beginner'"
+        },
+        "isSystem": {
+          "name": "isSystem",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPublished": {
+          "name": "isPublished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "usageCount": {
+          "name": "usageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_templates_category_idx": {
+          "name": "task_templates_category_idx",
+          "columns": [
+            {
+              "expression": "categorySlug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_templates_user_idx": {
+          "name": "task_templates_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_templates_system_idx": {
+          "name": "task_templates_system_idx",
+          "columns": [
+            {
+              "expression": "isSystem",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_templates_userId_users_id_fk": {
+          "name": "task_templates_userId_users_id_fk",
+          "tableFrom": "task_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rag_action_sequences": {
+      "name": "rag_action_sequences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "website_id": {
+          "name": "website_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_instruction": {
+          "name": "trigger_instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_keywords": {
+          "name": "trigger_keywords",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_outcome": {
+          "name": "expected_outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success_indicator": {
+          "name": "success_indicator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_execution_time": {
+          "name": "avg_execution_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success_rate": {
+          "name": "success_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "execution_count": {
+          "name": "execution_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rag_action_sequences_website_idx": {
+          "name": "rag_action_sequences_website_idx",
+          "columns": [
+            {
+              "expression": "website_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_action_sequences_task_idx": {
+          "name": "rag_action_sequences_task_idx",
+          "columns": [
+            {
+              "expression": "task_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_action_sequences_success_idx": {
+          "name": "rag_action_sequences_success_idx",
+          "columns": [
+            {
+              "expression": "success_rate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_action_sequences_website_name_unique": {
+          "name": "rag_action_sequences_website_name_unique",
+          "columns": [
+            {
+              "expression": "website_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rag_action_sequences_website_id_rag_websites_id_fk": {
+          "name": "rag_action_sequences_website_id_rag_websites_id_fk",
+          "tableFrom": "rag_action_sequences",
+          "tableTo": "rag_websites",
+          "columnsFrom": [
+            "website_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rag_element_selectors": {
+      "name": "rag_element_selectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_id": {
+          "name": "website_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "element_name": {
+          "name": "element_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "element_type": {
+          "name": "element_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_selector": {
+          "name": "primary_selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_selectors": {
+          "name": "fallback_selectors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xpath_selector": {
+          "name": "xpath_selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aria_label": {
+          "name": "aria_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "reliability_score": {
+          "name": "reliability_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "last_success": {
+          "name": "last_success",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_failure": {
+          "name": "last_failure",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rag_element_selectors_website_idx": {
+          "name": "rag_element_selectors_website_idx",
+          "columns": [
+            {
+              "expression": "website_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_element_selectors_page_idx": {
+          "name": "rag_element_selectors_page_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_element_selectors_type_idx": {
+          "name": "rag_element_selectors_type_idx",
+          "columns": [
+            {
+              "expression": "element_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_element_selectors_reliability_idx": {
+          "name": "rag_element_selectors_reliability_idx",
+          "columns": [
+            {
+              "expression": "reliability_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_element_selectors_website_element_unique": {
+          "name": "rag_element_selectors_website_element_unique",
+          "columns": [
+            {
+              "expression": "website_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "element_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rag_element_selectors_page_id_rag_page_knowledge_id_fk": {
+          "name": "rag_element_selectors_page_id_rag_page_knowledge_id_fk",
+          "tableFrom": "rag_element_selectors",
+          "tableTo": "rag_page_knowledge",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rag_element_selectors_website_id_rag_websites_id_fk": {
+          "name": "rag_element_selectors_website_id_rag_websites_id_fk",
+          "tableFrom": "rag_element_selectors",
+          "tableTo": "rag_websites",
+          "columnsFrom": [
+            "website_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rag_error_patterns": {
+      "name": "rag_error_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "website_id": {
+          "name": "website_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_pattern": {
+          "name": "error_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_strategy": {
+          "name": "recovery_strategy",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_steps": {
+          "name": "recovery_steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "retry_delay": {
+          "name": "retry_delay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1000
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "recovery_success_count": {
+          "name": "recovery_success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "recovery_rate": {
+          "name": "recovery_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rag_error_patterns_website_idx": {
+          "name": "rag_error_patterns_website_idx",
+          "columns": [
+            {
+              "expression": "website_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_error_patterns_type_idx": {
+          "name": "rag_error_patterns_type_idx",
+          "columns": [
+            {
+              "expression": "error_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rag_error_patterns_website_id_rag_websites_id_fk": {
+          "name": "rag_error_patterns_website_id_rag_websites_id_fk",
+          "tableFrom": "rag_error_patterns",
+          "tableTo": "rag_websites",
+          "columnsFrom": [
+            "website_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rag_execution_logs": {
+      "name": "rag_execution_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "website_id": {
+          "name": "website_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_sequence_id": {
+          "name": "action_sequence_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recovery_attempts": {
+          "name": "recovery_attempts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "final_state": {
+          "name": "final_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rag_execution_logs_website_idx": {
+          "name": "rag_execution_logs_website_idx",
+          "columns": [
+            {
+              "expression": "website_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_execution_logs_sequence_idx": {
+          "name": "rag_execution_logs_sequence_idx",
+          "columns": [
+            {
+              "expression": "action_sequence_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_execution_logs_success_idx": {
+          "name": "rag_execution_logs_success_idx",
+          "columns": [
+            {
+              "expression": "success",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_execution_logs_created_idx": {
+          "name": "rag_execution_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rag_execution_logs_website_id_rag_websites_id_fk": {
+          "name": "rag_execution_logs_website_id_rag_websites_id_fk",
+          "tableFrom": "rag_execution_logs",
+          "tableTo": "rag_websites",
+          "columnsFrom": [
+            "website_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "rag_execution_logs_action_sequence_id_rag_action_sequences_id_fk": {
+          "name": "rag_execution_logs_action_sequence_id_rag_action_sequences_id_fk",
+          "tableFrom": "rag_execution_logs",
+          "tableTo": "rag_action_sequences",
+          "columnsFrom": [
+            "action_sequence_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rag_page_knowledge": {
+      "name": "rag_page_knowledge",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "website_id": {
+          "name": "website_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_pattern": {
+          "name": "url_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_name": {
+          "name": "page_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_type": {
+          "name": "page_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_content_selector": {
+          "name": "main_content_selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "navigation_selector": {
+          "name": "navigation_selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "load_indicator": {
+          "name": "load_indicator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dom_snapshot": {
+          "name": "dom_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessibility_tree": {
+          "name": "accessibility_tree",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "known_elements": {
+          "name": "known_elements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "last_verified": {
+          "name": "last_verified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rag_page_knowledge_website_idx": {
+          "name": "rag_page_knowledge_website_idx",
+          "columns": [
+            {
+              "expression": "website_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_page_knowledge_type_idx": {
+          "name": "rag_page_knowledge_type_idx",
+          "columns": [
+            {
+              "expression": "page_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rag_page_knowledge_website_id_rag_websites_id_fk": {
+          "name": "rag_page_knowledge_website_id_rag_websites_id_fk",
+          "tableFrom": "rag_page_knowledge",
+          "tableTo": "rag_websites",
+          "columnsFrom": [
+            "website_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rag_support_documents": {
+      "name": "rag_support_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "website_id": {
+          "name": "website_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "parent_document_id": {
+          "name": "parent_document_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retrieval_count": {
+          "name": "retrieval_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "helpfulness_score": {
+          "name": "helpfulness_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rag_support_docs_website_idx": {
+          "name": "rag_support_docs_website_idx",
+          "columns": [
+            {
+              "expression": "website_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "rag_support_docs_type_idx": {
+          "name": "rag_support_docs_type_idx",
+          "columns": [
+            {
+              "expression": "document_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rag_support_documents_website_id_rag_websites_id_fk": {
+          "name": "rag_support_documents_website_id_rag_websites_id_fk",
+          "tableFrom": "rag_support_documents",
+          "tableTo": "rag_websites",
+          "columnsFrom": [
+            "website_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rag_websites": {
+      "name": "rag_websites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_url": {
+          "name": "login_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dashboard_url": {
+          "name": "dashboard_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_auth": {
+          "name": "requires_auth",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_timeout": {
+          "name": "default_timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30000
+        },
+        "wait_for_selector": {
+          "name": "wait_for_selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "load_strategy": {
+          "name": "load_strategy",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'domcontentloaded'"
+        },
+        "avg_load_time": {
+          "name": "avg_load_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reliability_score": {
+          "name": "reliability_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "last_crawled": {
+          "name": "last_crawled",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rag_websites_domain_idx": {
+          "name": "rag_websites_domain_idx",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rag_websites_domain_unique": {
+          "name": "rag_websites_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/schema-ghl-webhook-events.ts
+++ b/drizzle/schema-ghl-webhook-events.ts
@@ -1,0 +1,130 @@
+/**
+ * GHL Webhook Processing Schema
+ *
+ * Tables for synced contacts, opportunities, webhook event dedup,
+ * and dead letter queue for failed webhook processing.
+ *
+ * Linear: AI-3461
+ */
+
+import {
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar,
+  integer,
+  boolean,
+  jsonb,
+  index,
+  uniqueIndex,
+  numeric,
+} from "drizzle-orm/pg-core";
+import { users } from "./schema";
+
+// ========================================
+// GHL CONTACTS (synced from webhooks)
+// ========================================
+
+export const ghlContacts = pgTable("ghl_contacts", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  ghlContactId: varchar("ghlContactId", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }).notNull(),
+  firstName: text("firstName"),
+  lastName: text("lastName"),
+  email: varchar("email", { length: 320 }),
+  phone: varchar("phone", { length: 30 }),
+  tags: jsonb("tags").$type<string[]>(),
+  source: varchar("source", { length: 128 }),
+  customFields: jsonb("customFields").$type<Array<{ id: string; value: string }>>(),
+  lastWebhookAt: timestamp("lastWebhookAt").notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  ghlContactIdx: uniqueIndex("ghl_contacts_ghl_id_idx").on(table.ghlContactId, table.locationId),
+  userIdx: index("ghl_contacts_user_idx").on(table.userId),
+  locationIdx: index("ghl_contacts_location_idx").on(table.locationId),
+  emailIdx: index("ghl_contacts_email_idx").on(table.email),
+}));
+
+export type GHLContactRow = typeof ghlContacts.$inferSelect;
+export type InsertGHLContact = typeof ghlContacts.$inferInsert;
+
+// ========================================
+// GHL OPPORTUNITIES (synced from webhooks)
+// ========================================
+
+export const ghlOpportunities = pgTable("ghl_opportunities", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  ghlOpportunityId: varchar("ghlOpportunityId", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }).notNull(),
+  name: text("name"),
+  pipelineId: varchar("pipelineId", { length: 128 }),
+  pipelineStageId: varchar("pipelineStageId", { length: 128 }),
+  status: varchar("status", { length: 64 }),
+  monetaryValue: numeric("monetaryValue", { precision: 12, scale: 2 }),
+  ghlContactId: varchar("ghlContactId", { length: 128 }),
+  lastWebhookAt: timestamp("lastWebhookAt").notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  ghlOppIdx: uniqueIndex("ghl_opportunities_ghl_id_idx").on(table.ghlOpportunityId, table.locationId),
+  userIdx: index("ghl_opportunities_user_idx").on(table.userId),
+  locationIdx: index("ghl_opportunities_location_idx").on(table.locationId),
+  pipelineIdx: index("ghl_opportunities_pipeline_idx").on(table.pipelineId),
+  statusIdx: index("ghl_opportunities_status_idx").on(table.status),
+}));
+
+export type GHLOpportunityRow = typeof ghlOpportunities.$inferSelect;
+export type InsertGHLOpportunity = typeof ghlOpportunities.$inferInsert;
+
+// ========================================
+// WEBHOOK EVENT LOG (for dedup)
+// ========================================
+
+export const ghlWebhookEvents = pgTable("ghl_webhook_events", {
+  id: serial("id").primaryKey(),
+  eventId: varchar("eventId", { length: 256 }).notNull().unique(),
+  eventType: varchar("eventType", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }),
+  processedAt: timestamp("processedAt").defaultNow().notNull(),
+  /** Whether processing completed successfully */
+  success: boolean("success").notNull(),
+}, (table) => ({
+  eventIdIdx: uniqueIndex("ghl_webhook_events_event_id_idx").on(table.eventId),
+  eventTypeIdx: index("ghl_webhook_events_type_idx").on(table.eventType),
+  processedAtIdx: index("ghl_webhook_events_processed_at_idx").on(table.processedAt),
+}));
+
+export type GHLWebhookEventRow = typeof ghlWebhookEvents.$inferSelect;
+export type InsertGHLWebhookEvent = typeof ghlWebhookEvents.$inferInsert;
+
+// ========================================
+// DEAD LETTER QUEUE (failed webhook events)
+// ========================================
+
+export const ghlWebhookDeadLetters = pgTable("ghl_webhook_dead_letters", {
+  id: serial("id").primaryKey(),
+  eventId: varchar("eventId", { length: 256 }),
+  eventType: varchar("eventType", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }),
+  payload: jsonb("payload").notNull(),
+  error: text("error").notNull(),
+  retryCount: integer("retryCount").default(0).notNull(),
+  maxRetries: integer("maxRetries").default(3).notNull(),
+  /** null = pending retry, timestamp = last retry attempt */
+  lastRetriedAt: timestamp("lastRetriedAt"),
+  /** Whether this DLQ entry has been resolved (retried successfully or manually dismissed) */
+  resolved: boolean("resolved").default(false).notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  resolvedIdx: index("ghl_webhook_dlq_resolved_idx").on(table.resolved),
+  eventTypeIdx: index("ghl_webhook_dlq_type_idx").on(table.eventType),
+  createdAtIdx: index("ghl_webhook_dlq_created_at_idx").on(table.createdAt),
+}));
+
+export type GHLWebhookDeadLetterRow = typeof ghlWebhookDeadLetters.$inferSelect;
+export type InsertGHLWebhookDeadLetter = typeof ghlWebhookDeadLetters.$inferInsert;

--- a/drizzle/schema-ghl-webhooks.ts
+++ b/drizzle/schema-ghl-webhooks.ts
@@ -1,0 +1,130 @@
+/**
+ * GHL Webhook Processing Schema
+ *
+ * Tables for synced contacts, opportunities, webhook event dedup,
+ * and dead letter queue for failed webhook processing.
+ *
+ * Linear: AI-5147
+ */
+
+import {
+  pgTable,
+  serial,
+  text,
+  timestamp,
+  varchar,
+  integer,
+  boolean,
+  jsonb,
+  index,
+  uniqueIndex,
+  numeric,
+} from "drizzle-orm/pg-core";
+import { users } from "./schema";
+
+// ========================================
+// GHL CONTACTS (synced from webhooks)
+// ========================================
+
+export const ghlContacts = pgTable("ghl_contacts", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  ghlContactId: varchar("ghlContactId", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }).notNull(),
+  firstName: text("firstName"),
+  lastName: text("lastName"),
+  email: varchar("email", { length: 320 }),
+  phone: varchar("phone", { length: 30 }),
+  tags: jsonb("tags").$type<string[]>(),
+  source: varchar("source", { length: 128 }),
+  customFields: jsonb("customFields").$type<Array<{ id: string; value: string }>>(),
+  lastWebhookAt: timestamp("lastWebhookAt").notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  ghlContactIdx: uniqueIndex("ghl_contacts_ghl_id_idx").on(table.ghlContactId, table.locationId),
+  userIdx: index("ghl_contacts_user_idx").on(table.userId),
+  locationIdx: index("ghl_contacts_location_idx").on(table.locationId),
+  emailIdx: index("ghl_contacts_email_idx").on(table.email),
+}));
+
+export type GHLContactRow = typeof ghlContacts.$inferSelect;
+export type InsertGHLContact = typeof ghlContacts.$inferInsert;
+
+// ========================================
+// GHL OPPORTUNITIES (synced from webhooks)
+// ========================================
+
+export const ghlOpportunities = pgTable("ghl_opportunities", {
+  id: serial("id").primaryKey(),
+  userId: integer("userId").references(() => users.id).notNull(),
+  ghlOpportunityId: varchar("ghlOpportunityId", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }).notNull(),
+  name: text("name"),
+  pipelineId: varchar("pipelineId", { length: 128 }),
+  pipelineStageId: varchar("pipelineStageId", { length: 128 }),
+  status: varchar("status", { length: 64 }),
+  monetaryValue: numeric("monetaryValue", { precision: 12, scale: 2 }),
+  ghlContactId: varchar("ghlContactId", { length: 128 }),
+  lastWebhookAt: timestamp("lastWebhookAt").notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  ghlOppIdx: uniqueIndex("ghl_opportunities_ghl_id_idx").on(table.ghlOpportunityId, table.locationId),
+  userIdx: index("ghl_opportunities_user_idx").on(table.userId),
+  locationIdx: index("ghl_opportunities_location_idx").on(table.locationId),
+  pipelineIdx: index("ghl_opportunities_pipeline_idx").on(table.pipelineId),
+  statusIdx: index("ghl_opportunities_status_idx").on(table.status),
+}));
+
+export type GHLOpportunityRow = typeof ghlOpportunities.$inferSelect;
+export type InsertGHLOpportunity = typeof ghlOpportunities.$inferInsert;
+
+// ========================================
+// WEBHOOK EVENT LOG (for dedup)
+// ========================================
+
+export const ghlWebhookEvents = pgTable("ghl_webhook_events", {
+  id: serial("id").primaryKey(),
+  eventId: varchar("eventId", { length: 256 }).notNull().unique(),
+  eventType: varchar("eventType", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }),
+  processedAt: timestamp("processedAt").defaultNow().notNull(),
+  /** Whether processing completed successfully */
+  success: boolean("success").notNull(),
+}, (table) => ({
+  eventIdIdx: uniqueIndex("ghl_webhook_events_event_id_idx").on(table.eventId),
+  eventTypeIdx: index("ghl_webhook_events_type_idx").on(table.eventType),
+  processedAtIdx: index("ghl_webhook_events_processed_at_idx").on(table.processedAt),
+}));
+
+export type GHLWebhookEventRow = typeof ghlWebhookEvents.$inferSelect;
+export type InsertGHLWebhookEvent = typeof ghlWebhookEvents.$inferInsert;
+
+// ========================================
+// DEAD LETTER QUEUE (failed webhook events)
+// ========================================
+
+export const ghlWebhookDeadLetters = pgTable("ghl_webhook_dead_letters", {
+  id: serial("id").primaryKey(),
+  eventId: varchar("eventId", { length: 256 }),
+  eventType: varchar("eventType", { length: 128 }).notNull(),
+  locationId: varchar("locationId", { length: 128 }),
+  payload: jsonb("payload").notNull(),
+  error: text("error").notNull(),
+  retryCount: integer("retryCount").default(0).notNull(),
+  maxRetries: integer("maxRetries").default(3).notNull(),
+  /** null = pending retry, timestamp = retried at */
+  lastRetriedAt: timestamp("lastRetriedAt"),
+  /** Whether this DLQ entry has been resolved (retried successfully or manually dismissed) */
+  resolved: boolean("resolved").default(false).notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+  updatedAt: timestamp("updatedAt").defaultNow().notNull(),
+}, (table) => ({
+  resolvedIdx: index("ghl_webhook_dlq_resolved_idx").on(table.resolved),
+  eventTypeIdx: index("ghl_webhook_dlq_type_idx").on(table.eventType),
+  createdAtIdx: index("ghl_webhook_dlq_created_at_idx").on(table.createdAt),
+}));
+
+export type GHLWebhookDeadLetterRow = typeof ghlWebhookDeadLetters.$inferSelect;
+export type InsertGHLWebhookDeadLetter = typeof ghlWebhookDeadLetters.$inferInsert;

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -711,3 +711,19 @@ export {
   type GHLActiveLocationRow,
   type InsertGHLActiveLocation,
 } from "./schema-ghl-locations";
+
+// GHL Webhook Event Processing (contacts, opportunities, dedup, DLQ)
+export {
+  ghlContacts,
+  ghlOpportunities,
+  ghlWebhookEvents,
+  ghlWebhookDeadLetters,
+  type GHLContactRow,
+  type InsertGHLContact,
+  type GHLOpportunityRow,
+  type InsertGHLOpportunity,
+  type GHLWebhookEventRow,
+  type InsertGHLWebhookEvent,
+  type GHLWebhookDeadLetterRow,
+  type InsertGHLWebhookDeadLetter,
+} from "./schema-ghl-webhook-events";

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -138,6 +138,7 @@ export async function createApp() {
   app.use("/api/webhooks/stripe", stripeWebhookRouter);
   // GHL OAuth routes (AI-2877)
   app.use("/api/ghl/oauth", ghlOAuthRouter);
+  // GHL Webhook receiver (AI-3461)
   app.use("/api/ghl/webhooks", ghlWebhookRouter);
 
   // Mount REST API v1 routes (includes /api/v1/health, /api/v1/tasks, etc.)

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -28,6 +28,7 @@ import {
 } from "../lib/sentry";
 import { createRestApi } from "../api/rest";
 import ghlOAuthRouter from "../api/routes/ghl-oauth";
+import ghlWebhookRouter from "../api/routes/ghl-webhooks";
 
 // Initialize Sentry as early as possible
 initSentry();
@@ -137,6 +138,7 @@ export async function createApp() {
   app.use("/api/webhooks/stripe", stripeWebhookRouter);
   // GHL OAuth routes (AI-2877)
   app.use("/api/ghl/oauth", ghlOAuthRouter);
+  app.use("/api/ghl/webhooks", ghlWebhookRouter);
 
   // Mount REST API v1 routes (includes /api/v1/health, /api/v1/tasks, etc.)
   const restApi = createRestApi();

--- a/server/_core/orgoClient.ts
+++ b/server/_core/orgoClient.ts
@@ -1,0 +1,413 @@
+/**
+ * Orgo Clone API Client
+ * HTTP client for the Orgo desktop VM infrastructure
+ *
+ * Orgo provides Docker-based desktop VMs (Xvfb + Fluxbox + VNC) with:
+ * - Desktop actions: screenshot, click, type, key, scroll, drag, exec, bash
+ * - OpenAI-compatible /v1/chat/completions with computer-use tool loops
+ * - Multi-model support: Claude, GPT, Gemini
+ *
+ * Configuration via env vars:
+ *   ORGO_API_URL       — base URL (default: http://localhost:3100)
+ *   ORGO_API_KEY       — API key (sk_live_...)
+ *   ORGO_WORKSPACE_ID  — default workspace ID
+ *
+ * Includes:
+ * - Retry logic with exponential backoff
+ * - Circuit breaker pattern for service protection
+ * - Comprehensive error handling
+ */
+
+import { withRetry, DEFAULT_RETRY_OPTIONS } from '../lib/retry';
+import { circuitBreakers } from '../lib/circuitBreaker';
+
+// ========================================
+// TYPES
+// ========================================
+
+export interface Computer {
+  id: string;
+  name: string;
+  status: 'creating' | 'running' | 'stopped' | 'error';
+  workspaceId?: string;
+  cpu?: number;
+  ramMb?: number;
+  diskGb?: number;
+  gpu?: boolean;
+  createdAt: string;
+  updatedAt?: string;
+  vncUrl?: string;
+  wsUrl?: string;
+}
+
+export interface ComputerCreateOptions {
+  name: string;
+  cpu?: number;
+  ramMb?: number;
+  diskGb?: number;
+  gpu?: boolean;
+  workspaceId?: string;
+}
+
+export interface ScreenshotResponse {
+  data: string;   // base64 PNG
+  width: number;
+  height: number;
+}
+
+export interface ExecResponse {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string | Array<{ type: string; [key: string]: unknown }>;
+}
+
+export interface ChatCompletionOptions {
+  model: string;
+  messages: ChatMessage[];
+  computerId?: string;
+  autoExecuteTools?: boolean;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface ChatResponse {
+  id: string;
+  object: string;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: {
+      role: string;
+      content: string | null;
+      tool_calls?: Array<{
+        id: string;
+        type: string;
+        function: { name: string; arguments: string };
+      }>;
+    };
+    finish_reason: string;
+  }>;
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+// ========================================
+// ERROR
+// ========================================
+
+export class OrgoClientError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly statusCode?: number,
+    public readonly originalError?: unknown
+  ) {
+    super(message);
+    this.name = 'OrgoClientError';
+  }
+}
+
+// ========================================
+// CLIENT
+// ========================================
+
+class OrgoClient {
+  private static instance: OrgoClient;
+  private readonly apiUrl: string;
+  private readonly apiKey: string | null;
+  private readonly workspaceId: string | null;
+
+  private constructor() {
+    this.apiUrl = process.env.ORGO_API_URL || 'http://localhost:3100';
+    this.apiKey = process.env.ORGO_API_KEY || null;
+    this.workspaceId = process.env.ORGO_WORKSPACE_ID || null;
+
+    if (!this.apiKey) {
+      console.warn(
+        '[OrgoClient] ORGO_API_KEY not found in environment variables. Orgo client will not be operational.'
+      );
+    } else {
+      console.log('[OrgoClient] Successfully initialized with URL:', this.apiUrl);
+    }
+  }
+
+  public static getInstance(): OrgoClient {
+    if (!OrgoClient.instance) {
+      OrgoClient.instance = new OrgoClient();
+    }
+    return OrgoClient.instance;
+  }
+
+  // ----------------------------------------
+  // Internal helpers
+  // ----------------------------------------
+
+  private getHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    }
+    return headers;
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown
+  ): Promise<T> {
+    const url = `${this.apiUrl}${path}`;
+
+    return circuitBreakers.orgo.execute(async () => {
+      return withRetry(async () => {
+        let response: Response;
+        try {
+          response = await fetch(url, {
+            method,
+            headers: this.getHeaders(),
+            body: body !== undefined ? JSON.stringify(body) : undefined,
+          });
+        } catch (err) {
+          throw new OrgoClientError(
+            `Network error reaching Orgo at ${url}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+            'NETWORK_ERROR',
+            undefined,
+            err
+          );
+        }
+
+        if (!response.ok) {
+          let errorBody = '';
+          try {
+            errorBody = await response.text();
+          } catch {
+            // ignore
+          }
+          throw new OrgoClientError(
+            `Orgo API error ${response.status} ${response.statusText}${errorBody ? ': ' + errorBody : ''}`,
+            'API_ERROR',
+            response.status
+          );
+        }
+
+        // 204 No Content
+        if (response.status === 204) {
+          return undefined as unknown as T;
+        }
+
+        try {
+          return (await response.json()) as T;
+        } catch (err) {
+          throw new OrgoClientError(
+            'Failed to parse Orgo API response as JSON',
+            'PARSE_ERROR',
+            response.status,
+            err
+          );
+        }
+      }, {
+        ...DEFAULT_RETRY_OPTIONS,
+        maxAttempts: 3,
+        initialDelayMs: 1000,
+        maxDelayMs: 10000,
+      });
+    });
+  }
+
+  // ----------------------------------------
+  // Computer lifecycle
+  // ----------------------------------------
+
+  public async createComputer(opts: ComputerCreateOptions): Promise<Computer> {
+    const body: Record<string, unknown> = { name: opts.name };
+    if (opts.cpu !== undefined) body.cpu = opts.cpu;
+    if (opts.ramMb !== undefined) body.ramMb = opts.ramMb;
+    if (opts.diskGb !== undefined) body.diskGb = opts.diskGb;
+    if (opts.gpu !== undefined) body.gpu = opts.gpu;
+    if (opts.workspaceId || this.workspaceId) {
+      body.workspaceId = opts.workspaceId || this.workspaceId;
+    }
+
+    console.log('[OrgoClient] Creating computer:', opts.name);
+    const result = await this.request<Computer>('POST', '/api/v1/computers', body);
+    console.log('[OrgoClient] Computer created:', result.id);
+    return result;
+  }
+
+  public async getComputer(id: string): Promise<Computer> {
+    return this.request<Computer>('GET', `/api/v1/computers/${id}`);
+  }
+
+  public async listComputers(): Promise<Computer[]> {
+    const result = await this.request<Computer[] | { computers: Computer[] }>('GET', '/api/v1/computers');
+    // Handle both array and wrapped responses
+    if (Array.isArray(result)) return result;
+    return (result as { computers: Computer[] }).computers || [];
+  }
+
+  public async startComputer(id: string): Promise<void> {
+    console.log('[OrgoClient] Starting computer:', id);
+    await this.request<void>('POST', `/api/v1/computers/${id}/start`);
+  }
+
+  public async stopComputer(id: string): Promise<void> {
+    console.log('[OrgoClient] Stopping computer:', id);
+    await this.request<void>('POST', `/api/v1/computers/${id}/stop`);
+  }
+
+  public async destroyComputer(id: string): Promise<void> {
+    console.log('[OrgoClient] Destroying computer:', id);
+    await this.request<void>('DELETE', `/api/v1/computers/${id}`);
+  }
+
+  // ----------------------------------------
+  // Desktop actions
+  // ----------------------------------------
+
+  public async screenshot(computerId: string): Promise<ScreenshotResponse> {
+    return this.request<ScreenshotResponse>('GET', `/api/v1/computers/${computerId}/screenshot`);
+  }
+
+  public async click(
+    computerId: string,
+    x: number,
+    y: number,
+    button: 'left' | 'right' | 'middle' = 'left'
+  ): Promise<void> {
+    await this.request<void>('POST', `/api/v1/computers/${computerId}/click`, { x, y, button });
+  }
+
+  public async doubleClick(computerId: string, x: number, y: number): Promise<void> {
+    await this.request<void>('POST', `/api/v1/computers/${computerId}/click`, {
+      x,
+      y,
+      button: 'left',
+      double: true,
+    });
+  }
+
+  public async type(computerId: string, text: string): Promise<void> {
+    await this.request<void>('POST', `/api/v1/computers/${computerId}/type`, { text });
+  }
+
+  public async keyPress(
+    computerId: string,
+    key: string,
+    modifiers?: string[]
+  ): Promise<void> {
+    await this.request<void>('POST', `/api/v1/computers/${computerId}/key`, {
+      key,
+      modifiers: modifiers || [],
+    });
+  }
+
+  public async scroll(
+    computerId: string,
+    x: number,
+    y: number,
+    deltaX: number,
+    deltaY: number
+  ): Promise<void> {
+    await this.request<void>('POST', `/api/v1/computers/${computerId}/scroll`, {
+      x,
+      y,
+      deltaX,
+      deltaY,
+    });
+  }
+
+  public async drag(
+    computerId: string,
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number
+  ): Promise<void> {
+    await this.request<void>('POST', `/api/v1/computers/${computerId}/drag`, {
+      startX,
+      startY,
+      endX,
+      endY,
+    });
+  }
+
+  public async exec(computerId: string, command: string[]): Promise<ExecResponse> {
+    return this.request<ExecResponse>('POST', `/api/v1/computers/${computerId}/exec`, {
+      command,
+    });
+  }
+
+  public async bash(computerId: string, command: string): Promise<ExecResponse> {
+    return this.request<ExecResponse>('POST', `/api/v1/computers/${computerId}/bash`, {
+      command,
+    });
+  }
+
+  // ----------------------------------------
+  // Chat completions proxy (computer-use agent loop)
+  // ----------------------------------------
+
+  public async chatCompletion(opts: ChatCompletionOptions): Promise<ChatResponse> {
+    const body: Record<string, unknown> = {
+      model: opts.model,
+      messages: opts.messages,
+    };
+
+    if (opts.computerId) body.computer_id = opts.computerId;
+    if (opts.autoExecuteTools !== undefined) body.auto_execute_tools = opts.autoExecuteTools;
+    if (opts.maxTokens !== undefined) body.max_tokens = opts.maxTokens;
+    if (opts.temperature !== undefined) body.temperature = opts.temperature;
+
+    return this.request<ChatResponse>('POST', '/v1/chat/completions', body);
+  }
+
+  // ----------------------------------------
+  // Health
+  // ----------------------------------------
+
+  public async healthCheck(): Promise<{ status: string; healthy: boolean }> {
+    try {
+      const result = await this.request<{ status: string }>('GET', '/health');
+      return { ...result, healthy: result.status === 'ok' || result.status === 'healthy' };
+    } catch (error) {
+      return { status: 'error', healthy: false };
+    }
+  }
+
+  // ----------------------------------------
+  // Configuration status
+  // ----------------------------------------
+
+  public isConfigured(): boolean {
+    return !!this.apiKey;
+  }
+
+  public getConfigurationStatus(): {
+    configured: boolean;
+    apiUrl: string;
+    hasApiKey: boolean;
+    hasWorkspace: boolean;
+  } {
+    return {
+      configured: this.isConfigured(),
+      apiUrl: this.apiUrl,
+      hasApiKey: !!this.apiKey,
+      hasWorkspace: !!this.workspaceId,
+    };
+  }
+}
+
+// Export singleton instance
+export const orgoClient = OrgoClient.getInstance();
+
+// Export class for testing purposes
+export { OrgoClient };

--- a/server/api/routers/ghl.ts
+++ b/server/api/routers/ghl.ts
@@ -8,7 +8,9 @@
  * - Campaign/drip management (list, add/remove contacts)
  * - Workflow listing
  *
- * Linear: AI-2877, AI-2881, AI-3461
+ * - Messaging (send SMS, send email, delivery status, templates)
+ *
+ * Linear: AI-2877, AI-2881, AI-3461, AI-5149
  */
 
 import { z } from "zod";
@@ -644,6 +646,106 @@ export const ghlRouter = router({
       try {
         const service = await getServiceForUser(ctx.user.id, input?.locationId);
         const result = await service.listWorkflows();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Messaging / Communication (AI-5149)
+  // ----------------------------------------
+
+  sendSMS: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        message: z.string().min(1).max(1600),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.sendSMS(input.contactId, input.message);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  sendEmail: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        subject: z.string().min(1).max(998),
+        html: z.string().min(1),
+        emailFrom: z.string().email().optional(),
+        emailTo: z.string().email().optional(),
+        emailReplyTo: z.string().email().optional(),
+        templateId: z.string().optional(),
+        attachments: z
+          .array(
+            z.object({
+              url: z.string().url(),
+              name: z.string().optional(),
+            })
+          )
+          .optional(),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { contactId, locationId, ...emailData } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.sendEmail(contactId, emailData);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  getMessageStatus: protectedProcedure
+    .input(
+      z.object({
+        messageId: z.string().min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.getMessageStatus(input.messageId);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  listTemplates: protectedProcedure
+    .input(
+      z
+        .object({
+          locationId: z.string().optional(),
+          type: z.enum(["sms", "email", "whatsapp"]).optional(),
+          limit: z.number().int().min(1).max(100).default(20),
+          offset: z.number().int().min(0).default(0),
+        })
+        .optional()
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listTemplates({
+          type: input?.type,
+          limit: input?.limit,
+          offset: input?.offset,
+        });
         return result.data;
       } catch (err) {
         if (err instanceof TRPCError) throw err;

--- a/server/api/routers/ghl.ts
+++ b/server/api/routers/ghl.ts
@@ -2,17 +2,13 @@
  * GHL tRPC Router
  *
  * Provides typed RPC endpoints for GHL integration management:
- * - ghl.status — connection health check per location
- * - ghl.listLocations — list all authorized GHL locations
- * - ghl.disconnect — revoke and clean up
- * - ghl.configStatus — check OAuth configuration
- * - ghl.getActiveLocation — get user's currently selected location
- * - ghl.setActiveLocation — switch active location
- * - ghl.getLocationConfig — get per-location config
- * - ghl.updateLocationConfig — update per-location config
- * - ghl.updateLocationDetails — update location name/metadata
+ * - Connection management (status, list, disconnect, config)
+ * - Contact/lead management (search, create, update, tag)
+ * - Pipeline/opportunity management (list, search, create, update)
+ * - Campaign/drip management (list, add/remove contacts)
+ * - Workflow listing
  *
- * Linear: AI-2877, AI-2881
+ * Linear: AI-2877, AI-2881, AI-3461
  */
 
 import { z } from "zod";
@@ -22,6 +18,57 @@ import { GHLService, GHLError } from "../../services/ghl.service";
 import { getDb } from "../../db";
 import { ghlLocations, ghlActiveLocation } from "../../../drizzle/schema-ghl-locations";
 import { eq, and } from "drizzle-orm";
+
+// ========================================
+// HELPERS
+// ========================================
+
+function ghlErrorToTRPC(err: unknown): never {
+  if (err instanceof GHLError) {
+    throw new TRPCError({
+      code:
+        err.category === "auth"
+          ? "UNAUTHORIZED"
+          : err.category === "rate_limit"
+            ? "TOO_MANY_REQUESTS"
+            : "INTERNAL_SERVER_ERROR",
+      message: err.message,
+    });
+  }
+  throw new TRPCError({
+    code: "INTERNAL_SERVER_ERROR",
+    message: err instanceof Error ? err.message : "GHL operation failed",
+  });
+}
+
+/** Get a GHL service for the user's active location, or a specified one. */
+async function getServiceForUser(
+  userId: number,
+  locationId?: string
+): Promise<GHLService> {
+  if (locationId) {
+    return new GHLService(locationId, userId);
+  }
+
+  // Fall back to active location
+  const db = await getDb();
+  if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+
+  const [active] = await db
+    .select()
+    .from(ghlActiveLocation)
+    .where(eq(ghlActiveLocation.userId, userId))
+    .limit(1);
+
+  if (!active) {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "No active GHL location. Connect and select a location first.",
+    });
+  }
+
+  return new GHLService(active.locationId, userId);
+}
 
 const locationConfigSchema = z.object({
   automationsEnabled: z.boolean().optional(),
@@ -36,51 +83,29 @@ const locationConfigSchema = z.object({
   tags: z.array(z.string()).optional(),
 });
 
+// ========================================
+// ROUTER
+// ========================================
+
 export const ghlRouter = router({
-  /**
-   * Get connection status for a specific GHL location.
-   */
+  // ----------------------------------------
+  // Connection Management (existing)
+  // ----------------------------------------
+
   status: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1, "locationId is required"),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       try {
         const service = new GHLService(input.locationId, ctx.user.id);
-        const status = await service.getConnectionStatus();
-        return status;
+        return await service.getConnectionStatus();
       } catch (err) {
-        if (err instanceof GHLError) {
-          throw new TRPCError({
-            code:
-              err.category === "auth"
-                ? "UNAUTHORIZED"
-                : err.category === "rate_limit"
-                  ? "TOO_MANY_REQUESTS"
-                  : "INTERNAL_SERVER_ERROR",
-            message: err.message,
-          });
-        }
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message:
-            err instanceof Error ? err.message : "Failed to check GHL status",
-        });
+        ghlErrorToTRPC(err);
       }
     }),
 
-  /**
-   * List all authorized GHL locations for the current user.
-   * Merges data from integrations table + ghl_locations table.
-   */
   listLocations: protectedProcedure.query(async ({ ctx }) => {
     try {
-      // Get OAuth-connected locations from integrations table
       const oauthLocations = await GHLService.listLocations(ctx.user.id);
-
-      // Get enriched location data from ghl_locations table
       const db = await getDb();
       if (!db) return oauthLocations;
 
@@ -94,12 +119,10 @@ export const ghlRouter = router({
           )
         );
 
-      // Build lookup map of enriched data
       const enrichedMap = new Map(
         locationRows.map((row) => [row.locationId, row])
       );
 
-      // Merge: OAuth data + enriched metadata
       return oauthLocations.map((loc) => {
         const enriched = enrichedMap.get(loc.locationId);
         return {
@@ -118,31 +141,17 @@ export const ghlRouter = router({
         };
       });
     } catch (err) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message:
-          err instanceof Error
-            ? err.message
-            : "Failed to list GHL locations",
-      });
+      ghlErrorToTRPC(err);
     }
   }),
 
-  /**
-   * Disconnect a GHL location (revoke tokens and mark inactive).
-   */
   disconnect: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1, "locationId is required"),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       try {
         const service = new GHLService(input.locationId, ctx.user.id);
         await service.disconnect();
 
-        // Also deactivate in ghl_locations table
         const db = await getDb();
         if (db) {
           await db
@@ -155,7 +164,6 @@ export const ghlRouter = router({
               )
             );
 
-          // If this was the active location, clear it
           const [active] = await db
             .select()
             .from(ghlActiveLocation)
@@ -169,33 +177,12 @@ export const ghlRouter = router({
           }
         }
 
-        return {
-          success: true,
-          message: `Disconnected GHL location ${input.locationId}`,
-        };
+        return { success: true, message: `Disconnected GHL location ${input.locationId}` };
       } catch (err) {
-        if (err instanceof GHLError) {
-          throw new TRPCError({
-            code:
-              err.category === "auth"
-                ? "UNAUTHORIZED"
-                : "INTERNAL_SERVER_ERROR",
-            message: err.message,
-          });
-        }
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message:
-            err instanceof Error
-              ? err.message
-              : "Failed to disconnect GHL location",
-        });
+        ghlErrorToTRPC(err);
       }
     }),
 
-  /**
-   * Get the GHL OAuth configuration status (whether client ID/secret are set).
-   */
   configStatus: protectedProcedure.query(async () => {
     return {
       configured: !!process.env.GHL_CLIENT_ID && !!process.env.GHL_CLIENT_SECRET,
@@ -204,9 +191,6 @@ export const ghlRouter = router({
     };
   }),
 
-  /**
-   * Get the user's currently active/selected GHL location.
-   */
   getActiveLocation: protectedProcedure.query(async ({ ctx }) => {
     const db = await getDb();
     if (!db) return null;
@@ -219,7 +203,6 @@ export const ghlRouter = router({
 
     if (!active) return null;
 
-    // Fetch enriched details
     const [location] = await db
       .select()
       .from(ghlLocations)
@@ -240,22 +223,12 @@ export const ghlRouter = router({
     };
   }),
 
-  /**
-   * Set the active/selected GHL location for the current user.
-   */
   setActiveLocation: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1, "locationId is required"),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
-      }
+      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
 
-      // Verify this location exists and belongs to user
       const [location] = await db
         .select()
         .from(ghlLocations)
@@ -269,13 +242,9 @@ export const ghlRouter = router({
         .limit(1);
 
       if (!location) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `GHL location ${input.locationId} not found or not connected`,
-        });
+        throw new TRPCError({ code: "NOT_FOUND", message: `GHL location ${input.locationId} not found` });
       }
 
-      // Upsert active location
       const [existing] = await db
         .select()
         .from(ghlActiveLocation)
@@ -295,22 +264,11 @@ export const ghlRouter = router({
         });
       }
 
-      return {
-        success: true,
-        locationId: input.locationId,
-        name: location.name,
-      };
+      return { success: true, locationId: input.locationId, name: location.name };
     }),
 
-  /**
-   * Get per-location configuration.
-   */
   getLocationConfig: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1),
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
       const db = await getDb();
       if (!db) return null;
@@ -334,23 +292,12 @@ export const ghlRouter = router({
       };
     }),
 
-  /**
-   * Update per-location configuration.
-   */
   updateLocationConfig: protectedProcedure
-    .input(
-      z.object({
-        locationId: z.string().min(1),
-        config: locationConfigSchema,
-      })
-    )
+    .input(z.object({ locationId: z.string().min(1), config: locationConfigSchema }))
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
-      }
+      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
 
-      // Get current config and merge
       const [location] = await db
         .select()
         .from(ghlLocations)
@@ -362,12 +309,7 @@ export const ghlRouter = router({
         )
         .limit(1);
 
-      if (!location) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `GHL location ${input.locationId} not found`,
-        });
-      }
+      if (!location) throw new TRPCError({ code: "NOT_FOUND", message: `Location not found` });
 
       const mergedConfig = { ...(location.config || {}), ...input.config };
 
@@ -384,9 +326,6 @@ export const ghlRouter = router({
       return { success: true, config: mergedConfig };
     }),
 
-  /**
-   * Update location display name and metadata.
-   */
   updateLocationDetails: protectedProcedure
     .input(
       z.object({
@@ -400,18 +339,12 @@ export const ghlRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) {
-        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
-      }
+      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
 
       const { locationId, ...updates } = input;
-
-      // Filter out undefined values
       const setValues: Record<string, unknown> = { updatedAt: new Date() };
       for (const [key, value] of Object.entries(updates)) {
-        if (value !== undefined) {
-          setValues[key] = value || null;
-        }
+        if (value !== undefined) setValues[key] = value || null;
       }
 
       await db
@@ -425,5 +358,296 @@ export const ghlRouter = router({
         );
 
       return { success: true };
+    }),
+
+  // ----------------------------------------
+  // Contact / Lead Management (AI-3461)
+  // ----------------------------------------
+
+  searchContacts: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        query: z.string().optional(),
+        limit: z.number().int().min(1).max(100).default(20),
+        offset: z.number().int().min(0).default(0),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.searchContacts({
+          query: input.query,
+          limit: input.limit,
+          offset: input.offset,
+        });
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  getContact: protectedProcedure
+    .input(z.object({ contactId: z.string().min(1), locationId: z.string().optional() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.getContact(input.contactId);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  createContact: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        firstName: z.string().optional(),
+        lastName: z.string().optional(),
+        email: z.string().email().optional(),
+        phone: z.string().optional(),
+        tags: z.array(z.string()).optional(),
+        source: z.string().optional(),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { locationId, ...contactData } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.createContact(contactData);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  updateContact: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        locationId: z.string().optional(),
+        firstName: z.string().optional(),
+        lastName: z.string().optional(),
+        email: z.string().email().optional(),
+        phone: z.string().optional(),
+        tags: z.array(z.string()).optional(),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { contactId, locationId, ...updateData } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.updateContact(contactId, updateData);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  addContactTags: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        tags: z.array(z.string().min(1)).min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.addContactTags(input.contactId, input.tags);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  removeContactTags: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        tags: z.array(z.string().min(1)).min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        await service.removeContactTags(input.contactId, input.tags);
+        return { success: true };
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Pipeline / Opportunity Management (AI-3461)
+  // ----------------------------------------
+
+  listPipelines: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listPipelines();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  searchOpportunities: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        pipelineId: z.string().optional(),
+        stageId: z.string().optional(),
+        status: z.enum(["open", "won", "lost", "abandoned", "all"]).default("open"),
+        query: z.string().optional(),
+        limit: z.number().int().min(1).max(100).default(20),
+        offset: z.number().int().min(0).default(0),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const { locationId, ...params } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.searchOpportunities(params);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  createOpportunity: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        pipelineId: z.string().min(1),
+        stageId: z.string().min(1),
+        contactId: z.string().min(1),
+        name: z.string().min(1),
+        monetaryValue: z.number().optional(),
+        status: z.enum(["open", "won", "lost", "abandoned"]).default("open"),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { locationId, ...data } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.createOpportunity(data);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  updateOpportunity: protectedProcedure
+    .input(
+      z.object({
+        opportunityId: z.string().min(1),
+        locationId: z.string().optional(),
+        stageId: z.string().optional(),
+        status: z.enum(["open", "won", "lost", "abandoned"]).optional(),
+        monetaryValue: z.number().optional(),
+        name: z.string().optional(),
+        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { opportunityId, locationId, ...data } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        const result = await service.updateOpportunity(opportunityId, data);
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Campaign / Drip Management (AI-3461)
+  // ----------------------------------------
+
+  listCampaigns: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listCampaigns();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  addContactToCampaign: protectedProcedure
+    .input(
+      z.object({
+        campaignId: z.string().min(1),
+        contactId: z.string().min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        await service.addContactToCampaign(input.campaignId, input.contactId);
+        return { success: true };
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  removeContactFromCampaign: protectedProcedure
+    .input(
+      z.object({
+        campaignId: z.string().min(1),
+        contactId: z.string().min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        await service.removeContactFromCampaign(input.campaignId, input.contactId);
+        return { success: true };
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Workflows (AI-3461)
+  // ----------------------------------------
+
+  listWorkflows: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listWorkflows();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
     }),
 });

--- a/server/api/routers/ghl.ts
+++ b/server/api/routers/ghl.ts
@@ -10,13 +10,13 @@
  *
  * - Messaging (send SMS, send email, delivery status, templates)
  *
- * Linear: AI-2877, AI-2881, AI-3461, AI-5149
+ * Linear: AI-2877, AI-2881, AI-3461, AI-5148, AI-5149
  */
 
 import { z } from "zod";
 import { router, protectedProcedure } from "../../_core/trpc";
 import { TRPCError } from "@trpc/server";
-import { GHLService, GHLError } from "../../services/ghl.service";
+import { GHLService, GHLError, type GHLContact } from "../../services/ghl.service";
 import { getDb } from "../../db";
 import { ghlLocations, ghlActiveLocation } from "../../../drizzle/schema-ghl-locations";
 import { eq, and } from "drizzle-orm";
@@ -492,6 +492,158 @@ export const ghlRouter = router({
     }),
 
   // ----------------------------------------
+  // Bulk Contact Ops / Custom Fields / Tags (AI-5148)
+  // ----------------------------------------
+
+  bulkImport: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        contacts: z
+          .array(
+            z.object({
+              firstName: z.string().optional(),
+              lastName: z.string().optional(),
+              email: z.string().email().optional(),
+              phone: z.string().optional(),
+              tags: z.array(z.string()).optional(),
+              source: z.string().optional(),
+              customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+            })
+          )
+          .min(1)
+          .max(50000),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.bulkImport(input.contacts);
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  bulkExport: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        query: z.string().optional(),
+        filters: z.record(z.string(), z.string()).optional(),
+        maxRecords: z.number().int().min(1).max(50000).default(10000),
+        format: z.enum(["json", "csv"]).default("json"),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.bulkExport({
+          query: input.query,
+          filters: input.filters,
+          maxRecords: input.maxRecords,
+        });
+
+        if (input.format === "csv") {
+          return {
+            csv: contactsToCsv(result.contacts),
+            total: result.total,
+          };
+        }
+
+        return result;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  mergeContacts: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        primaryId: z.string().min(1),
+        duplicateIds: z.array(z.string().min(1)).min(1).max(50),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.mergeContacts(input.primaryId, input.duplicateIds);
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  getContactActivity: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        locationId: z.string().optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.getContactActivity(input.contactId);
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  getCustomFields: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.getCustomFields();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  updateContactCustomField: protectedProcedure
+    .input(
+      z.object({
+        contactId: z.string().min(1),
+        fieldId: z.string().min(1),
+        value: z.string(),
+        locationId: z.string().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        const result = await service.updateContactCustomField(
+          input.contactId,
+          input.fieldId,
+          input.value
+        );
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  listTags: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }).optional())
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input?.locationId);
+        const result = await service.listTags();
+        return result.data;
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
   // Pipeline / Opportunity Management (AI-3461)
   // ----------------------------------------
 
@@ -753,3 +905,34 @@ export const ghlRouter = router({
       }
     }),
 });
+
+// ========================================
+// HELPERS
+// ========================================
+
+function escapeCsvField(value: string): string {
+  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function contactsToCsv(contacts: GHLContact[]): string {
+  const headers = ["id", "firstName", "lastName", "name", "email", "phone", "tags", "source", "dateAdded"];
+  const rows = contacts.map((c) =>
+    [
+      c.id || "",
+      c.firstName || "",
+      c.lastName || "",
+      c.name || "",
+      c.email || "",
+      c.phone || "",
+      (c.tags || []).join(";"),
+      c.source || "",
+      c.dateAdded || "",
+    ]
+      .map(escapeCsvField)
+      .join(",")
+  );
+  return [headers.join(","), ...rows].join("\n");
+}

--- a/server/api/routers/ghl.ts
+++ b/server/api/routers/ghl.ts
@@ -2,21 +2,40 @@
  * GHL tRPC Router
  *
  * Provides typed RPC endpoints for GHL integration management:
- * - Connection management (status, list, disconnect, config)
- * - Contact/lead management (search, create, update, tag)
- * - Pipeline/opportunity management (list, search, create, update)
- * - Campaign/drip management (list, add/remove contacts)
- * - Workflow listing
+ * - ghl.status — connection health check per location
+ * - ghl.listLocations — list all authorized GHL locations
+ * - ghl.disconnect — revoke and clean up
+ * - ghl.configStatus — check OAuth configuration
+ * - ghl.getActiveLocation — get user's currently selected location
+ * - ghl.setActiveLocation — switch active location
+ * - ghl.getLocationConfig — get per-location config
+ * - ghl.updateLocationConfig — update per-location config
+ * - ghl.updateLocationDetails — update location name/metadata
  *
- * - Messaging (send SMS, send email, delivery status, templates)
+ * Contacts: searchContacts, getContact, createContact, updateContact,
+ *   addTags, removeTags, bulkImportContacts, bulkExportContacts,
+ *   mergeContacts, getContactActivity, getCustomFields, listContactTags
  *
- * Linear: AI-2877, AI-2881, AI-3461, AI-5148, AI-5149
+ * Pipelines/Opportunities: listPipelines, searchOpportunities,
+ *   createOpportunity, updateOpportunity
+ *
+ * Campaigns: listCampaigns, addContactToCampaign, removeContactFromCampaign,
+ *   getCampaignStats, createCampaign
+ *
+ * Workflows: listWorkflows, triggerWorkflow
+ *
+ * Communications: sendSMS, sendEmail, getMessageStatus, listTemplates
+ *
+ * Appointments: createAppointment, getAppointment, updateAppointment,
+ *   deleteAppointment, getAvailability
+ *
+ * Linear: AI-2877, AI-2881, AI-3461
  */
 
 import { z } from "zod";
 import { router, protectedProcedure } from "../../_core/trpc";
 import { TRPCError } from "@trpc/server";
-import { GHLService, GHLError, type GHLContact } from "../../services/ghl.service";
+import { GHLService, GHLError } from "../../services/ghl.service";
 import { getDb } from "../../db";
 import { ghlLocations, ghlActiveLocation } from "../../../drizzle/schema-ghl-locations";
 import { eq, and } from "drizzle-orm";
@@ -25,25 +44,10 @@ import { eq, and } from "drizzle-orm";
 // HELPERS
 // ========================================
 
-function ghlErrorToTRPC(err: unknown): never {
-  if (err instanceof GHLError) {
-    throw new TRPCError({
-      code:
-        err.category === "auth"
-          ? "UNAUTHORIZED"
-          : err.category === "rate_limit"
-            ? "TOO_MANY_REQUESTS"
-            : "INTERNAL_SERVER_ERROR",
-      message: err.message,
-    });
-  }
-  throw new TRPCError({
-    code: "INTERNAL_SERVER_ERROR",
-    message: err instanceof Error ? err.message : "GHL operation failed",
-  });
-}
-
-/** Get a GHL service for the user's active location, or a specified one. */
+/**
+ * Instantiate a GHLService for the given user, resolving the location from
+ * either the explicit locationId input or the user's active location in DB.
+ */
 async function getServiceForUser(
   userId: number,
   locationId?: string
@@ -52,9 +56,14 @@ async function getServiceForUser(
     return new GHLService(locationId, userId);
   }
 
-  // Fall back to active location
+  // Fall back to the user's currently active location
   const db = await getDb();
-  if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+  if (!db) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Database not available",
+    });
+  }
 
   const [active] = await db
     .select()
@@ -64,13 +73,38 @@ async function getServiceForUser(
 
   if (!active) {
     throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: "No active GHL location. Connect and select a location first.",
+      code: "BAD_REQUEST",
+      message: "No active GHL location — provide locationId or set an active location",
     });
   }
 
   return new GHLService(active.locationId, userId);
 }
+
+/**
+ * Map a GHLError to a TRPCError code.
+ */
+function ghlErrorToTRPC(err: unknown): TRPCError {
+  if (err instanceof GHLError) {
+    const code =
+      err.category === "auth"
+        ? "UNAUTHORIZED"
+        : err.category === "rate_limit"
+          ? "TOO_MANY_REQUESTS"
+          : err.category === "client"
+            ? "BAD_REQUEST"
+            : "INTERNAL_SERVER_ERROR";
+    return new TRPCError({ code, message: err.message });
+  }
+  return new TRPCError({
+    code: "INTERNAL_SERVER_ERROR",
+    message: err instanceof Error ? err.message : "Unknown GHL error",
+  });
+}
+
+// ========================================
+// SCHEMAS
+// ========================================
 
 const locationConfigSchema = z.object({
   automationsEnabled: z.boolean().optional(),
@@ -90,24 +124,38 @@ const locationConfigSchema = z.object({
 // ========================================
 
 export const ghlRouter = router({
+
   // ----------------------------------------
-  // Connection Management (existing)
+  // Connection management
   // ----------------------------------------
 
+  /**
+   * Get connection status for a specific GHL location.
+   */
   status: protectedProcedure
-    .input(z.object({ locationId: z.string().min(1) }))
+    .input(
+      z.object({
+        locationId: z.string().min(1, "locationId is required"),
+      })
+    )
     .query(async ({ ctx, input }) => {
       try {
         const service = new GHLService(input.locationId, ctx.user.id);
         return await service.getConnectionStatus();
       } catch (err) {
-        ghlErrorToTRPC(err);
+        if (err instanceof TRPCError) throw err;
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * List all authorized GHL locations for the current user.
+   * Merges data from integrations table + ghl_locations table.
+   */
   listLocations: protectedProcedure.query(async ({ ctx }) => {
     try {
       const oauthLocations = await GHLService.listLocations(ctx.user.id);
+
       const db = await getDb();
       if (!db) return oauthLocations;
 
@@ -143,12 +191,20 @@ export const ghlRouter = router({
         };
       });
     } catch (err) {
-      ghlErrorToTRPC(err);
+      if (err instanceof TRPCError) throw err;
+      throw ghlErrorToTRPC(err);
     }
   }),
 
+  /**
+   * Disconnect a GHL location (revoke tokens and mark inactive).
+   */
   disconnect: protectedProcedure
-    .input(z.object({ locationId: z.string().min(1) }))
+    .input(
+      z.object({
+        locationId: z.string().min(1, "locationId is required"),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       try {
         const service = new GHLService(input.locationId, ctx.user.id);
@@ -179,12 +235,19 @@ export const ghlRouter = router({
           }
         }
 
-        return { success: true, message: `Disconnected GHL location ${input.locationId}` };
+        return {
+          success: true,
+          message: `Disconnected GHL location ${input.locationId}`,
+        };
       } catch (err) {
-        ghlErrorToTRPC(err);
+        if (err instanceof TRPCError) throw err;
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Get the GHL OAuth configuration status (whether client ID/secret are set).
+   */
   configStatus: protectedProcedure.query(async () => {
     return {
       configured: !!process.env.GHL_CLIENT_ID && !!process.env.GHL_CLIENT_SECRET,
@@ -193,6 +256,9 @@ export const ghlRouter = router({
     };
   }),
 
+  /**
+   * Get the user's currently active/selected GHL location.
+   */
   getActiveLocation: protectedProcedure.query(async ({ ctx }) => {
     const db = await getDb();
     if (!db) return null;
@@ -225,11 +291,20 @@ export const ghlRouter = router({
     };
   }),
 
+  /**
+   * Set the active/selected GHL location for the current user.
+   */
   setActiveLocation: protectedProcedure
-    .input(z.object({ locationId: z.string().min(1) }))
+    .input(
+      z.object({
+        locationId: z.string().min(1, "locationId is required"),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+      }
 
       const [location] = await db
         .select()
@@ -244,7 +319,10 @@ export const ghlRouter = router({
         .limit(1);
 
       if (!location) {
-        throw new TRPCError({ code: "NOT_FOUND", message: `GHL location ${input.locationId} not found` });
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `GHL location ${input.locationId} not found or not connected`,
+        });
       }
 
       const [existing] = await db
@@ -266,9 +344,16 @@ export const ghlRouter = router({
         });
       }
 
-      return { success: true, locationId: input.locationId, name: location.name };
+      return {
+        success: true,
+        locationId: input.locationId,
+        name: location.name,
+      };
     }),
 
+  /**
+   * Get per-location configuration.
+   */
   getLocationConfig: protectedProcedure
     .input(z.object({ locationId: z.string().min(1) }))
     .query(async ({ ctx, input }) => {
@@ -294,11 +379,21 @@ export const ghlRouter = router({
       };
     }),
 
+  /**
+   * Update per-location configuration.
+   */
   updateLocationConfig: protectedProcedure
-    .input(z.object({ locationId: z.string().min(1), config: locationConfigSchema }))
+    .input(
+      z.object({
+        locationId: z.string().min(1),
+        config: locationConfigSchema,
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+      }
 
       const [location] = await db
         .select()
@@ -311,7 +406,12 @@ export const ghlRouter = router({
         )
         .limit(1);
 
-      if (!location) throw new TRPCError({ code: "NOT_FOUND", message: `Location not found` });
+      if (!location) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `GHL location ${input.locationId} not found`,
+        });
+      }
 
       const mergedConfig = { ...(location.config || {}), ...input.config };
 
@@ -328,6 +428,9 @@ export const ghlRouter = router({
       return { success: true, config: mergedConfig };
     }),
 
+  /**
+   * Update location display name and metadata.
+   */
   updateLocationDetails: protectedProcedure
     .input(
       z.object({
@@ -341,12 +444,17 @@ export const ghlRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       const db = await getDb();
-      if (!db) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+      if (!db) {
+        throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
+      }
 
       const { locationId, ...updates } = input;
+
       const setValues: Record<string, unknown> = { updatedAt: new Date() };
       for (const [key, value] of Object.entries(updates)) {
-        if (value !== undefined) setValues[key] = value || null;
+        if (value !== undefined) {
+          setValues[key] = value || null;
+        }
       }
 
       await db
@@ -363,46 +471,53 @@ export const ghlRouter = router({
     }),
 
   // ----------------------------------------
-  // Contact / Lead Management (AI-3461)
+  // Contacts — CRUD
   // ----------------------------------------
 
+  /**
+   * Search contacts by query string.
+   */
   searchContacts: protectedProcedure
     .input(
       z.object({
         locationId: z.string().optional(),
-        query: z.string().optional(),
+        query: z.string().min(1),
         limit: z.number().int().min(1).max(100).default(20),
-        offset: z.number().int().min(0).default(0),
       })
     )
     .query(async ({ ctx, input }) => {
       try {
         const service = await getServiceForUser(ctx.user.id, input.locationId);
-        const result = await service.searchContacts({
-          query: input.query,
-          limit: input.limit,
-          offset: input.offset,
-        });
-        return result.data;
+        return await service.searchContacts(input.query, input.limit);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Get a contact by ID.
+   */
   getContact: protectedProcedure
-    .input(z.object({ contactId: z.string().min(1), locationId: z.string().optional() }))
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        contactId: z.string().min(1),
+      })
+    )
     .query(async ({ ctx, input }) => {
       try {
         const service = await getServiceForUser(ctx.user.id, input.locationId);
-        const result = await service.getContact(input.contactId);
-        return result.data;
+        return await service.getContact(input.contactId);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Create a new contact.
+   */
   createContact: protectedProcedure
     .input(
       z.object({
@@ -411,91 +526,100 @@ export const ghlRouter = router({
         lastName: z.string().optional(),
         email: z.string().email().optional(),
         phone: z.string().optional(),
+        companyName: z.string().optional(),
         tags: z.array(z.string()).optional(),
-        source: z.string().optional(),
-        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+        additionalFields: z.record(z.string(), z.unknown()).optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       try {
-        const { locationId, ...contactData } = input;
+        const { locationId, additionalFields, ...contactData } = input;
         const service = await getServiceForUser(ctx.user.id, locationId);
-        const result = await service.createContact(contactData);
-        return result.data;
+        return await service.createContact({ ...contactData, ...additionalFields });
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Update an existing contact.
+   */
   updateContact: protectedProcedure
     .input(
       z.object({
-        contactId: z.string().min(1),
         locationId: z.string().optional(),
+        contactId: z.string().min(1),
         firstName: z.string().optional(),
         lastName: z.string().optional(),
         email: z.string().email().optional(),
         phone: z.string().optional(),
+        companyName: z.string().optional(),
         tags: z.array(z.string()).optional(),
-        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+        additionalFields: z.record(z.string(), z.unknown()).optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       try {
-        const { contactId, locationId, ...updateData } = input;
+        const { locationId, contactId, additionalFields, ...contactData } = input;
         const service = await getServiceForUser(ctx.user.id, locationId);
-        const result = await service.updateContact(contactId, updateData);
-        return result.data;
+        return await service.updateContact(contactId, { ...contactData, ...additionalFields });
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
-  addContactTags: protectedProcedure
+  /**
+   * Add tags to a contact.
+   */
+  addTags: protectedProcedure
     .input(
       z.object({
-        contactId: z.string().min(1),
-        tags: z.array(z.string().min(1)).min(1),
         locationId: z.string().optional(),
+        contactId: z.string().min(1),
+        tags: z.array(z.string()).min(1),
       })
     )
     .mutation(async ({ ctx, input }) => {
       try {
         const service = await getServiceForUser(ctx.user.id, input.locationId);
-        const result = await service.addContactTags(input.contactId, input.tags);
-        return result.data;
+        return await service.addTags(input.contactId, input.tags);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
-  removeContactTags: protectedProcedure
+  /**
+   * Remove tags from a contact.
+   */
+  removeTags: protectedProcedure
     .input(
       z.object({
-        contactId: z.string().min(1),
-        tags: z.array(z.string().min(1)).min(1),
         locationId: z.string().optional(),
+        contactId: z.string().min(1),
+        tags: z.array(z.string()).min(1),
       })
     )
     .mutation(async ({ ctx, input }) => {
       try {
         const service = await getServiceForUser(ctx.user.id, input.locationId);
-        await service.removeContactTags(input.contactId, input.tags);
-        return { success: true };
+        return await service.removeTags(input.contactId, input.tags);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
   // ----------------------------------------
-  // Bulk Contact Ops / Custom Fields / Tags (AI-5148)
+  // Contacts — Bulk operations
   // ----------------------------------------
 
-  bulkImport: protectedProcedure
+  /**
+   * Bulk import contacts into this location.
+   */
+  bulkImportContacts: protectedProcedure
     .input(
       z.object({
         locationId: z.string().optional(),
@@ -507,63 +631,51 @@ export const ghlRouter = router({
               email: z.string().email().optional(),
               phone: z.string().optional(),
               tags: z.array(z.string()).optional(),
-              source: z.string().optional(),
-              customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
             })
           )
           .min(1)
-          .max(50000),
+          .max(500),
       })
     )
     .mutation(async ({ ctx, input }) => {
       try {
         const service = await getServiceForUser(ctx.user.id, input.locationId);
-        return await service.bulkImport(input.contacts);
+        return await service.bulkImportContacts(input.contacts);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
-  bulkExport: protectedProcedure
+  /**
+   * Export contacts with optional filters.
+   */
+  bulkExportContacts: protectedProcedure
     .input(
       z.object({
         locationId: z.string().optional(),
-        query: z.string().optional(),
         filters: z.record(z.string(), z.string()).optional(),
-        maxRecords: z.number().int().min(1).max(50000).default(10000),
-        format: z.enum(["json", "csv"]).default("json"),
       })
     )
     .query(async ({ ctx, input }) => {
       try {
         const service = await getServiceForUser(ctx.user.id, input.locationId);
-        const result = await service.bulkExport({
-          query: input.query,
-          filters: input.filters,
-          maxRecords: input.maxRecords,
-        });
-
-        if (input.format === "csv") {
-          return {
-            csv: contactsToCsv(result.contacts),
-            total: result.total,
-          };
-        }
-
-        return result;
+        return await service.bulkExportContacts(input.filters);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Merge duplicate contacts into a primary contact.
+   */
   mergeContacts: protectedProcedure
     .input(
       z.object({
         locationId: z.string().optional(),
         primaryId: z.string().min(1),
-        duplicateIds: z.array(z.string().min(1)).min(1).max(50),
+        duplicateIds: z.array(z.string()).min(1),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -572,15 +684,18 @@ export const ghlRouter = router({
         return await service.mergeContacts(input.primaryId, input.duplicateIds);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Get activity/tasks for a contact.
+   */
   getContactActivity: protectedProcedure
     .input(
       z.object({
-        contactId: z.string().min(1),
         locationId: z.string().optional(),
+        contactId: z.string().min(1),
       })
     )
     .query(async ({ ctx, input }) => {
@@ -589,350 +704,495 @@ export const ghlRouter = router({
         return await service.getContactActivity(input.contactId);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * List all custom fields for this location.
+   */
   getCustomFields: protectedProcedure
-    .input(z.object({ locationId: z.string().optional() }).optional())
+    .input(z.object({ locationId: z.string().optional() }))
     .query(async ({ ctx, input }) => {
-      try {
-        const service = await getServiceForUser(ctx.user.id, input?.locationId);
-        const result = await service.getCustomFields();
-        return result.data;
-      } catch (err) {
-        if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
-      }
-    }),
-
-  updateContactCustomField: protectedProcedure
-    .input(
-      z.object({
-        contactId: z.string().min(1),
-        fieldId: z.string().min(1),
-        value: z.string(),
-        locationId: z.string().optional(),
-      })
-    )
-    .mutation(async ({ ctx, input }) => {
       try {
         const service = await getServiceForUser(ctx.user.id, input.locationId);
-        const result = await service.updateContactCustomField(
-          input.contactId,
-          input.fieldId,
-          input.value
-        );
-        return result.data;
+        return await service.getCustomFields();
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
-  listTags: protectedProcedure
-    .input(z.object({ locationId: z.string().optional() }).optional())
+  /**
+   * List all contact tags for this location.
+   */
+  listContactTags: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }))
     .query(async ({ ctx, input }) => {
       try {
-        const service = await getServiceForUser(ctx.user.id, input?.locationId);
-        const result = await service.listTags();
-        return result.data;
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.listContactTags();
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
   // ----------------------------------------
-  // Pipeline / Opportunity Management (AI-3461)
+  // Pipelines / Opportunities
   // ----------------------------------------
 
+  /**
+   * List all pipelines for this location.
+   */
   listPipelines: protectedProcedure
-    .input(z.object({ locationId: z.string().optional() }).optional())
+    .input(z.object({ locationId: z.string().optional() }))
     .query(async ({ ctx, input }) => {
       try {
-        const service = await getServiceForUser(ctx.user.id, input?.locationId);
-        const result = await service.listPipelines();
-        return result.data;
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.listPipelines();
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Search opportunities, optionally filtered by pipeline.
+   */
   searchOpportunities: protectedProcedure
     .input(
       z.object({
         locationId: z.string().optional(),
+        query: z.string().min(1),
         pipelineId: z.string().optional(),
-        stageId: z.string().optional(),
-        status: z.enum(["open", "won", "lost", "abandoned", "all"]).default("open"),
-        query: z.string().optional(),
-        limit: z.number().int().min(1).max(100).default(20),
-        offset: z.number().int().min(0).default(0),
       })
     )
     .query(async ({ ctx, input }) => {
       try {
-        const { locationId, ...params } = input;
-        const service = await getServiceForUser(ctx.user.id, locationId);
-        const result = await service.searchOpportunities(params);
-        return result.data;
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.searchOpportunities(input.query, input.pipelineId);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Create a new opportunity in a pipeline.
+   */
   createOpportunity: protectedProcedure
     .input(
       z.object({
         locationId: z.string().optional(),
-        pipelineId: z.string().min(1),
-        stageId: z.string().min(1),
-        contactId: z.string().min(1),
         name: z.string().min(1),
+        status: z.string().optional(),
+        pipelineId: z.string().min(1),
+        pipelineStageId: z.string().optional(),
+        contactId: z.string().optional(),
         monetaryValue: z.number().optional(),
-        status: z.enum(["open", "won", "lost", "abandoned"]).default("open"),
-        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+        assignedTo: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       try {
         const { locationId, ...data } = input;
         const service = await getServiceForUser(ctx.user.id, locationId);
-        const result = await service.createOpportunity(data);
-        return result.data;
+        return await service.createOpportunity(data);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Update an existing opportunity.
+   */
   updateOpportunity: protectedProcedure
     .input(
       z.object({
-        opportunityId: z.string().min(1),
         locationId: z.string().optional(),
-        stageId: z.string().optional(),
-        status: z.enum(["open", "won", "lost", "abandoned"]).optional(),
-        monetaryValue: z.number().optional(),
+        opportunityId: z.string().min(1),
         name: z.string().optional(),
-        customFields: z.array(z.object({ id: z.string(), value: z.string() })).optional(),
+        status: z.string().optional(),
+        pipelineStageId: z.string().optional(),
+        monetaryValue: z.number().optional(),
+        assignedTo: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       try {
-        const { opportunityId, locationId, ...data } = input;
+        const { locationId, opportunityId, ...data } = input;
         const service = await getServiceForUser(ctx.user.id, locationId);
-        const result = await service.updateOpportunity(opportunityId, data);
-        return result.data;
+        return await service.updateOpportunity(opportunityId, data);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
   // ----------------------------------------
-  // Campaign / Drip Management (AI-3461)
+  // Campaigns
   // ----------------------------------------
 
+  /**
+   * List all campaigns for this location.
+   */
   listCampaigns: protectedProcedure
-    .input(z.object({ locationId: z.string().optional() }).optional())
+    .input(z.object({ locationId: z.string().optional() }))
     .query(async ({ ctx, input }) => {
       try {
-        const service = await getServiceForUser(ctx.user.id, input?.locationId);
-        const result = await service.listCampaigns();
-        return result.data;
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.listCampaigns();
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Add a contact to a campaign.
+   */
   addContactToCampaign: protectedProcedure
     .input(
       z.object({
+        locationId: z.string().optional(),
         campaignId: z.string().min(1),
         contactId: z.string().min(1),
-        locationId: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       try {
         const service = await getServiceForUser(ctx.user.id, input.locationId);
-        await service.addContactToCampaign(input.campaignId, input.contactId);
-        return { success: true };
+        return await service.addContactToCampaign(input.campaignId, input.contactId);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Remove a contact from a campaign.
+   */
   removeContactFromCampaign: protectedProcedure
     .input(
       z.object({
+        locationId: z.string().optional(),
         campaignId: z.string().min(1),
         contactId: z.string().min(1),
-        locationId: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       try {
         const service = await getServiceForUser(ctx.user.id, input.locationId);
-        await service.removeContactFromCampaign(input.campaignId, input.contactId);
-        return { success: true };
+        return await service.removeContactFromCampaign(input.campaignId, input.contactId);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
-  // ----------------------------------------
-  // Workflows (AI-3461)
-  // ----------------------------------------
-
-  listWorkflows: protectedProcedure
-    .input(z.object({ locationId: z.string().optional() }).optional())
+  /**
+   * Get stats for a specific campaign.
+   */
+  getCampaignStats: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        campaignId: z.string().min(1),
+      })
+    )
     .query(async ({ ctx, input }) => {
       try {
-        const service = await getServiceForUser(ctx.user.id, input?.locationId);
-        const result = await service.listWorkflows();
-        return result.data;
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.getCampaignStats(input.campaignId);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
+      }
+    }),
+
+  /**
+   * Create a new campaign.
+   */
+  createCampaign: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        name: z.string().min(1).max(200),
+        type: z.string().optional(),
+        additionalFields: z.record(z.string(), z.unknown()).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { locationId, additionalFields, ...campaignData } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        return await service.createCampaign({ ...campaignData, ...additionalFields });
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        throw ghlErrorToTRPC(err);
       }
     }),
 
   // ----------------------------------------
-  // Messaging / Communication (AI-5149)
+  // Workflows
   // ----------------------------------------
 
+  /**
+   * List all workflows for this location.
+   */
+  listWorkflows: protectedProcedure
+    .input(z.object({ locationId: z.string().optional() }))
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.listWorkflows();
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        throw ghlErrorToTRPC(err);
+      }
+    }),
+
+  /**
+   * Trigger a workflow for a specific contact.
+   */
+  triggerWorkflow: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        workflowId: z.string().min(1),
+        contactId: z.string().min(1),
+        additionalData: z.record(z.string(), z.unknown()).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { locationId, workflowId, contactId, additionalData } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        return await service.triggerWorkflow(workflowId, {
+          contactId,
+          ...(additionalData ?? {}),
+        });
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        throw ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Communications
+  // ----------------------------------------
+
+  /**
+   * Send an SMS to a contact.
+   */
   sendSMS: protectedProcedure
     .input(
       z.object({
+        locationId: z.string().optional(),
         contactId: z.string().min(1),
         message: z.string().min(1).max(1600),
-        locationId: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       try {
         const service = await getServiceForUser(ctx.user.id, input.locationId);
-        const result = await service.sendSMS(input.contactId, input.message);
-        return result.data;
+        return await service.sendSMS(input.contactId, input.message);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Send an email to a contact, optionally using a template.
+   */
   sendEmail: protectedProcedure
     .input(
       z.object({
-        contactId: z.string().min(1),
-        subject: z.string().min(1).max(998),
-        html: z.string().min(1),
-        emailFrom: z.string().email().optional(),
-        emailTo: z.string().email().optional(),
-        emailReplyTo: z.string().email().optional(),
-        templateId: z.string().optional(),
-        attachments: z
-          .array(
-            z.object({
-              url: z.string().url(),
-              name: z.string().optional(),
-            })
-          )
-          .optional(),
         locationId: z.string().optional(),
+        contactId: z.string().min(1),
+        subject: z.string().min(1).max(500),
+        body: z.string().min(1),
+        templateId: z.string().optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
       try {
-        const { contactId, locationId, ...emailData } = input;
-        const service = await getServiceForUser(ctx.user.id, locationId);
-        const result = await service.sendEmail(contactId, emailData);
-        return result.data;
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.sendEmail(
+          input.contactId,
+          input.subject,
+          input.body,
+          input.templateId
+        );
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * Get the delivery status of a message.
+   */
   getMessageStatus: protectedProcedure
     .input(
       z.object({
-        messageId: z.string().min(1),
         locationId: z.string().optional(),
+        messageId: z.string().min(1),
       })
     )
     .query(async ({ ctx, input }) => {
       try {
         const service = await getServiceForUser(ctx.user.id, input.locationId);
-        const result = await service.getMessageStatus(input.messageId);
-        return result.data;
+        return await service.getMessageStatus(input.messageId);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
       }
     }),
 
+  /**
+   * List message templates for this location.
+   */
   listTemplates: protectedProcedure
     .input(
-      z
-        .object({
-          locationId: z.string().optional(),
-          type: z.enum(["sms", "email", "whatsapp"]).optional(),
-          limit: z.number().int().min(1).max(100).default(20),
-          offset: z.number().int().min(0).default(0),
-        })
-        .optional()
+      z.object({
+        locationId: z.string().optional(),
+        type: z.enum(["sms", "email"]).optional(),
+      })
     )
     .query(async ({ ctx, input }) => {
       try {
-        const service = await getServiceForUser(ctx.user.id, input?.locationId);
-        const result = await service.listTemplates({
-          type: input?.type,
-          limit: input?.limit,
-          offset: input?.offset,
-        });
-        return result.data;
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.listTemplates(input.type);
       } catch (err) {
         if (err instanceof TRPCError) throw err;
-        ghlErrorToTRPC(err);
+        throw ghlErrorToTRPC(err);
+      }
+    }),
+
+  // ----------------------------------------
+  // Appointments
+  // ----------------------------------------
+
+  /**
+   * Create a new calendar appointment.
+   */
+  createAppointment: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        calendarId: z.string().min(1),
+        contactId: z.string().min(1),
+        startTime: z.string().min(1),
+        endTime: z.string().min(1),
+        title: z.string().max(500).optional(),
+        notes: z.string().max(2000).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { locationId, ...data } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        return await service.createAppointment(data);
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        throw ghlErrorToTRPC(err);
+      }
+    }),
+
+  /**
+   * Get a calendar event by ID.
+   */
+  getAppointment: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        eventId: z.string().min(1),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.getAppointment(input.eventId);
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        throw ghlErrorToTRPC(err);
+      }
+    }),
+
+  /**
+   * Update a calendar event.
+   */
+  updateAppointment: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        eventId: z.string().min(1),
+        calendarId: z.string().optional(),
+        contactId: z.string().optional(),
+        startTime: z.string().optional(),
+        endTime: z.string().optional(),
+        title: z.string().max(500).optional(),
+        notes: z.string().max(2000).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const { locationId, eventId, ...data } = input;
+        const service = await getServiceForUser(ctx.user.id, locationId);
+        return await service.updateAppointment(eventId, data);
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        throw ghlErrorToTRPC(err);
+      }
+    }),
+
+  /**
+   * Delete a calendar event.
+   */
+  deleteAppointment: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        eventId: z.string().min(1),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.deleteAppointment(input.eventId);
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        throw ghlErrorToTRPC(err);
+      }
+    }),
+
+  /**
+   * Get available time slots for a calendar.
+   */
+  getAvailability: protectedProcedure
+    .input(
+      z.object({
+        locationId: z.string().optional(),
+        calendarId: z.string().min(1),
+        startDate: z.string().min(1),
+        endDate: z.string().min(1),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      try {
+        const service = await getServiceForUser(ctx.user.id, input.locationId);
+        return await service.getAvailability(
+          input.calendarId,
+          input.startDate,
+          input.endDate
+        );
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        throw ghlErrorToTRPC(err);
       }
     }),
 });
-
-// ========================================
-// HELPERS
-// ========================================
-
-function escapeCsvField(value: string): string {
-  if (value.includes(",") || value.includes('"') || value.includes("\n")) {
-    return `"${value.replace(/"/g, '""')}"`;
-  }
-  return value;
-}
-
-function contactsToCsv(contacts: GHLContact[]): string {
-  const headers = ["id", "firstName", "lastName", "name", "email", "phone", "tags", "source", "dateAdded"];
-  const rows = contacts.map((c) =>
-    [
-      c.id || "",
-      c.firstName || "",
-      c.lastName || "",
-      c.name || "",
-      c.email || "",
-      c.phone || "",
-      (c.tags || []).join(";"),
-      c.source || "",
-      c.dateAdded || "",
-    ]
-      .map(escapeCsvField)
-      .join(",")
-  );
-  return [headers.join(","), ...rows].join("\n");
-}

--- a/server/api/routers/health.ts
+++ b/server/api/routers/health.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { router, publicProcedure, adminProcedure } from "../../_core/trpc";
 import { circuitBreakerRegistry } from "../../lib/circuitBreaker";
 import { browserbaseSDK } from "../../_core/browserbaseSDK";
+import { orgoClient } from "../../_core/orgoClient";
 
 /**
  * Health Router
@@ -93,6 +94,7 @@ export const healthRouter = router({
           'anthropic',
           'gmail',
           'outlook',
+          'orgo',
         ]),
       })
     )
@@ -136,6 +138,7 @@ export const healthRouter = router({
           'anthropic',
           'gmail',
           'outlook',
+          'orgo',
         ]),
       })
     )
@@ -258,6 +261,56 @@ export const healthRouter = router({
    */
   getBrowserbaseConfig: publicProcedure.query(async () => {
     return browserbaseSDK.getConfigurationStatus();
+  }),
+
+  /**
+   * Check Orgo compute provider health
+   * Verifies configuration and API connectivity
+   *
+   * @example
+   * ```ts
+   * const orgoHealth = await trpc.health.getOrgoHealth.query();
+   * if (!orgoHealth.healthy) {
+   *   console.error('Orgo not configured:', orgoHealth.config);
+   * }
+   * ```
+   */
+  getOrgoHealth: publicProcedure.query(async () => {
+    try {
+      const config = orgoClient.getConfigurationStatus();
+      if (!config.configured) {
+        return {
+          healthy: false,
+          status: 'not_configured',
+          config,
+        };
+      }
+      const health = await orgoClient.healthCheck();
+      return { ...health, config };
+    } catch (error) {
+      return {
+        healthy: false,
+        status: 'error',
+        config: orgoClient.getConfigurationStatus(),
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }),
+
+  /**
+   * Get Orgo configuration status (without testing connectivity)
+   * Fast check for configuration validation
+   *
+   * @example
+   * ```ts
+   * const config = await trpc.health.getOrgoConfig.query();
+   * if (!config.configured) {
+   *   console.log('Orgo not configured — ORGO_API_KEY missing');
+   * }
+   * ```
+   */
+  getOrgoConfig: publicProcedure.query(() => {
+    return orgoClient.getConfigurationStatus();
   }),
 
   /**

--- a/server/api/routers/orgo.ts
+++ b/server/api/routers/orgo.ts
@@ -1,0 +1,257 @@
+/**
+ * Orgo tRPC Router
+ *
+ * Exposes Orgo desktop VM operations to the Bottleneck Bots frontend dashboard.
+ *
+ * Endpoints:
+ *   orgo.configStatus    — check if Orgo is configured (API key present)
+ *   orgo.listComputers   — list all computers in the workspace
+ *   orgo.createComputer  — create a new desktop VM
+ *   orgo.getComputer     — get computer status/details
+ *   orgo.startComputer   — start a stopped computer
+ *   orgo.stopComputer    — stop a running computer
+ *   orgo.destroyComputer — permanently destroy a computer
+ *   orgo.screenshot      — get a screenshot from a running computer
+ *   orgo.executeAction   — run a desktop action (click, type, keyPress, etc.)
+ *   orgo.healthCheck     — check Orgo API health
+ *
+ * All endpoints require authentication (protectedProcedure).
+ */
+
+import { z } from 'zod';
+import { router, protectedProcedure } from '../../_core/trpc';
+import { TRPCError } from '@trpc/server';
+import { orgoClient, OrgoClientError } from '../../_core/orgoClient';
+
+/**
+ * Map OrgoClientError to appropriate TRPCError code
+ */
+function toTRPCError(err: unknown): TRPCError {
+  if (err instanceof OrgoClientError) {
+    let code: TRPCError['code'] = 'INTERNAL_SERVER_ERROR';
+    if (err.statusCode === 401 || err.statusCode === 403) {
+      code = 'UNAUTHORIZED';
+    } else if (err.statusCode === 404) {
+      code = 'NOT_FOUND';
+    } else if (err.statusCode === 429) {
+      code = 'TOO_MANY_REQUESTS';
+    } else if (err.statusCode && err.statusCode >= 400 && err.statusCode < 500) {
+      code = 'BAD_REQUEST';
+    }
+    return new TRPCError({ code, message: err.message });
+  }
+  return new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    message: err instanceof Error ? err.message : 'Unknown Orgo error',
+  });
+}
+
+export const orgoRouter = router({
+  /**
+   * Check whether Orgo is configured (API key present and URL set).
+   * Safe to call even when Orgo is not set up — never throws.
+   */
+  configStatus: protectedProcedure.query(() => {
+    return orgoClient.getConfigurationStatus();
+  }),
+
+  /**
+   * List all computers in the default workspace.
+   */
+  listComputers: protectedProcedure.query(async () => {
+    try {
+      return await orgoClient.listComputers();
+    } catch (err) {
+      throw toTRPCError(err);
+    }
+  }),
+
+  /**
+   * Create a new Orgo desktop VM.
+   */
+  createComputer: protectedProcedure
+    .input(
+      z.object({
+        name: z.string().min(1).max(128),
+        cpu: z.number().int().min(1).max(32).optional(),
+        ramMb: z.number().int().min(512).optional(),
+        diskGb: z.number().int().min(1).optional(),
+        gpu: z.boolean().optional(),
+      })
+    )
+    .mutation(async ({ input }) => {
+      try {
+        return await orgoClient.createComputer(input);
+      } catch (err) {
+        throw toTRPCError(err);
+      }
+    }),
+
+  /**
+   * Get details and status for a specific computer.
+   */
+  getComputer: protectedProcedure
+    .input(z.object({ computerId: z.string().min(1) }))
+    .query(async ({ input }) => {
+      try {
+        return await orgoClient.getComputer(input.computerId);
+      } catch (err) {
+        throw toTRPCError(err);
+      }
+    }),
+
+  /**
+   * Start a stopped computer.
+   */
+  startComputer: protectedProcedure
+    .input(z.object({ computerId: z.string().min(1) }))
+    .mutation(async ({ input }) => {
+      try {
+        await orgoClient.startComputer(input.computerId);
+        return { success: true, computerId: input.computerId };
+      } catch (err) {
+        throw toTRPCError(err);
+      }
+    }),
+
+  /**
+   * Stop a running computer (preserves disk state).
+   */
+  stopComputer: protectedProcedure
+    .input(z.object({ computerId: z.string().min(1) }))
+    .mutation(async ({ input }) => {
+      try {
+        await orgoClient.stopComputer(input.computerId);
+        return { success: true, computerId: input.computerId };
+      } catch (err) {
+        throw toTRPCError(err);
+      }
+    }),
+
+  /**
+   * Permanently destroy a computer and release all resources.
+   */
+  destroyComputer: protectedProcedure
+    .input(z.object({ computerId: z.string().min(1) }))
+    .mutation(async ({ input }) => {
+      try {
+        await orgoClient.destroyComputer(input.computerId);
+        return { success: true, computerId: input.computerId };
+      } catch (err) {
+        throw toTRPCError(err);
+      }
+    }),
+
+  /**
+   * Get a base64-encoded PNG screenshot from a running computer.
+   */
+  screenshot: protectedProcedure
+    .input(z.object({ computerId: z.string().min(1) }))
+    .query(async ({ input }) => {
+      try {
+        return await orgoClient.screenshot(input.computerId);
+      } catch (err) {
+        throw toTRPCError(err);
+      }
+    }),
+
+  /**
+   * Execute a desktop action on a running computer.
+   *
+   * Supported actions: click, doubleClick, type, keyPress, scroll, drag, exec, bash
+   */
+  executeAction: protectedProcedure
+    .input(
+      z.object({
+        computerId: z.string().min(1),
+        action: z.enum(['click', 'doubleClick', 'type', 'keyPress', 'scroll', 'drag', 'exec', 'bash']),
+        params: z.record(z.string(), z.unknown()),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const { computerId, action, params } = input;
+
+      try {
+        switch (action) {
+          case 'click': {
+            const p = params as { x: number; y: number; button?: 'left' | 'right' | 'middle' };
+            await orgoClient.click(computerId, p.x, p.y, p.button);
+            return { success: true, action };
+          }
+
+          case 'doubleClick': {
+            const p = params as { x: number; y: number };
+            await orgoClient.doubleClick(computerId, p.x, p.y);
+            return { success: true, action };
+          }
+
+          case 'type': {
+            const p = params as { text: string };
+            await orgoClient.type(computerId, p.text);
+            return { success: true, action };
+          }
+
+          case 'keyPress': {
+            const p = params as { key: string; modifiers?: string[] };
+            await orgoClient.keyPress(computerId, p.key, p.modifiers);
+            return { success: true, action };
+          }
+
+          case 'scroll': {
+            const p = params as { x: number; y: number; deltaX: number; deltaY: number };
+            await orgoClient.scroll(computerId, p.x, p.y, p.deltaX, p.deltaY);
+            return { success: true, action };
+          }
+
+          case 'drag': {
+            const p = params as { startX: number; startY: number; endX: number; endY: number };
+            await orgoClient.drag(computerId, p.startX, p.startY, p.endX, p.endY);
+            return { success: true, action };
+          }
+
+          case 'exec': {
+            const p = params as { command: string[] };
+            const result = await orgoClient.exec(computerId, p.command);
+            return { success: true, action, result };
+          }
+
+          case 'bash': {
+            const p = params as { command: string };
+            const result = await orgoClient.bash(computerId, p.command);
+            return { success: true, action, result };
+          }
+
+          default: {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: `Unknown action: ${action}`,
+            });
+          }
+        }
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        throw toTRPCError(err);
+      }
+    }),
+
+  /**
+   * Check Orgo API health and connectivity.
+   */
+  healthCheck: protectedProcedure.query(async () => {
+    try {
+      const result = await orgoClient.healthCheck();
+      const config = orgoClient.getConfigurationStatus();
+      return {
+        ...result,
+        config,
+      };
+    } catch (err) {
+      return {
+        status: 'error',
+        healthy: false,
+        config: orgoClient.getConfigurationStatus(),
+        error: err instanceof Error ? err.message : 'Unknown error',
+      };
+    }
+  }),
+});

--- a/server/api/routers/pipelines.ts
+++ b/server/api/routers/pipelines.ts
@@ -1,0 +1,40 @@
+/**
+ * Pipelines Router (stub)
+ *
+ * Pipeline operations are primarily handled through the GHL router (ghl.ts)
+ * which provides listPipelines, searchOpportunities, createOpportunity,
+ * and updateOpportunity endpoints.
+ *
+ * This router provides a platform-agnostic pipeline view layer
+ * that can aggregate data from GHL and other CRM sources.
+ *
+ * Linear: AI-3461
+ */
+
+import { z } from "zod";
+import { router, protectedProcedure } from "../../_core/trpc";
+
+export const pipelinesRouter = router({
+  /**
+   * List all pipelines across connected CRM integrations.
+   * Currently delegates to GHL; future: aggregate from multiple sources.
+   */
+  list: protectedProcedure.query(async ({ ctx }) => {
+    // TODO: aggregate from GHL + future CRM sources
+    return { pipelines: [], source: "stub" };
+  }),
+
+  /**
+   * Get pipeline summary stats (opportunity counts, total value per stage).
+   */
+  summary: protectedProcedure
+    .input(z.object({ pipelineId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      return {
+        pipelineId: input.pipelineId,
+        stages: [],
+        totalValue: 0,
+        totalOpportunities: 0,
+      };
+    }),
+});

--- a/server/api/routes/ghl-webhooks.ts
+++ b/server/api/routes/ghl-webhooks.ts
@@ -1,21 +1,36 @@
 /**
- * GHL Webhook Receiver
+ * GHL Webhook Receiver -- Production-Grade
  *
  * Express routes for receiving inbound webhooks from GoHighLevel.
  * Handles contact events, opportunity events, and campaign events
- * for lead routing and data flow synchronization.
+ * with real DB sync, event deduplication, dead letter queue,
+ * structured logging, and workflow engine integration.
  *
  * Routes:
- *   POST /api/ghl/webhooks/inbound — receive GHL webhook events
- *   GET  /api/ghl/webhooks/health  — health check
+ *   POST /api/ghl/webhooks/inbound  -- receive GHL webhook events
+ *   GET  /api/ghl/webhooks/health   -- health check
+ *   GET  /api/ghl/webhooks/dlq      -- view dead letter queue
+ *   POST /api/ghl/webhooks/dlq/:id/retry -- retry a dead letter
  *
- * Linear: AI-3461
+ * Linear: AI-5147
  */
 
 import express, { Request, Response } from "express";
 import crypto from "crypto";
+import { eq, and, desc } from "drizzle-orm";
+import { getDb } from "../../db";
+import { ghlLocations } from "../../../drizzle/schema-ghl-locations";
+import {
+  ghlContacts,
+  ghlOpportunities,
+  ghlWebhookEvents,
+  ghlWebhookDeadLetters,
+} from "../../../drizzle/schema-ghl-webhooks";
+import { addWorkflowExecutionJob, REDIS_AVAILABLE } from "../../_core/queue";
+import { logger } from "../../lib/logger";
 
 const webhookRouter = express.Router();
+const log = logger.child({ service: "ghl-webhooks" });
 
 // ========================================
 // TYPES
@@ -24,6 +39,8 @@ const webhookRouter = express.Router();
 interface GHLWebhookEvent {
   type: string;
   locationId?: string;
+  /** GHL-provided event ID for deduplication */
+  id?: string;
   // Contact events
   contact?: {
     id: string;
@@ -54,75 +71,371 @@ interface GHLWebhookEvent {
   timestamp?: string;
 }
 
-type WebhookHandler = (event: GHLWebhookEvent) => Promise<void>;
+type WebhookHandler = (event: GHLWebhookEvent, userId: number) => Promise<void>;
+
+// ========================================
+// HELPERS
+// ========================================
+
+/**
+ * Resolve the userId that owns a given GHL locationId.
+ * Returns null if the location is not connected.
+ */
+async function resolveUserForLocation(locationId: string): Promise<number | null> {
+  const db = await getDb();
+  if (!db || !locationId) return null;
+
+  const rows = await db
+    .select({ userId: ghlLocations.userId })
+    .from(ghlLocations)
+    .where(and(eq(ghlLocations.locationId, locationId), eq(ghlLocations.isActive, true)))
+    .limit(1);
+
+  return rows.length > 0 ? rows[0].userId : null;
+}
+
+/**
+ * Generate a deterministic event ID when GHL does not provide one.
+ * Uses type + locationId + contactId/opportunityId + timestamp.
+ */
+function deriveEventId(event: GHLWebhookEvent): string {
+  if (event.id) return event.id;
+  const parts = [
+    event.type,
+    event.locationId || "",
+    event.contact?.id || event.opportunity?.id || event.contactId || "",
+    event.timestamp || "",
+  ];
+  return crypto.createHash("sha256").update(parts.join("|")).digest("hex").slice(0, 64);
+}
+
+/**
+ * Check if this event has already been processed (dedup).
+ */
+async function isDuplicateEvent(eventId: string): Promise<boolean> {
+  const db = await getDb();
+  if (!db) return false;
+
+  const rows = await db
+    .select({ id: ghlWebhookEvents.id })
+    .from(ghlWebhookEvents)
+    .where(eq(ghlWebhookEvents.eventId, eventId))
+    .limit(1);
+
+  return rows.length > 0;
+}
+
+/**
+ * Record a processed event for future dedup.
+ */
+async function recordEvent(eventId: string, eventType: string, locationId: string | undefined, success: boolean): Promise<void> {
+  const db = await getDb();
+  if (!db) return;
+
+  await db.insert(ghlWebhookEvents).values({
+    eventId,
+    eventType,
+    locationId: locationId || null,
+    success,
+  }).onConflictDoNothing();
+}
+
+/**
+ * Push a failed event into the dead letter queue.
+ */
+async function pushToDeadLetterQueue(
+  event: GHLWebhookEvent,
+  eventId: string,
+  error: string
+): Promise<void> {
+  const db = await getDb();
+  if (!db) return;
+
+  await db.insert(ghlWebhookDeadLetters).values({
+    eventId,
+    eventType: event.type,
+    locationId: event.locationId || null,
+    payload: event as unknown as Record<string, unknown>,
+    error,
+  });
+
+  log.warn({ eventId, eventType: event.type, error }, "Event pushed to dead letter queue");
+}
+
+/**
+ * Fire a workflow execution job if Redis + workflow queue is available.
+ */
+async function triggerWorkflow(userId: number, event: GHLWebhookEvent): Promise<void> {
+  if (!REDIS_AVAILABLE) return;
+
+  try {
+    await addWorkflowExecutionJob({
+      userId: String(userId),
+      workflowId: `ghl-webhook-${event.type}`,
+      triggerId: event.id || deriveEventId(event),
+      context: {
+        source: "ghl-webhook",
+        eventType: event.type,
+        locationId: event.locationId,
+        contactId: event.contact?.id || event.contactId,
+        opportunityId: event.opportunity?.id,
+        campaignId: event.campaign?.id,
+        timestamp: event.timestamp || new Date().toISOString(),
+      },
+    });
+
+    log.debug({ eventType: event.type, userId }, "Workflow job enqueued");
+  } catch (err) {
+    log.warn({ err, eventType: event.type }, "Failed to enqueue workflow job (non-fatal)");
+  }
+}
 
 // ========================================
 // EVENT HANDLERS
 // ========================================
 
 const eventHandlers: Record<string, WebhookHandler> = {
-  "ContactCreate": async (event) => {
-    console.log("[GHL Webhook] New contact created:", {
-      contactId: event.contact?.id,
-      name: `${event.contact?.firstName || ""} ${event.contact?.lastName || ""}`.trim(),
-      email: event.contact?.email,
-      source: event.contact?.source,
-      locationId: event.locationId,
+  ContactCreate: async (event, userId) => {
+    const c = event.contact;
+    if (!c?.id) throw new Error("Missing contact.id in ContactCreate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlContacts).values({
+      userId,
+      ghlContactId: c.id,
+      locationId: event.locationId || "",
+      firstName: c.firstName || null,
+      lastName: c.lastName || null,
+      email: c.email || null,
+      phone: c.phone || null,
+      tags: c.tags || null,
+      source: c.source || null,
+      customFields: c.customFields || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+      set: {
+        firstName: c.firstName || null,
+        lastName: c.lastName || null,
+        email: c.email || null,
+        phone: c.phone || null,
+        tags: c.tags || null,
+        source: c.source || null,
+        customFields: c.customFields || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
-    // Lead routing logic: tag-based routing happens in GHL workflows,
-    // but we log and can trigger internal automations here
+
+    log.info({
+      contactId: c.id,
+      email: c.email,
+      locationId: event.locationId,
+    }, "Contact created/upserted");
   },
 
-  "ContactUpdate": async (event) => {
-    console.log("[GHL Webhook] Contact updated:", {
-      contactId: event.contact?.id,
-      locationId: event.locationId,
+  ContactUpdate: async (event, userId) => {
+    const c = event.contact;
+    if (!c?.id) throw new Error("Missing contact.id in ContactUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlContacts).values({
+      userId,
+      ghlContactId: c.id,
+      locationId: event.locationId || "",
+      firstName: c.firstName || null,
+      lastName: c.lastName || null,
+      email: c.email || null,
+      phone: c.phone || null,
+      tags: c.tags || null,
+      source: c.source || null,
+      customFields: c.customFields || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+      set: {
+        firstName: c.firstName || null,
+        lastName: c.lastName || null,
+        email: c.email || null,
+        phone: c.phone || null,
+        tags: c.tags || null,
+        source: c.source || null,
+        customFields: c.customFields || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({ contactId: c.id, locationId: event.locationId }, "Contact updated");
   },
 
-  "ContactTagUpdate": async (event) => {
-    console.log("[GHL Webhook] Contact tags changed:", {
-      contactId: event.contact?.id,
-      tags: event.contact?.tags,
-      locationId: event.locationId,
+  ContactTagUpdate: async (event, userId) => {
+    const c = event.contact;
+    if (!c?.id) throw new Error("Missing contact.id in ContactTagUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlContacts).values({
+      userId,
+      ghlContactId: c.id,
+      locationId: event.locationId || "",
+      tags: c.tags || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+      set: {
+        tags: c.tags || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({ contactId: c.id, tags: c.tags, locationId: event.locationId }, "Contact tags updated");
   },
 
-  "OpportunityCreate": async (event) => {
-    console.log("[GHL Webhook] New opportunity:", {
-      opportunityId: event.opportunity?.id,
-      name: event.opportunity?.name,
-      pipelineId: event.opportunity?.pipelineId,
-      stageId: event.opportunity?.pipelineStageId,
-      contactId: event.opportunity?.contactId,
-      value: event.opportunity?.monetaryValue,
-      locationId: event.locationId,
+  OpportunityCreate: async (event, userId) => {
+    const o = event.opportunity;
+    if (!o?.id) throw new Error("Missing opportunity.id in OpportunityCreate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlOpportunities).values({
+      userId,
+      ghlOpportunityId: o.id,
+      locationId: event.locationId || "",
+      name: o.name || null,
+      pipelineId: o.pipelineId || null,
+      pipelineStageId: o.pipelineStageId || null,
+      status: o.status || null,
+      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+      ghlContactId: o.contactId || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+      set: {
+        name: o.name || null,
+        pipelineId: o.pipelineId || null,
+        pipelineStageId: o.pipelineStageId || null,
+        status: o.status || null,
+        monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+        ghlContactId: o.contactId || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({
+      opportunityId: o.id,
+      pipeline: o.pipelineId,
+      stage: o.pipelineStageId,
+      value: o.monetaryValue,
+      locationId: event.locationId,
+    }, "Opportunity created/upserted");
   },
 
-  "OpportunityStageUpdate": async (event) => {
-    console.log("[GHL Webhook] Opportunity stage changed:", {
-      opportunityId: event.opportunity?.id,
-      newStage: event.opportunity?.pipelineStageId,
-      status: event.opportunity?.status,
-      locationId: event.locationId,
+  OpportunityStageUpdate: async (event, userId) => {
+    const o = event.opportunity;
+    if (!o?.id) throw new Error("Missing opportunity.id in OpportunityStageUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlOpportunities).values({
+      userId,
+      ghlOpportunityId: o.id,
+      locationId: event.locationId || "",
+      name: o.name || null,
+      pipelineId: o.pipelineId || null,
+      pipelineStageId: o.pipelineStageId || null,
+      status: o.status || null,
+      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+      ghlContactId: o.contactId || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+      set: {
+        pipelineStageId: o.pipelineStageId || null,
+        status: o.status || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({
+      opportunityId: o.id,
+      newStage: o.pipelineStageId,
+      status: o.status,
+      locationId: event.locationId,
+    }, "Opportunity stage updated");
   },
 
-  "OpportunityStatusUpdate": async (event) => {
-    console.log("[GHL Webhook] Opportunity status changed:", {
-      opportunityId: event.opportunity?.id,
-      status: event.opportunity?.status,
-      locationId: event.locationId,
+  OpportunityStatusUpdate: async (event, userId) => {
+    const o = event.opportunity;
+    if (!o?.id) throw new Error("Missing opportunity.id in OpportunityStatusUpdate event");
+
+    const db = await getDb();
+    if (!db) throw new Error("Database not available");
+
+    const now = new Date();
+    await db.insert(ghlOpportunities).values({
+      userId,
+      ghlOpportunityId: o.id,
+      locationId: event.locationId || "",
+      name: o.name || null,
+      pipelineId: o.pipelineId || null,
+      pipelineStageId: o.pipelineStageId || null,
+      status: o.status || null,
+      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+      ghlContactId: o.contactId || null,
+      lastWebhookAt: now,
+      createdAt: now,
+      updatedAt: now,
+    }).onConflictDoUpdate({
+      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+      set: {
+        status: o.status || null,
+        lastWebhookAt: now,
+        updatedAt: now,
+      },
     });
+
+    log.info({
+      opportunityId: o.id,
+      status: o.status,
+      locationId: event.locationId,
+    }, "Opportunity status updated");
   },
 
-  "CampaignStatusUpdate": async (event) => {
-    console.log("[GHL Webhook] Campaign status update:", {
+  CampaignStatusUpdate: async (event, _userId) => {
+    // Campaign events are logged and forwarded to workflow engine.
+    // No dedicated table -- these trigger internal automations.
+    log.info({
       campaignId: event.campaign?.id,
+      campaignName: event.campaign?.name,
       contactId: event.contactId,
       locationId: event.locationId,
-    });
+    }, "Campaign status update received");
   },
 };
 
@@ -157,7 +470,7 @@ webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Reques
 
   // Verify signature if secret is configured
   if (webhookSecret && !verifyWebhookSignature(rawBody, signature, webhookSecret)) {
-    console.warn("[GHL Webhook] Invalid signature, rejecting");
+    log.warn({ ip: req.ip }, "Invalid webhook signature, rejecting");
     res.status(401).json({ error: "Invalid webhook signature" });
     return;
   }
@@ -166,36 +479,73 @@ webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Reques
   try {
     event = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
   } catch {
-    console.error("[GHL Webhook] Failed to parse body");
+    log.error("Failed to parse webhook body");
     res.status(400).json({ error: "Invalid JSON body" });
     return;
   }
 
   const eventType = event.type;
   if (!eventType) {
-    console.warn("[GHL Webhook] Missing event type");
+    log.warn("Missing event type in webhook payload");
     res.status(400).json({ error: "Missing event type" });
     return;
   }
 
-  console.log(`[GHL Webhook] Received event: ${eventType}`, {
+  const eventId = deriveEventId(event);
+
+  log.info({
+    eventId,
+    eventType,
     locationId: event.locationId,
     timestamp: event.timestamp || new Date().toISOString(),
-  });
+  }, "Webhook received");
 
   // Respond immediately (GHL expects quick 200)
-  res.status(200).json({ received: true, type: eventType });
+  res.status(200).json({ received: true, type: eventType, eventId });
 
-  // Process event asynchronously
+  // ---- Async processing below ----
+
+  // 1. Dedup check
+  try {
+    if (await isDuplicateEvent(eventId)) {
+      log.info({ eventId, eventType }, "Duplicate event, skipping");
+      return;
+    }
+  } catch (err) {
+    log.warn({ err, eventId }, "Dedup check failed, processing anyway");
+  }
+
+  // 2. Resolve user from locationId
+  let userId: number | null = null;
+  if (event.locationId) {
+    userId = await resolveUserForLocation(event.locationId);
+  }
+
+  if (!userId) {
+    log.warn({ locationId: event.locationId, eventType }, "No user found for location, using DLQ");
+    await pushToDeadLetterQueue(event, eventId, `No user found for locationId: ${event.locationId || "missing"}`);
+    await recordEvent(eventId, eventType, event.locationId, false);
+    return;
+  }
+
+  // 3. Process event
   const handler = eventHandlers[eventType];
   if (handler) {
     try {
-      await handler(event);
+      await handler(event, userId);
+      await recordEvent(eventId, eventType, event.locationId, true);
+
+      // 4. Trigger workflow engine
+      await triggerWorkflow(userId, event);
     } catch (err) {
-      console.error(`[GHL Webhook] Error handling ${eventType}:`, err);
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      log.error({ err, eventId, eventType, locationId: event.locationId }, "Handler failed");
+      await pushToDeadLetterQueue(event, eventId, errorMsg);
+      await recordEvent(eventId, eventType, event.locationId, false);
     }
   } else {
-    console.log(`[GHL Webhook] No handler for event type: ${eventType}`);
+    log.info({ eventType }, "No handler registered for event type");
+    await recordEvent(eventId, eventType, event.locationId, true);
   }
 });
 
@@ -203,14 +553,152 @@ webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Reques
 // HEALTH CHECK
 // ========================================
 
-webhookRouter.get("/health", (_req: Request, res: Response) => {
+webhookRouter.get("/health", async (_req: Request, res: Response) => {
+  const db = await getDb();
+  let dlqCount = 0;
+
+  if (db) {
+    try {
+      const rows = await db
+        .select({ id: ghlWebhookDeadLetters.id })
+        .from(ghlWebhookDeadLetters)
+        .where(eq(ghlWebhookDeadLetters.resolved, false));
+      dlqCount = rows.length;
+    } catch {
+      // DB may not have the table yet
+    }
+  }
+
   res.json({
     status: "ok",
     service: "ghl-webhooks",
     configured: !!process.env.GHL_WEBHOOK_SECRET,
     supportedEvents: Object.keys(eventHandlers),
+    deadLetterCount: dlqCount,
+    workflowQueueAvailable: REDIS_AVAILABLE,
     timestamp: new Date().toISOString(),
   });
+});
+
+// ========================================
+// DLQ MANAGEMENT
+// ========================================
+
+webhookRouter.get("/dlq", async (_req: Request, res: Response) => {
+  const db = await getDb();
+  if (!db) {
+    res.status(503).json({ error: "Database not available" });
+    return;
+  }
+
+  try {
+    const items = await db
+      .select()
+      .from(ghlWebhookDeadLetters)
+      .where(eq(ghlWebhookDeadLetters.resolved, false))
+      .orderBy(desc(ghlWebhookDeadLetters.createdAt))
+      .limit(100);
+
+    res.json({ count: items.length, items });
+  } catch (err) {
+    log.error({ err }, "Failed to fetch DLQ items");
+    res.status(500).json({ error: "Failed to fetch dead letter queue" });
+  }
+});
+
+webhookRouter.post("/dlq/:id/retry", async (req: Request, res: Response) => {
+  const db = await getDb();
+  if (!db) {
+    res.status(503).json({ error: "Database not available" });
+    return;
+  }
+
+  const dlqId = parseInt(req.params.id, 10);
+  if (isNaN(dlqId)) {
+    res.status(400).json({ error: "Invalid DLQ entry ID" });
+    return;
+  }
+
+  try {
+    const rows = await db
+      .select()
+      .from(ghlWebhookDeadLetters)
+      .where(eq(ghlWebhookDeadLetters.id, dlqId))
+      .limit(1);
+
+    if (rows.length === 0) {
+      res.status(404).json({ error: "DLQ entry not found" });
+      return;
+    }
+
+    const entry = rows[0];
+    if (entry.resolved) {
+      res.status(400).json({ error: "DLQ entry already resolved" });
+      return;
+    }
+
+    if (entry.retryCount >= entry.maxRetries) {
+      res.status(400).json({ error: "Max retries exceeded" });
+      return;
+    }
+
+    const event = entry.payload as unknown as GHLWebhookEvent;
+    const eventType = event.type || entry.eventType;
+
+    // Re-resolve user
+    let userId: number | null = null;
+    if (event.locationId) {
+      userId = await resolveUserForLocation(event.locationId);
+    }
+
+    if (!userId) {
+      await db.update(ghlWebhookDeadLetters).set({
+        retryCount: entry.retryCount + 1,
+        lastRetriedAt: new Date(),
+        error: `Retry failed: No user found for locationId: ${event.locationId || "missing"}`,
+        updatedAt: new Date(),
+      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+
+      res.status(422).json({ error: "No user found for location on retry" });
+      return;
+    }
+
+    const handler = eventHandlers[eventType];
+    if (!handler) {
+      res.status(422).json({ error: `No handler for event type: ${eventType}` });
+      return;
+    }
+
+    try {
+      await handler(event, userId);
+      await triggerWorkflow(userId, event);
+
+      // Mark resolved
+      await db.update(ghlWebhookDeadLetters).set({
+        resolved: true,
+        retryCount: entry.retryCount + 1,
+        lastRetriedAt: new Date(),
+        updatedAt: new Date(),
+      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+
+      log.info({ dlqId, eventType }, "DLQ entry retried successfully");
+      res.json({ success: true, message: "Event reprocessed successfully" });
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      await db.update(ghlWebhookDeadLetters).set({
+        retryCount: entry.retryCount + 1,
+        lastRetriedAt: new Date(),
+        error: `Retry failed: ${errorMsg}`,
+        updatedAt: new Date(),
+      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+
+      log.error({ err, dlqId, eventType }, "DLQ retry failed");
+      res.status(500).json({ error: "Retry failed", detail: errorMsg });
+    }
+  } catch (err) {
+    log.error({ err }, "Failed to process DLQ retry");
+    res.status(500).json({ error: "Failed to process retry" });
+  }
 });
 
 export default webhookRouter;

--- a/server/api/routes/ghl-webhooks.ts
+++ b/server/api/routes/ghl-webhooks.ts
@@ -1,5 +1,5 @@
 /**
- * GHL Webhook Receiver -- Production-Grade
+ * GHL Webhook Receiver — Production-Grade
  *
  * Express routes for receiving inbound webhooks from GoHighLevel.
  * Handles contact events, opportunity events, and campaign events
@@ -7,12 +7,12 @@
  * structured logging, and workflow engine integration.
  *
  * Routes:
- *   POST /api/ghl/webhooks/inbound  -- receive GHL webhook events
- *   GET  /api/ghl/webhooks/health   -- health check
- *   GET  /api/ghl/webhooks/dlq      -- view dead letter queue
- *   POST /api/ghl/webhooks/dlq/:id/retry -- retry a dead letter
+ *   POST /api/ghl/webhooks/inbound  — receive GHL webhook events
+ *   GET  /api/ghl/webhooks/health   — health check
+ *   GET  /api/ghl/webhooks/dlq      — view dead letter queue
+ *   POST /api/ghl/webhooks/dlq/:id/retry — retry a dead letter entry
  *
- * Linear: AI-5147
+ * Linear: AI-3461
  */
 
 import express, { Request, Response } from "express";
@@ -25,7 +25,7 @@ import {
   ghlOpportunities,
   ghlWebhookEvents,
   ghlWebhookDeadLetters,
-} from "../../../drizzle/schema-ghl-webhooks";
+} from "../../../drizzle/schema-ghl-webhook-events";
 import { addWorkflowExecutionJob, REDIS_AVAILABLE } from "../../_core/queue";
 import { logger } from "../../lib/logger";
 
@@ -110,7 +110,7 @@ function deriveEventId(event: GHLWebhookEvent): string {
 }
 
 /**
- * Check if this event has already been processed (dedup).
+ * Check if this event has already been processed (deduplication).
  */
 async function isDuplicateEvent(eventId: string): Promise<boolean> {
   const db = await getDb();
@@ -126,18 +126,26 @@ async function isDuplicateEvent(eventId: string): Promise<boolean> {
 }
 
 /**
- * Record a processed event for future dedup.
+ * Record a processed event for future deduplication.
  */
-async function recordEvent(eventId: string, eventType: string, locationId: string | undefined, success: boolean): Promise<void> {
+async function recordEvent(
+  eventId: string,
+  eventType: string,
+  locationId: string | undefined,
+  success: boolean
+): Promise<void> {
   const db = await getDb();
   if (!db) return;
 
-  await db.insert(ghlWebhookEvents).values({
-    eventId,
-    eventType,
-    locationId: locationId || null,
-    success,
-  }).onConflictDoNothing();
+  await db
+    .insert(ghlWebhookEvents)
+    .values({
+      eventId,
+      eventType,
+      locationId: locationId || null,
+      success,
+    })
+    .onConflictDoNothing();
 }
 
 /**
@@ -203,23 +211,12 @@ const eventHandlers: Record<string, WebhookHandler> = {
     if (!db) throw new Error("Database not available");
 
     const now = new Date();
-    await db.insert(ghlContacts).values({
-      userId,
-      ghlContactId: c.id,
-      locationId: event.locationId || "",
-      firstName: c.firstName || null,
-      lastName: c.lastName || null,
-      email: c.email || null,
-      phone: c.phone || null,
-      tags: c.tags || null,
-      source: c.source || null,
-      customFields: c.customFields || null,
-      lastWebhookAt: now,
-      createdAt: now,
-      updatedAt: now,
-    }).onConflictDoUpdate({
-      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
-      set: {
+    await db
+      .insert(ghlContacts)
+      .values({
+        userId,
+        ghlContactId: c.id,
+        locationId: event.locationId || "",
         firstName: c.firstName || null,
         lastName: c.lastName || null,
         email: c.email || null,
@@ -228,15 +225,32 @@ const eventHandlers: Record<string, WebhookHandler> = {
         source: c.source || null,
         customFields: c.customFields || null,
         lastWebhookAt: now,
+        createdAt: now,
         updatedAt: now,
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+        set: {
+          firstName: c.firstName || null,
+          lastName: c.lastName || null,
+          email: c.email || null,
+          phone: c.phone || null,
+          tags: c.tags || null,
+          source: c.source || null,
+          customFields: c.customFields || null,
+          lastWebhookAt: now,
+          updatedAt: now,
+        },
+      });
 
-    log.info({
-      contactId: c.id,
-      email: c.email,
-      locationId: event.locationId,
-    }, "Contact created/upserted");
+    log.info(
+      {
+        contactId: c.id,
+        email: c.email,
+        locationId: event.locationId,
+      },
+      "Contact created/upserted"
+    );
   },
 
   ContactUpdate: async (event, userId) => {
@@ -247,23 +261,12 @@ const eventHandlers: Record<string, WebhookHandler> = {
     if (!db) throw new Error("Database not available");
 
     const now = new Date();
-    await db.insert(ghlContacts).values({
-      userId,
-      ghlContactId: c.id,
-      locationId: event.locationId || "",
-      firstName: c.firstName || null,
-      lastName: c.lastName || null,
-      email: c.email || null,
-      phone: c.phone || null,
-      tags: c.tags || null,
-      source: c.source || null,
-      customFields: c.customFields || null,
-      lastWebhookAt: now,
-      createdAt: now,
-      updatedAt: now,
-    }).onConflictDoUpdate({
-      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
-      set: {
+    await db
+      .insert(ghlContacts)
+      .values({
+        userId,
+        ghlContactId: c.id,
+        locationId: event.locationId || "",
         firstName: c.firstName || null,
         lastName: c.lastName || null,
         email: c.email || null,
@@ -272,9 +275,23 @@ const eventHandlers: Record<string, WebhookHandler> = {
         source: c.source || null,
         customFields: c.customFields || null,
         lastWebhookAt: now,
+        createdAt: now,
         updatedAt: now,
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+        set: {
+          firstName: c.firstName || null,
+          lastName: c.lastName || null,
+          email: c.email || null,
+          phone: c.phone || null,
+          tags: c.tags || null,
+          source: c.source || null,
+          customFields: c.customFields || null,
+          lastWebhookAt: now,
+          updatedAt: now,
+        },
+      });
 
     log.info({ contactId: c.id, locationId: event.locationId }, "Contact updated");
   },
@@ -287,24 +304,30 @@ const eventHandlers: Record<string, WebhookHandler> = {
     if (!db) throw new Error("Database not available");
 
     const now = new Date();
-    await db.insert(ghlContacts).values({
-      userId,
-      ghlContactId: c.id,
-      locationId: event.locationId || "",
-      tags: c.tags || null,
-      lastWebhookAt: now,
-      createdAt: now,
-      updatedAt: now,
-    }).onConflictDoUpdate({
-      target: [ghlContacts.ghlContactId, ghlContacts.locationId],
-      set: {
+    await db
+      .insert(ghlContacts)
+      .values({
+        userId,
+        ghlContactId: c.id,
+        locationId: event.locationId || "",
         tags: c.tags || null,
         lastWebhookAt: now,
+        createdAt: now,
         updatedAt: now,
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: [ghlContacts.ghlContactId, ghlContacts.locationId],
+        set: {
+          tags: c.tags || null,
+          lastWebhookAt: now,
+          updatedAt: now,
+        },
+      });
 
-    log.info({ contactId: c.id, tags: c.tags, locationId: event.locationId }, "Contact tags updated");
+    log.info(
+      { contactId: c.id, tags: c.tags, locationId: event.locationId },
+      "Contact tags updated"
+    );
   },
 
   OpportunityCreate: async (event, userId) => {
@@ -315,22 +338,12 @@ const eventHandlers: Record<string, WebhookHandler> = {
     if (!db) throw new Error("Database not available");
 
     const now = new Date();
-    await db.insert(ghlOpportunities).values({
-      userId,
-      ghlOpportunityId: o.id,
-      locationId: event.locationId || "",
-      name: o.name || null,
-      pipelineId: o.pipelineId || null,
-      pipelineStageId: o.pipelineStageId || null,
-      status: o.status || null,
-      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
-      ghlContactId: o.contactId || null,
-      lastWebhookAt: now,
-      createdAt: now,
-      updatedAt: now,
-    }).onConflictDoUpdate({
-      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
-      set: {
+    await db
+      .insert(ghlOpportunities)
+      .values({
+        userId,
+        ghlOpportunityId: o.id,
+        locationId: event.locationId || "",
         name: o.name || null,
         pipelineId: o.pipelineId || null,
         pipelineStageId: o.pipelineStageId || null,
@@ -338,17 +351,33 @@ const eventHandlers: Record<string, WebhookHandler> = {
         monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
         ghlContactId: o.contactId || null,
         lastWebhookAt: now,
+        createdAt: now,
         updatedAt: now,
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+        set: {
+          name: o.name || null,
+          pipelineId: o.pipelineId || null,
+          pipelineStageId: o.pipelineStageId || null,
+          status: o.status || null,
+          monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+          ghlContactId: o.contactId || null,
+          lastWebhookAt: now,
+          updatedAt: now,
+        },
+      });
 
-    log.info({
-      opportunityId: o.id,
-      pipeline: o.pipelineId,
-      stage: o.pipelineStageId,
-      value: o.monetaryValue,
-      locationId: event.locationId,
-    }, "Opportunity created/upserted");
+    log.info(
+      {
+        opportunityId: o.id,
+        pipeline: o.pipelineId,
+        stage: o.pipelineStageId,
+        value: o.monetaryValue,
+        locationId: event.locationId,
+      },
+      "Opportunity created/upserted"
+    );
   },
 
   OpportunityStageUpdate: async (event, userId) => {
@@ -359,35 +388,41 @@ const eventHandlers: Record<string, WebhookHandler> = {
     if (!db) throw new Error("Database not available");
 
     const now = new Date();
-    await db.insert(ghlOpportunities).values({
-      userId,
-      ghlOpportunityId: o.id,
-      locationId: event.locationId || "",
-      name: o.name || null,
-      pipelineId: o.pipelineId || null,
-      pipelineStageId: o.pipelineStageId || null,
-      status: o.status || null,
-      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
-      ghlContactId: o.contactId || null,
-      lastWebhookAt: now,
-      createdAt: now,
-      updatedAt: now,
-    }).onConflictDoUpdate({
-      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
-      set: {
+    await db
+      .insert(ghlOpportunities)
+      .values({
+        userId,
+        ghlOpportunityId: o.id,
+        locationId: event.locationId || "",
+        name: o.name || null,
+        pipelineId: o.pipelineId || null,
         pipelineStageId: o.pipelineStageId || null,
         status: o.status || null,
+        monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+        ghlContactId: o.contactId || null,
         lastWebhookAt: now,
+        createdAt: now,
         updatedAt: now,
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+        set: {
+          pipelineStageId: o.pipelineStageId || null,
+          status: o.status || null,
+          lastWebhookAt: now,
+          updatedAt: now,
+        },
+      });
 
-    log.info({
-      opportunityId: o.id,
-      newStage: o.pipelineStageId,
-      status: o.status,
-      locationId: event.locationId,
-    }, "Opportunity stage updated");
+    log.info(
+      {
+        opportunityId: o.id,
+        newStage: o.pipelineStageId,
+        status: o.status,
+        locationId: event.locationId,
+      },
+      "Opportunity stage updated"
+    );
   },
 
   OpportunityStatusUpdate: async (event, userId) => {
@@ -398,44 +433,53 @@ const eventHandlers: Record<string, WebhookHandler> = {
     if (!db) throw new Error("Database not available");
 
     const now = new Date();
-    await db.insert(ghlOpportunities).values({
-      userId,
-      ghlOpportunityId: o.id,
-      locationId: event.locationId || "",
-      name: o.name || null,
-      pipelineId: o.pipelineId || null,
-      pipelineStageId: o.pipelineStageId || null,
-      status: o.status || null,
-      monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
-      ghlContactId: o.contactId || null,
-      lastWebhookAt: now,
-      createdAt: now,
-      updatedAt: now,
-    }).onConflictDoUpdate({
-      target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
-      set: {
+    await db
+      .insert(ghlOpportunities)
+      .values({
+        userId,
+        ghlOpportunityId: o.id,
+        locationId: event.locationId || "",
+        name: o.name || null,
+        pipelineId: o.pipelineId || null,
+        pipelineStageId: o.pipelineStageId || null,
         status: o.status || null,
+        monetaryValue: o.monetaryValue != null ? String(o.monetaryValue) : null,
+        ghlContactId: o.contactId || null,
         lastWebhookAt: now,
+        createdAt: now,
         updatedAt: now,
-      },
-    });
+      })
+      .onConflictDoUpdate({
+        target: [ghlOpportunities.ghlOpportunityId, ghlOpportunities.locationId],
+        set: {
+          status: o.status || null,
+          lastWebhookAt: now,
+          updatedAt: now,
+        },
+      });
 
-    log.info({
-      opportunityId: o.id,
-      status: o.status,
-      locationId: event.locationId,
-    }, "Opportunity status updated");
+    log.info(
+      {
+        opportunityId: o.id,
+        status: o.status,
+        locationId: event.locationId,
+      },
+      "Opportunity status updated"
+    );
   },
 
   CampaignStatusUpdate: async (event, _userId) => {
     // Campaign events are logged and forwarded to workflow engine.
-    // No dedicated table -- these trigger internal automations.
-    log.info({
-      campaignId: event.campaign?.id,
-      campaignName: event.campaign?.name,
-      contactId: event.contactId,
-      locationId: event.locationId,
-    }, "Campaign status update received");
+    // No dedicated table — these trigger internal automations.
+    log.info(
+      {
+        campaignId: event.campaign?.id,
+        campaignName: event.campaign?.name,
+        contactId: event.contactId,
+        locationId: event.locationId,
+      },
+      "Campaign status update received"
+    );
   },
 };
 
@@ -449,105 +493,130 @@ function verifyWebhookSignature(
   secret: string
 ): boolean {
   if (!signature || !secret) return !secret; // Skip if no secret configured
-  const expected = crypto
-    .createHmac("sha256", secret)
-    .update(body)
-    .digest("hex");
-  return crypto.timingSafeEqual(
-    Buffer.from(signature),
-    Buffer.from(expected)
-  );
+  const expected = crypto.createHmac("sha256", secret).update(body).digest("hex");
+  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
 }
 
 // ========================================
 // POST /api/ghl/webhooks/inbound
 // ========================================
 
-webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Request, res: Response) => {
-  const webhookSecret = process.env.GHL_WEBHOOK_SECRET;
-  const signature = req.headers["x-ghl-signature"] as string | undefined;
-  const rawBody = typeof req.body === "string" ? req.body : JSON.stringify(req.body);
+webhookRouter.post(
+  "/inbound",
+  express.text({ type: "*/*" }),
+  async (req: Request, res: Response) => {
+    const startMs = Date.now();
+    const webhookSecret = process.env.GHL_WEBHOOK_SECRET;
+    const signature = req.headers["x-ghl-signature"] as string | undefined;
+    const rawBody = typeof req.body === "string" ? req.body : JSON.stringify(req.body);
 
-  // Verify signature if secret is configured
-  if (webhookSecret && !verifyWebhookSignature(rawBody, signature, webhookSecret)) {
-    log.warn({ ip: req.ip }, "Invalid webhook signature, rejecting");
-    res.status(401).json({ error: "Invalid webhook signature" });
-    return;
-  }
-
-  let event: GHLWebhookEvent;
-  try {
-    event = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
-  } catch {
-    log.error("Failed to parse webhook body");
-    res.status(400).json({ error: "Invalid JSON body" });
-    return;
-  }
-
-  const eventType = event.type;
-  if (!eventType) {
-    log.warn("Missing event type in webhook payload");
-    res.status(400).json({ error: "Missing event type" });
-    return;
-  }
-
-  const eventId = deriveEventId(event);
-
-  log.info({
-    eventId,
-    eventType,
-    locationId: event.locationId,
-    timestamp: event.timestamp || new Date().toISOString(),
-  }, "Webhook received");
-
-  // Respond immediately (GHL expects quick 200)
-  res.status(200).json({ received: true, type: eventType, eventId });
-
-  // ---- Async processing below ----
-
-  // 1. Dedup check
-  try {
-    if (await isDuplicateEvent(eventId)) {
-      log.info({ eventId, eventType }, "Duplicate event, skipping");
+    // Verify signature if secret is configured
+    if (webhookSecret && !verifyWebhookSignature(rawBody, signature, webhookSecret)) {
+      log.warn({ ip: req.ip }, "Invalid webhook signature, rejecting");
+      res.status(401).json({ error: "Invalid webhook signature" });
       return;
     }
-  } catch (err) {
-    log.warn({ err, eventId }, "Dedup check failed, processing anyway");
-  }
 
-  // 2. Resolve user from locationId
-  let userId: number | null = null;
-  if (event.locationId) {
-    userId = await resolveUserForLocation(event.locationId);
-  }
-
-  if (!userId) {
-    log.warn({ locationId: event.locationId, eventType }, "No user found for location, using DLQ");
-    await pushToDeadLetterQueue(event, eventId, `No user found for locationId: ${event.locationId || "missing"}`);
-    await recordEvent(eventId, eventType, event.locationId, false);
-    return;
-  }
-
-  // 3. Process event
-  const handler = eventHandlers[eventType];
-  if (handler) {
+    let event: GHLWebhookEvent;
     try {
-      await handler(event, userId);
-      await recordEvent(eventId, eventType, event.locationId, true);
-
-      // 4. Trigger workflow engine
-      await triggerWorkflow(userId, event);
-    } catch (err) {
-      const errorMsg = err instanceof Error ? err.message : String(err);
-      log.error({ err, eventId, eventType, locationId: event.locationId }, "Handler failed");
-      await pushToDeadLetterQueue(event, eventId, errorMsg);
-      await recordEvent(eventId, eventType, event.locationId, false);
+      event = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+    } catch {
+      log.error("Failed to parse webhook body");
+      res.status(400).json({ error: "Invalid JSON body" });
+      return;
     }
-  } else {
-    log.info({ eventType }, "No handler registered for event type");
-    await recordEvent(eventId, eventType, event.locationId, true);
+
+    const eventType = event.type;
+    if (!eventType) {
+      log.warn("Missing event type in webhook payload");
+      res.status(400).json({ error: "Missing event type" });
+      return;
+    }
+
+    const eventId = deriveEventId(event);
+
+    log.info(
+      {
+        eventId,
+        eventType,
+        locationId: event.locationId,
+        timestamp: event.timestamp || new Date().toISOString(),
+      },
+      "Webhook received"
+    );
+
+    // Respond immediately (GHL expects quick 200)
+    res.status(200).json({ received: true, type: eventType, eventId });
+
+    // ---- Async processing below ----
+
+    // 1. Dedup check
+    try {
+      if (await isDuplicateEvent(eventId)) {
+        log.info({ eventId, eventType }, "Duplicate event, skipping");
+        return;
+      }
+    } catch (err) {
+      log.warn({ err, eventId }, "Dedup check failed, processing anyway");
+    }
+
+    // 2. Resolve user from locationId
+    let userId: number | null = null;
+    if (event.locationId) {
+      userId = await resolveUserForLocation(event.locationId);
+    }
+
+    if (!userId) {
+      log.warn(
+        { locationId: event.locationId, eventType },
+        "No user found for location, routing to DLQ"
+      );
+      await pushToDeadLetterQueue(
+        event,
+        eventId,
+        `No user found for locationId: ${event.locationId || "missing"}`
+      );
+      await recordEvent(eventId, eventType, event.locationId, false);
+      return;
+    }
+
+    // 3. Process event
+    const handler = eventHandlers[eventType];
+    if (handler) {
+      try {
+        await handler(event, userId);
+
+        const processingTimeMs = Date.now() - startMs;
+        log.info(
+          {
+            eventType,
+            locationId: event.locationId,
+            entityId: event.contact?.id || event.opportunity?.id || event.contactId,
+            processingTimeMs,
+          },
+          "Event processed successfully"
+        );
+
+        await recordEvent(eventId, eventType, event.locationId, true);
+
+        // 4. Trigger workflow engine
+        await triggerWorkflow(userId, event);
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
+        const processingTimeMs = Date.now() - startMs;
+        log.error(
+          { err, eventId, eventType, locationId: event.locationId, processingTimeMs },
+          "Handler failed"
+        );
+        await pushToDeadLetterQueue(event, eventId, errorMsg);
+        await recordEvent(eventId, eventType, event.locationId, false);
+      }
+    } else {
+      log.info({ eventType }, "No handler registered for event type");
+      await recordEvent(eventId, eventType, event.locationId, true);
+    }
   }
-});
+);
 
 // ========================================
 // HEALTH CHECK
@@ -565,7 +634,7 @@ webhookRouter.get("/health", async (_req: Request, res: Response) => {
         .where(eq(ghlWebhookDeadLetters.resolved, false));
       dlqCount = rows.length;
     } catch {
-      // DB may not have the table yet
+      // DB may not have tables yet during initial deployment
     }
   }
 
@@ -652,12 +721,15 @@ webhookRouter.post("/dlq/:id/retry", async (req: Request, res: Response) => {
     }
 
     if (!userId) {
-      await db.update(ghlWebhookDeadLetters).set({
-        retryCount: entry.retryCount + 1,
-        lastRetriedAt: new Date(),
-        error: `Retry failed: No user found for locationId: ${event.locationId || "missing"}`,
-        updatedAt: new Date(),
-      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+      await db
+        .update(ghlWebhookDeadLetters)
+        .set({
+          retryCount: entry.retryCount + 1,
+          lastRetriedAt: new Date(),
+          error: `Retry failed: No user found for locationId: ${event.locationId || "missing"}`,
+          updatedAt: new Date(),
+        })
+        .where(eq(ghlWebhookDeadLetters.id, dlqId));
 
       res.status(422).json({ error: "No user found for location on retry" });
       return;
@@ -674,23 +746,29 @@ webhookRouter.post("/dlq/:id/retry", async (req: Request, res: Response) => {
       await triggerWorkflow(userId, event);
 
       // Mark resolved
-      await db.update(ghlWebhookDeadLetters).set({
-        resolved: true,
-        retryCount: entry.retryCount + 1,
-        lastRetriedAt: new Date(),
-        updatedAt: new Date(),
-      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+      await db
+        .update(ghlWebhookDeadLetters)
+        .set({
+          resolved: true,
+          retryCount: entry.retryCount + 1,
+          lastRetriedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(ghlWebhookDeadLetters.id, dlqId));
 
       log.info({ dlqId, eventType }, "DLQ entry retried successfully");
       res.json({ success: true, message: "Event reprocessed successfully" });
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
-      await db.update(ghlWebhookDeadLetters).set({
-        retryCount: entry.retryCount + 1,
-        lastRetriedAt: new Date(),
-        error: `Retry failed: ${errorMsg}`,
-        updatedAt: new Date(),
-      }).where(eq(ghlWebhookDeadLetters.id, dlqId));
+      await db
+        .update(ghlWebhookDeadLetters)
+        .set({
+          retryCount: entry.retryCount + 1,
+          lastRetriedAt: new Date(),
+          error: `Retry failed: ${errorMsg}`,
+          updatedAt: new Date(),
+        })
+        .where(eq(ghlWebhookDeadLetters.id, dlqId));
 
       log.error({ err, dlqId, eventType }, "DLQ retry failed");
       res.status(500).json({ error: "Retry failed", detail: errorMsg });

--- a/server/api/routes/ghl-webhooks.ts
+++ b/server/api/routes/ghl-webhooks.ts
@@ -1,0 +1,216 @@
+/**
+ * GHL Webhook Receiver
+ *
+ * Express routes for receiving inbound webhooks from GoHighLevel.
+ * Handles contact events, opportunity events, and campaign events
+ * for lead routing and data flow synchronization.
+ *
+ * Routes:
+ *   POST /api/ghl/webhooks/inbound — receive GHL webhook events
+ *   GET  /api/ghl/webhooks/health  — health check
+ *
+ * Linear: AI-3461
+ */
+
+import express, { Request, Response } from "express";
+import crypto from "crypto";
+
+const webhookRouter = express.Router();
+
+// ========================================
+// TYPES
+// ========================================
+
+interface GHLWebhookEvent {
+  type: string;
+  locationId?: string;
+  // Contact events
+  contact?: {
+    id: string;
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phone?: string;
+    tags?: string[];
+    source?: string;
+    customFields?: Array<{ id: string; value: string }>;
+  };
+  // Opportunity events
+  opportunity?: {
+    id: string;
+    name: string;
+    pipelineId: string;
+    pipelineStageId: string;
+    status: string;
+    monetaryValue?: number;
+    contactId: string;
+  };
+  // Campaign events
+  campaign?: {
+    id: string;
+    name: string;
+  };
+  contactId?: string;
+  timestamp?: string;
+}
+
+type WebhookHandler = (event: GHLWebhookEvent) => Promise<void>;
+
+// ========================================
+// EVENT HANDLERS
+// ========================================
+
+const eventHandlers: Record<string, WebhookHandler> = {
+  "ContactCreate": async (event) => {
+    console.log("[GHL Webhook] New contact created:", {
+      contactId: event.contact?.id,
+      name: `${event.contact?.firstName || ""} ${event.contact?.lastName || ""}`.trim(),
+      email: event.contact?.email,
+      source: event.contact?.source,
+      locationId: event.locationId,
+    });
+    // Lead routing logic: tag-based routing happens in GHL workflows,
+    // but we log and can trigger internal automations here
+  },
+
+  "ContactUpdate": async (event) => {
+    console.log("[GHL Webhook] Contact updated:", {
+      contactId: event.contact?.id,
+      locationId: event.locationId,
+    });
+  },
+
+  "ContactTagUpdate": async (event) => {
+    console.log("[GHL Webhook] Contact tags changed:", {
+      contactId: event.contact?.id,
+      tags: event.contact?.tags,
+      locationId: event.locationId,
+    });
+  },
+
+  "OpportunityCreate": async (event) => {
+    console.log("[GHL Webhook] New opportunity:", {
+      opportunityId: event.opportunity?.id,
+      name: event.opportunity?.name,
+      pipelineId: event.opportunity?.pipelineId,
+      stageId: event.opportunity?.pipelineStageId,
+      contactId: event.opportunity?.contactId,
+      value: event.opportunity?.monetaryValue,
+      locationId: event.locationId,
+    });
+  },
+
+  "OpportunityStageUpdate": async (event) => {
+    console.log("[GHL Webhook] Opportunity stage changed:", {
+      opportunityId: event.opportunity?.id,
+      newStage: event.opportunity?.pipelineStageId,
+      status: event.opportunity?.status,
+      locationId: event.locationId,
+    });
+  },
+
+  "OpportunityStatusUpdate": async (event) => {
+    console.log("[GHL Webhook] Opportunity status changed:", {
+      opportunityId: event.opportunity?.id,
+      status: event.opportunity?.status,
+      locationId: event.locationId,
+    });
+  },
+
+  "CampaignStatusUpdate": async (event) => {
+    console.log("[GHL Webhook] Campaign status update:", {
+      campaignId: event.campaign?.id,
+      contactId: event.contactId,
+      locationId: event.locationId,
+    });
+  },
+};
+
+// ========================================
+// SIGNATURE VERIFICATION
+// ========================================
+
+function verifyWebhookSignature(
+  body: string,
+  signature: string | undefined,
+  secret: string
+): boolean {
+  if (!signature || !secret) return !secret; // Skip if no secret configured
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(body)
+    .digest("hex");
+  return crypto.timingSafeEqual(
+    Buffer.from(signature),
+    Buffer.from(expected)
+  );
+}
+
+// ========================================
+// POST /api/ghl/webhooks/inbound
+// ========================================
+
+webhookRouter.post("/inbound", express.text({ type: "*/*" }), async (req: Request, res: Response) => {
+  const webhookSecret = process.env.GHL_WEBHOOK_SECRET;
+  const signature = req.headers["x-ghl-signature"] as string | undefined;
+  const rawBody = typeof req.body === "string" ? req.body : JSON.stringify(req.body);
+
+  // Verify signature if secret is configured
+  if (webhookSecret && !verifyWebhookSignature(rawBody, signature, webhookSecret)) {
+    console.warn("[GHL Webhook] Invalid signature, rejecting");
+    res.status(401).json({ error: "Invalid webhook signature" });
+    return;
+  }
+
+  let event: GHLWebhookEvent;
+  try {
+    event = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+  } catch {
+    console.error("[GHL Webhook] Failed to parse body");
+    res.status(400).json({ error: "Invalid JSON body" });
+    return;
+  }
+
+  const eventType = event.type;
+  if (!eventType) {
+    console.warn("[GHL Webhook] Missing event type");
+    res.status(400).json({ error: "Missing event type" });
+    return;
+  }
+
+  console.log(`[GHL Webhook] Received event: ${eventType}`, {
+    locationId: event.locationId,
+    timestamp: event.timestamp || new Date().toISOString(),
+  });
+
+  // Respond immediately (GHL expects quick 200)
+  res.status(200).json({ received: true, type: eventType });
+
+  // Process event asynchronously
+  const handler = eventHandlers[eventType];
+  if (handler) {
+    try {
+      await handler(event);
+    } catch (err) {
+      console.error(`[GHL Webhook] Error handling ${eventType}:`, err);
+    }
+  } else {
+    console.log(`[GHL Webhook] No handler for event type: ${eventType}`);
+  }
+});
+
+// ========================================
+// HEALTH CHECK
+// ========================================
+
+webhookRouter.get("/health", (_req: Request, res: Response) => {
+  res.json({
+    status: "ok",
+    service: "ghl-webhooks",
+    configured: !!process.env.GHL_WEBHOOK_SECRET,
+    supportedEvents: Object.keys(eventHandlers),
+    timestamp: new Date().toISOString(),
+  });
+});
+
+export default webhookRouter;

--- a/server/lib/circuitBreaker.ts
+++ b/server/lib/circuitBreaker.ts
@@ -425,4 +425,11 @@ export const circuitBreakers = {
     monitoringWindowMs: 60000, // 1 minute window
     successThreshold: 2,
   }),
+
+  orgo: circuitBreakerRegistry.getOrCreate('orgo', {
+    failureThreshold: 5,
+    resetTimeoutMs: 60000, // 1 minute
+    monitoringWindowMs: 60000, // 1 minute window
+    successThreshold: 2,
+  }),
 };

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -43,6 +43,7 @@ import { agentTrainingRouter } from "./api/routers/agentTraining";
 import { costsRouter } from "./api/routers/costs";
 import { pipelinesRouter } from "./api/routers/pipelines";
 import { ghlRouter } from "./api/routers/ghl";
+import { orgoRouter } from "./api/routers/orgo";
 import { publicProcedure, router } from "./_core/trpc";
 
 export const appRouter = router({
@@ -142,6 +143,9 @@ export const appRouter = router({
 
   // GHL OAuth & Connection Management (AI-2877)
   ghl: ghlRouter,
+
+  // Orgo Compute Provider (desktop VM infrastructure)
+  orgo: orgoRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/server/services/agentBrowserTools.ts
+++ b/server/services/agentBrowserTools.ts
@@ -1356,3 +1356,349 @@ export function registerBrowserTools(toolRegistry: Map<string, Function>): void 
 export function getBrowserToolDefinitions(): Anthropic.Tool[] {
   return browserToolDefinitions;
 }
+
+// ========================================
+// ORGO DESKTOP VM TOOLS
+// ========================================
+
+/**
+ * Orgo-backed tool implementations.
+ * These map the agent's browser-tool interface to Orgo desktop VM operations,
+ * allowing the agent orchestrator to swap BrowserBase for Orgo when
+ * COMPUTE_PROVIDER=orgo is configured.
+ */
+export const orgoTools = {
+  /**
+   * Create a new Orgo desktop VM session.
+   */
+  orgo_create_session: async (params: {
+    userId?: number;
+    executionId?: number;
+    cpu?: number;
+    ramMb?: number;
+    diskGb?: number;
+  }): Promise<{
+    success: boolean;
+    sessionId?: string;
+    computerId?: string;
+    error?: string;
+  }> => {
+    try {
+      const { orgoComputeProvider } = await import('./orgoComputeProvider');
+      const result = await orgoComputeProvider.createSession({
+        userId: params.userId,
+        executionId: params.executionId,
+        specs: {
+          cpu: params.cpu,
+          ramMb: params.ramMb,
+          diskGb: params.diskGb,
+        },
+      });
+      return { success: true, ...result };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to create Orgo session',
+      };
+    }
+  },
+
+  /**
+   * Navigate to a URL by launching Chromium inside the desktop VM.
+   */
+  orgo_navigate: async (params: {
+    sessionId: string;
+    url: string;
+  }): Promise<{
+    success: boolean;
+    error?: string;
+  }> => {
+    try {
+      const { orgoComputeProvider } = await import('./orgoComputeProvider');
+      await orgoComputeProvider.navigate(params.sessionId, params.url);
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Navigation failed',
+      };
+    }
+  },
+
+  /**
+   * Take a screenshot of the desktop VM and return base64-encoded PNG.
+   */
+  orgo_screenshot: async (params: {
+    sessionId: string;
+  }): Promise<{
+    success: boolean;
+    base64?: string;
+    error?: string;
+  }> => {
+    try {
+      const { orgoComputeProvider } = await import('./orgoComputeProvider');
+      const base64 = await orgoComputeProvider.screenshot(params.sessionId);
+      return { success: true, base64 };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Screenshot failed',
+      };
+    }
+  },
+
+  /**
+   * Click at absolute desktop coordinates.
+   */
+  orgo_click: async (params: {
+    sessionId: string;
+    x: number;
+    y: number;
+  }): Promise<{
+    success: boolean;
+    error?: string;
+  }> => {
+    try {
+      const { orgoComputeProvider } = await import('./orgoComputeProvider');
+      await orgoComputeProvider.click(params.sessionId, params.x, params.y);
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Click failed',
+      };
+    }
+  },
+
+  /**
+   * Type text into the currently focused element.
+   */
+  orgo_type: async (params: {
+    sessionId: string;
+    text: string;
+  }): Promise<{
+    success: boolean;
+    error?: string;
+  }> => {
+    try {
+      const { orgoComputeProvider } = await import('./orgoComputeProvider');
+      await orgoComputeProvider.type(params.sessionId, params.text);
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Type failed',
+      };
+    }
+  },
+
+  /**
+   * Execute a shell command inside the desktop VM.
+   */
+  orgo_exec: async (params: {
+    sessionId: string;
+    command: string;
+  }): Promise<{
+    success: boolean;
+    exitCode?: number;
+    stdout?: string;
+    stderr?: string;
+    error?: string;
+  }> => {
+    try {
+      const { orgoComputeProvider } = await import('./orgoComputeProvider');
+      // Retrieve computerId from the session registry via provider internal access
+      const status = await orgoComputeProvider.getSessionStatus(params.sessionId);
+      if (!status.computerId) {
+        return { success: false, error: 'Session not found or no computerId' };
+      }
+      const { orgoClient } = await import('../_core/orgoClient');
+      const result = await orgoClient.bash(status.computerId, params.command);
+      return {
+        success: result.exitCode === 0,
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Exec failed',
+      };
+    }
+  },
+
+  /**
+   * Destroy the Orgo desktop VM session and release resources.
+   */
+  orgo_close_session: async (params: {
+    sessionId: string;
+  }): Promise<{
+    success: boolean;
+    error?: string;
+  }> => {
+    try {
+      const { orgoComputeProvider } = await import('./orgoComputeProvider');
+      await orgoComputeProvider.destroySession(params.sessionId);
+      return { success: true };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to close Orgo session',
+      };
+    }
+  },
+};
+
+/**
+ * Anthropic tool definitions for Orgo desktop VM tools.
+ * Register these with the agent orchestrator when COMPUTE_PROVIDER=orgo.
+ */
+export function getOrgoToolDefinitions(): Anthropic.Tool[] {
+  return [
+    {
+      name: 'orgo_create_session',
+      description: 'Create a new Orgo desktop VM session for automation. The VM runs a full Linux desktop (Xvfb + Fluxbox) with a browser. Returns a sessionId for subsequent operations.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          userId: {
+            type: 'number',
+            description: 'Optional user ID to associate with the session',
+          },
+          executionId: {
+            type: 'number',
+            description: 'Optional execution ID to associate with the session',
+          },
+          cpu: {
+            type: 'number',
+            description: 'Number of CPU cores to allocate (default: 2)',
+          },
+          ramMb: {
+            type: 'number',
+            description: 'RAM in megabytes to allocate (default: 2048)',
+          },
+          diskGb: {
+            type: 'number',
+            description: 'Disk size in gigabytes (default: 20)',
+          },
+        },
+        required: [],
+      },
+    },
+    {
+      name: 'orgo_navigate',
+      description: 'Navigate the desktop VM browser to a URL. Launches Chromium in the VM pointing at the target URL.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          sessionId: {
+            type: 'string',
+            description: 'The Orgo session ID',
+          },
+          url: {
+            type: 'string',
+            description: 'The URL to navigate to',
+          },
+        },
+        required: ['sessionId', 'url'],
+      },
+    },
+    {
+      name: 'orgo_screenshot',
+      description: 'Take a screenshot of the current state of the desktop VM. Returns a base64-encoded PNG image showing everything visible on the desktop.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          sessionId: {
+            type: 'string',
+            description: 'The Orgo session ID',
+          },
+        },
+        required: ['sessionId'],
+      },
+    },
+    {
+      name: 'orgo_click',
+      description: 'Click at specific pixel coordinates on the desktop VM screen. Use orgo_screenshot first to determine the correct coordinates.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          sessionId: {
+            type: 'string',
+            description: 'The Orgo session ID',
+          },
+          x: {
+            type: 'number',
+            description: 'X coordinate (pixels from left edge)',
+          },
+          y: {
+            type: 'number',
+            description: 'Y coordinate (pixels from top edge)',
+          },
+        },
+        required: ['sessionId', 'x', 'y'],
+      },
+    },
+    {
+      name: 'orgo_type',
+      description: 'Type text into the currently focused element on the desktop VM. Ensure the target element is focused (via orgo_click) before typing.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          sessionId: {
+            type: 'string',
+            description: 'The Orgo session ID',
+          },
+          text: {
+            type: 'string',
+            description: 'Text to type',
+          },
+        },
+        required: ['sessionId', 'text'],
+      },
+    },
+    {
+      name: 'orgo_exec',
+      description: 'Execute a bash shell command inside the desktop VM. Useful for running scripts, checking state, or automating tasks that are easier via the shell than via the GUI.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          sessionId: {
+            type: 'string',
+            description: 'The Orgo session ID',
+          },
+          command: {
+            type: 'string',
+            description: 'Shell command to execute (runs as bash -c)',
+          },
+        },
+        required: ['sessionId', 'command'],
+      },
+    },
+    {
+      name: 'orgo_close_session',
+      description: 'Destroy the Orgo desktop VM session and release all compute resources. Always call this when the automation task is complete.',
+      input_schema: {
+        type: 'object' as const,
+        properties: {
+          sessionId: {
+            type: 'string',
+            description: 'The Orgo session ID to close',
+          },
+        },
+        required: ['sessionId'],
+      },
+    },
+  ];
+}
+
+/**
+ * Register Orgo tools with the agent orchestrator's tool registry.
+ * Call this instead of registerBrowserTools when COMPUTE_PROVIDER=orgo.
+ */
+export function registerOrgoTools(toolRegistry: Map<string, Function>): void {
+  for (const [name, handler] of Object.entries(orgoTools)) {
+    toolRegistry.set(name, handler);
+  }
+}

--- a/server/services/ghl.service.ts
+++ b/server/services/ghl.service.ts
@@ -187,6 +187,37 @@ export interface GHLWorkflow {
   locationId: string;
 }
 
+export interface GHLMessage {
+  id: string;
+  conversationId: string;
+  contactId: string;
+  locationId: string;
+  body?: string;
+  type: "SMS" | "Email" | "TYPE_CALL" | "TYPE_LIVE_CHAT" | "TYPE_ACTIVITY_CONTACT";
+  direction: "inbound" | "outbound";
+  status: "pending" | "sent" | "delivered" | "read" | "failed" | "undelivered";
+  dateAdded?: string;
+  messageType?: string;
+  source?: string;
+  contentType?: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface GHLEmailAttachment {
+  url: string;
+  name?: string;
+}
+
+export interface GHLTemplate {
+  id: string;
+  name: string;
+  type: "sms" | "email" | "whatsapp";
+  body?: string;
+  subject?: string;
+  locationId: string;
+  dateAdded?: string;
+}
+
 // ========================================
 // TOKEN BUCKET RATE LIMITER
 // ========================================
@@ -1018,6 +1049,88 @@ export class GHLService {
       method: "GET",
       endpoint: "/workflows/",
       params: { locationId: this.locationId },
+    });
+  }
+
+  // ----------------------------------------
+  // Messaging / Communication (AI-5149)
+  // ----------------------------------------
+
+  /**
+   * Send an SMS message to a contact via GHL Conversations API.
+   */
+  async sendSMS(
+    contactId: string,
+    message: string
+  ): Promise<GHLApiResponse<{ messageId: string; message: GHLMessage }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/conversations/messages",
+      data: {
+        type: "SMS",
+        contactId,
+        message,
+      },
+    });
+  }
+
+  /**
+   * Send an email to a contact via GHL Conversations API.
+   */
+  async sendEmail(
+    contactId: string,
+    data: {
+      subject: string;
+      html: string;
+      emailFrom?: string;
+      emailTo?: string;
+      emailReplyTo?: string;
+      templateId?: string;
+      attachments?: GHLEmailAttachment[];
+    }
+  ): Promise<GHLApiResponse<{ messageId: string; message: GHLMessage }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/conversations/messages",
+      data: {
+        type: "Email",
+        contactId,
+        ...data,
+      },
+    });
+  }
+
+  /**
+   * Get message delivery status by message ID.
+   */
+  async getMessageStatus(
+    messageId: string
+  ): Promise<GHLApiResponse<{ message: GHLMessage }>> {
+    return this.request({
+      method: "GET",
+      endpoint: `/conversations/messages/${messageId}`,
+    });
+  }
+
+  /**
+   * List email/SMS templates for this location.
+   */
+  async listTemplates(params?: {
+    type?: "sms" | "email" | "whatsapp";
+    limit?: number;
+    offset?: number;
+  }): Promise<GHLApiResponse<{ templates: GHLTemplate[]; total: number }>> {
+    const searchParams: Record<string, string> = {
+      locationId: this.locationId,
+      ...(params?.type ? { type: params.type } : {}),
+      ...(params?.limit ? { limit: String(params.limit) } : {}),
+      ...(params?.offset ? { offset: String(params.offset) } : {}),
+    };
+
+    return this.request({
+      method: "GET",
+      endpoint: "/conversations/templates",
+      params: searchParams,
     });
   }
 

--- a/server/services/ghl.service.ts
+++ b/server/services/ghl.service.ts
@@ -8,8 +8,10 @@
  * - Base HTTP client with retry (3 attempts, exponential backoff)
  * - Error categorization (auth errors vs rate limits vs server errors)
  * - Multi-location support
+ * - Full CRM API coverage: contacts, pipelines, campaigns, workflows,
+ *   communications, and appointments
  *
- * Linear: AI-2877
+ * Linear: AI-2877, AI-3461
  */
 
 import { getCredentialVault } from "./credentialVault.service";
@@ -265,6 +267,114 @@ export interface GHLBulkImportResult {
   imported: number;
   failed: number;
   errors: Array<{ index: number; error: string }>;
+}
+
+// ========================================
+// CRM TYPES
+// ========================================
+
+export interface GHLContact {
+  id: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  tags?: string[];
+  locationId?: string;
+  companyName?: string;
+  [key: string]: unknown;
+}
+
+export interface GHLContactsResponse {
+  contacts: GHLContact[];
+  total?: number;
+  count?: number;
+  meta?: Record<string, unknown>;
+}
+
+export interface GHLOpportunity {
+  id: string;
+  name: string;
+  status: string;
+  pipelineId: string;
+  pipelineStageId?: string;
+  contactId?: string;
+  monetaryValue?: number;
+  assignedTo?: string;
+  [key: string]: unknown;
+}
+
+export interface GHLPipeline {
+  id: string;
+  name: string;
+  stages?: Array<{ id: string; name: string }>;
+  [key: string]: unknown;
+}
+
+export interface GHLCampaign {
+  id: string;
+  name: string;
+  status?: string;
+  type?: string;
+  [key: string]: unknown;
+}
+
+export interface GHLWorkflow {
+  id: string;
+  name: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface GHLCustomField {
+  id: string;
+  name: string;
+  fieldKey?: string;
+  dataType?: string;
+  [key: string]: unknown;
+}
+
+export interface GHLTag {
+  id: string;
+  name: string;
+  [key: string]: unknown;
+}
+
+export interface GHLMessage {
+  id: string;
+  type: string;
+  status?: string;
+  contactId?: string;
+  conversationId?: string;
+  body?: string;
+  [key: string]: unknown;
+}
+
+export interface GHLTemplate {
+  id: string;
+  name: string;
+  type?: string;
+  body?: string;
+  subject?: string;
+  [key: string]: unknown;
+}
+
+export interface GHLAppointment {
+  id: string;
+  calendarId: string;
+  contactId?: string;
+  startTime: string;
+  endTime: string;
+  title?: string;
+  notes?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface GHLAvailabilitySlot {
+  startTime: string;
+  endTime: string;
+  [key: string]: unknown;
 }
 
 // ========================================
@@ -1473,6 +1583,509 @@ export class GHLService {
           scopes: metadata.scope ? metadata.scope.split(" ") : [],
         };
       });
+  }
+
+  // ----------------------------------------
+  // Contact CRUD
+  // ----------------------------------------
+
+  /**
+   * Search contacts by query string.
+   */
+  async searchContacts(
+    query: string,
+    limit = 20
+  ): Promise<GHLContactsResponse> {
+    const res = await this.request<GHLContactsResponse>({
+      method: "GET",
+      endpoint: "/contacts/",
+      params: {
+        locationId: this.locationId,
+        query,
+        limit: String(limit),
+      },
+    });
+    return res.data;
+  }
+
+  /**
+   * Get a single contact by ID.
+   */
+  async getContact(contactId: string): Promise<GHLContact> {
+    const res = await this.request<{ contact: GHLContact }>({
+      method: "GET",
+      endpoint: `/contacts/${contactId}`,
+    });
+    return res.data.contact;
+  }
+
+  /**
+   * Create a new contact in this location.
+   */
+  async createContact(data: Partial<GHLContact>): Promise<GHLContact> {
+    const res = await this.request<{ contact: GHLContact }>({
+      method: "POST",
+      endpoint: "/contacts/",
+      data: { ...data, locationId: this.locationId },
+    });
+    return res.data.contact;
+  }
+
+  /**
+   * Update an existing contact.
+   */
+  async updateContact(
+    contactId: string,
+    data: Partial<GHLContact>
+  ): Promise<GHLContact> {
+    const res = await this.request<{ contact: GHLContact }>({
+      method: "PUT",
+      endpoint: `/contacts/${contactId}`,
+      data,
+    });
+    return res.data.contact;
+  }
+
+  /**
+   * Add tags to a contact.
+   */
+  async addTags(contactId: string, tags: string[]): Promise<GHLContact> {
+    const res = await this.request<{ contact: GHLContact }>({
+      method: "POST",
+      endpoint: `/contacts/${contactId}/tags`,
+      data: { tags },
+    });
+    return res.data.contact;
+  }
+
+  /**
+   * Remove tags from a contact.
+   */
+  async removeTags(contactId: string, tags: string[]): Promise<GHLContact> {
+    const res = await this.request<{ contact: GHLContact }>({
+      method: "DELETE",
+      endpoint: `/contacts/${contactId}/tags`,
+      data: { tags },
+    });
+    return res.data.contact;
+  }
+
+  // ----------------------------------------
+  // Contact bulk operations
+  // ----------------------------------------
+
+  /**
+   * Bulk import contacts into this location.
+   */
+  async bulkImportContacts(
+    contacts: Array<{
+      firstName?: string;
+      lastName?: string;
+      email?: string;
+      phone?: string;
+      tags?: string[];
+    }>
+  ): Promise<{ succeeded: number; failed: number; contacts?: GHLContact[] }> {
+    const res = await this.request<{
+      succeeded: number;
+      failed: number;
+      contacts?: GHLContact[];
+    }>({
+      method: "POST",
+      endpoint: "/contacts/bulk",
+      data: { locationId: this.locationId, contacts },
+    });
+    return res.data;
+  }
+
+  /**
+   * Export contacts with optional filters.
+   */
+  async bulkExportContacts(
+    filters?: Record<string, string>
+  ): Promise<GHLContact[]> {
+    const res = await this.request<{ contacts: GHLContact[] }>({
+      method: "GET",
+      endpoint: "/contacts/export",
+      params: { locationId: this.locationId, ...(filters ?? {}) },
+    });
+    return res.data.contacts ?? [];
+  }
+
+  /**
+   * Merge duplicate contacts into a primary contact.
+   */
+  async mergeContacts(
+    primaryId: string,
+    duplicateIds: string[]
+  ): Promise<GHLContact> {
+    const res = await this.request<{ contact: GHLContact }>({
+      method: "POST",
+      endpoint: `/contacts/${primaryId}/merge`,
+      data: { duplicateIds },
+    });
+    return res.data.contact;
+  }
+
+  /**
+   * Get activity/tasks for a contact.
+   */
+  async getContactActivity(
+    contactId: string
+  ): Promise<{ tasks: unknown[] }> {
+    const res = await this.request<{ tasks: unknown[] }>({
+      method: "GET",
+      endpoint: `/contacts/${contactId}/tasks`,
+    });
+    return res.data;
+  }
+
+  /**
+   * List all custom fields for this location.
+   */
+  async getCustomFields(): Promise<{ customFields: GHLCustomField[] }> {
+    const res = await this.request<{ customFields: GHLCustomField[] }>({
+      method: "GET",
+      endpoint: `/locations/${this.locationId}/customFields`,
+    });
+    return res.data;
+  }
+
+  /**
+   * List all contact tags for this location.
+   */
+  async listContactTags(): Promise<{ tags: GHLTag[] }> {
+    const res = await this.request<{ tags: GHLTag[] }>({
+      method: "GET",
+      endpoint: `/locations/${this.locationId}/tags`,
+    });
+    return res.data;
+  }
+
+  // ----------------------------------------
+  // Pipeline / Opportunity
+  // ----------------------------------------
+
+  /**
+   * List all pipelines for this location.
+   */
+  async listPipelines(): Promise<{ pipelines: GHLPipeline[] }> {
+    const res = await this.request<{ pipelines: GHLPipeline[] }>({
+      method: "GET",
+      endpoint: "/opportunities/pipelines",
+      params: { locationId: this.locationId },
+    });
+    return res.data;
+  }
+
+  /**
+   * Search opportunities by query, optionally filtered by pipeline.
+   */
+  async searchOpportunities(
+    query: string,
+    pipelineId?: string
+  ): Promise<{ opportunities: GHLOpportunity[] }> {
+    const params: Record<string, string> = {
+      locationId: this.locationId,
+      query,
+    };
+    if (pipelineId) params.pipelineId = pipelineId;
+
+    const res = await this.request<{ opportunities: GHLOpportunity[] }>({
+      method: "GET",
+      endpoint: "/opportunities/search",
+      params,
+    });
+    return res.data;
+  }
+
+  /**
+   * Create a new opportunity in a pipeline.
+   */
+  async createOpportunity(
+    data: Partial<GHLOpportunity>
+  ): Promise<GHLOpportunity> {
+    const res = await this.request<{ opportunity: GHLOpportunity }>({
+      method: "POST",
+      endpoint: "/opportunities/",
+      data: { ...data, locationId: this.locationId },
+    });
+    return res.data.opportunity;
+  }
+
+  /**
+   * Update an existing opportunity.
+   */
+  async updateOpportunity(
+    opportunityId: string,
+    data: Partial<GHLOpportunity>
+  ): Promise<GHLOpportunity> {
+    const res = await this.request<{ opportunity: GHLOpportunity }>({
+      method: "PUT",
+      endpoint: `/opportunities/${opportunityId}`,
+      data,
+    });
+    return res.data.opportunity;
+  }
+
+  // ----------------------------------------
+  // Campaigns
+  // ----------------------------------------
+
+  /**
+   * List all campaigns for this location.
+   */
+  async listCampaigns(): Promise<{ campaigns: GHLCampaign[] }> {
+    const res = await this.request<{ campaigns: GHLCampaign[] }>({
+      method: "GET",
+      endpoint: "/campaigns/",
+      params: { locationId: this.locationId },
+    });
+    return res.data;
+  }
+
+  /**
+   * Add a contact to a campaign.
+   */
+  async addContactToCampaign(
+    campaignId: string,
+    contactId: string
+  ): Promise<unknown> {
+    const res = await this.request<unknown>({
+      method: "POST",
+      endpoint: `/campaigns/${campaignId}/contacts/${contactId}`,
+    });
+    return res.data;
+  }
+
+  /**
+   * Remove a contact from a campaign.
+   */
+  async removeContactFromCampaign(
+    campaignId: string,
+    contactId: string
+  ): Promise<unknown> {
+    const res = await this.request<unknown>({
+      method: "DELETE",
+      endpoint: `/campaigns/${campaignId}/contacts/${contactId}`,
+    });
+    return res.data;
+  }
+
+  /**
+   * Get stats for a specific campaign.
+   */
+  async getCampaignStats(campaignId: string): Promise<unknown> {
+    const res = await this.request<unknown>({
+      method: "GET",
+      endpoint: `/campaigns/${campaignId}/stats`,
+    });
+    return res.data;
+  }
+
+  /**
+   * Create a new campaign.
+   */
+  async createCampaign(data: {
+    name: string;
+    type?: string;
+    [key: string]: unknown;
+  }): Promise<GHLCampaign> {
+    const res = await this.request<{ campaign: GHLCampaign }>({
+      method: "POST",
+      endpoint: "/campaigns/",
+      data: { ...data, locationId: this.locationId },
+    });
+    return res.data.campaign;
+  }
+
+  // ----------------------------------------
+  // Workflows
+  // ----------------------------------------
+
+  /**
+   * List all workflows for this location.
+   */
+  async listWorkflows(): Promise<{ workflows: GHLWorkflow[] }> {
+    const res = await this.request<{ workflows: GHLWorkflow[] }>({
+      method: "GET",
+      endpoint: "/workflows/",
+      params: { locationId: this.locationId },
+    });
+    return res.data;
+  }
+
+  /**
+   * Trigger a workflow for a specific contact, with optional custom data.
+   */
+  async triggerWorkflow(
+    workflowId: string,
+    data: { contactId: string; [key: string]: unknown }
+  ): Promise<unknown> {
+    const res = await this.request<unknown>({
+      method: "POST",
+      endpoint: `/workflows/${workflowId}/trigger`,
+      data,
+    });
+    return res.data;
+  }
+
+  // ----------------------------------------
+  // Communications
+  // ----------------------------------------
+
+  /**
+   * Send an SMS message to a contact.
+   */
+  async sendSMS(contactId: string, message: string): Promise<GHLMessage> {
+    const res = await this.request<{ message: GHLMessage }>({
+      method: "POST",
+      endpoint: "/conversations/messages",
+      data: {
+        type: "SMS",
+        contactId,
+        message,
+        locationId: this.locationId,
+      },
+    });
+    return res.data.message;
+  }
+
+  /**
+   * Send an email to a contact, optionally using a template.
+   */
+  async sendEmail(
+    contactId: string,
+    subject: string,
+    body: string,
+    templateId?: string
+  ): Promise<GHLMessage> {
+    const payload: Record<string, unknown> = {
+      type: "Email",
+      contactId,
+      subject,
+      body,
+      locationId: this.locationId,
+    };
+    if (templateId) payload.templateId = templateId;
+
+    const res = await this.request<{ message: GHLMessage }>({
+      method: "POST",
+      endpoint: "/conversations/messages",
+      data: payload,
+    });
+    return res.data.message;
+  }
+
+  /**
+   * Get the delivery status of a message.
+   */
+  async getMessageStatus(messageId: string): Promise<GHLMessage> {
+    const res = await this.request<{ message: GHLMessage }>({
+      method: "GET",
+      endpoint: `/conversations/messages/${messageId}`,
+    });
+    return res.data.message;
+  }
+
+  /**
+   * List message templates for this location, optionally filtered by type.
+   */
+  async listTemplates(
+    type?: "sms" | "email"
+  ): Promise<{ templates: GHLTemplate[] }> {
+    const params: Record<string, string> = {};
+    if (type) params.type = type;
+
+    const res = await this.request<{ templates: GHLTemplate[] }>({
+      method: "GET",
+      endpoint: `/locations/${this.locationId}/templates`,
+      params,
+    });
+    return res.data;
+  }
+
+  // ----------------------------------------
+  // Appointments
+  // ----------------------------------------
+
+  /**
+   * Create a new appointment/calendar event.
+   */
+  async createAppointment(data: {
+    calendarId: string;
+    contactId: string;
+    startTime: string;
+    endTime: string;
+    title?: string;
+    notes?: string;
+  }): Promise<GHLAppointment> {
+    const res = await this.request<{ event: GHLAppointment }>({
+      method: "POST",
+      endpoint: "/calendars/events",
+      data: { ...data, locationId: this.locationId },
+    });
+    return res.data.event;
+  }
+
+  /**
+   * Get a calendar event by ID.
+   */
+  async getAppointment(eventId: string): Promise<GHLAppointment> {
+    const res = await this.request<{ event: GHLAppointment }>({
+      method: "GET",
+      endpoint: `/calendars/events/${eventId}`,
+    });
+    return res.data.event;
+  }
+
+  /**
+   * Update a calendar event.
+   */
+  async updateAppointment(
+    eventId: string,
+    data: Partial<{
+      calendarId: string;
+      contactId: string;
+      startTime: string;
+      endTime: string;
+      title: string;
+      notes: string;
+    }>
+  ): Promise<GHLAppointment> {
+    const res = await this.request<{ event: GHLAppointment }>({
+      method: "PUT",
+      endpoint: `/calendars/events/${eventId}`,
+      data,
+    });
+    return res.data.event;
+  }
+
+  /**
+   * Delete a calendar event.
+   */
+  async deleteAppointment(eventId: string): Promise<{ success: boolean }> {
+    await this.request<unknown>({
+      method: "DELETE",
+      endpoint: `/calendars/events/${eventId}`,
+    });
+    return { success: true };
+  }
+
+  /**
+   * Get available time slots for a calendar in a date range.
+   */
+  async getAvailability(
+    calendarId: string,
+    startDate: string,
+    endDate: string
+  ): Promise<{ slots: GHLAvailabilitySlot[] }> {
+    const res = await this.request<{ slots: GHLAvailabilitySlot[] }>({
+      method: "GET",
+      endpoint: `/calendars/${calendarId}/free-slots`,
+      params: { startDate, endDate, locationId: this.locationId },
+    });
+    return res.data;
   }
 }
 

--- a/server/services/ghl.service.ts
+++ b/server/services/ghl.service.ts
@@ -218,6 +218,55 @@ export interface GHLTemplate {
   dateAdded?: string;
 }
 
+export interface GHLCustomField {
+  id: string;
+  name: string;
+  fieldKey: string;
+  dataType: string;
+  position: number;
+  placeholder?: string;
+  isAllowedCustomOption?: boolean;
+  options?: string[];
+}
+
+export interface GHLTag {
+  id: string;
+  name: string;
+  locationId: string;
+}
+
+export interface GHLNote {
+  id: string;
+  body: string;
+  contactId: string;
+  dateAdded: string;
+  userId?: string;
+}
+
+export interface GHLTask {
+  id: string;
+  title: string;
+  body?: string;
+  contactId: string;
+  dueDate?: string;
+  completed: boolean;
+  dateAdded: string;
+  assignedTo?: string;
+}
+
+export interface GHLActivityEvent {
+  type: "note" | "task" | "appointment" | "conversation";
+  id: string;
+  timestamp: string;
+  data: GHLNote | GHLTask | Record<string, unknown>;
+}
+
+export interface GHLBulkImportResult {
+  imported: number;
+  failed: number;
+  errors: Array<{ index: number; error: string }>;
+}
+
 // ========================================
 // TOKEN BUCKET RATE LIMITER
 // ========================================
@@ -908,6 +957,256 @@ export class GHLService {
       method: "DELETE",
       endpoint: `/contacts/${contactId}/tags`,
       data: { tags },
+    });
+  }
+
+  // ----------------------------------------
+  // Bulk Contact Operations (AI-5148)
+  // ----------------------------------------
+
+  /**
+   * Bulk import contacts in batches of 100. Returns summary of imported/failed.
+   */
+  async bulkImport(
+    contacts: Array<{
+      firstName?: string;
+      lastName?: string;
+      email?: string;
+      phone?: string;
+      tags?: string[];
+      customFields?: Array<{ id: string; value: string }>;
+      source?: string;
+    }>
+  ): Promise<GHLBulkImportResult> {
+    const BATCH_SIZE = 100;
+    const result: GHLBulkImportResult = { imported: 0, failed: 0, errors: [] };
+
+    for (let i = 0; i < contacts.length; i += BATCH_SIZE) {
+      const batch = contacts.slice(i, i + BATCH_SIZE);
+      const settled = await Promise.allSettled(
+        batch.map((contact, batchIdx) =>
+          this.createContact(contact).then(
+            () => ({ index: i + batchIdx, ok: true as const }),
+            (err: unknown) => ({
+              index: i + batchIdx,
+              ok: false as const,
+              error: err instanceof Error ? err.message : String(err),
+            })
+          )
+        )
+      );
+
+      for (const item of settled) {
+        if (item.status === "fulfilled") {
+          if (item.value.ok) {
+            result.imported++;
+          } else {
+            result.failed++;
+            result.errors.push({ index: item.value.index, error: item.value.error });
+          }
+        } else {
+          result.failed++;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Export contacts matching filters as an array of flat objects (CSV-ready).
+   * Paginates through all results up to the given limit.
+   */
+  async bulkExport(params: {
+    query?: string;
+    filters?: Record<string, string>;
+    maxRecords?: number;
+  }): Promise<{ contacts: GHLContact[]; total: number }> {
+    const maxRecords = params.maxRecords || 10000;
+    const pageSize = 100;
+    const allContacts: GHLContact[] = [];
+    let offset = 0;
+    let hasMore = true;
+
+    while (hasMore && allContacts.length < maxRecords) {
+      const result = await this.searchContacts({
+        query: params.query,
+        limit: pageSize,
+        offset,
+        filters: params.filters,
+      });
+      const contacts = result.data.contacts || [];
+      allContacts.push(...contacts);
+
+      if (contacts.length < pageSize || allContacts.length >= maxRecords) {
+        hasMore = false;
+      }
+      offset += pageSize;
+    }
+
+    return {
+      contacts: allContacts.slice(0, maxRecords),
+      total: allContacts.length,
+    };
+  }
+
+  /**
+   * Merge duplicate contacts into a primary contact.
+   * Copies non-empty fields from duplicates to primary (primary fields take precedence),
+   * merges tags, then deletes duplicates.
+   */
+  async mergeContacts(
+    primaryId: string,
+    duplicateIds: string[]
+  ): Promise<{
+    primaryContact: GHLContact;
+    mergedCount: number;
+    deletedIds: string[];
+  }> {
+    // 1. Fetch primary contact
+    const primaryResult = await this.getContact(primaryId);
+    const primary = primaryResult.data.contact;
+
+    // 2. Fetch all duplicates
+    const duplicateResults = await Promise.all(
+      duplicateIds.map((id) => this.getContact(id))
+    );
+    const duplicates = duplicateResults.map((r) => r.data.contact);
+
+    // 3. Build merged field values (primary wins, fill in blanks from duplicates)
+    const mergedTags = new Set<string>(primary.tags || []);
+    const mergedCustomFields = new Map<string, string>();
+    (primary.customFields || []).forEach((f) => mergedCustomFields.set(f.id, f.value));
+
+    const updateData: Record<string, string | undefined> = {};
+
+    for (const dup of duplicates) {
+      if (!primary.firstName && dup.firstName) updateData.firstName = dup.firstName;
+      if (!primary.lastName && dup.lastName) updateData.lastName = dup.lastName;
+      if (!primary.email && dup.email) updateData.email = dup.email;
+      if (!primary.phone && dup.phone) updateData.phone = dup.phone;
+      (dup.tags || []).forEach((t) => mergedTags.add(t));
+      (dup.customFields || []).forEach((f) => {
+        if (!mergedCustomFields.has(f.id)) mergedCustomFields.set(f.id, f.value);
+      });
+    }
+
+    // 4. Update primary with merged data
+    const finalCustomFields = Array.from(mergedCustomFields.entries()).map(([id, value]) => ({
+      id,
+      value,
+    }));
+    await this.updateContact(primaryId, {
+      ...updateData,
+      tags: Array.from(mergedTags),
+      customFields: finalCustomFields,
+    });
+
+    // 5. Delete duplicates
+    const deletedIds: string[] = [];
+    for (const dupId of duplicateIds) {
+      try {
+        await this.deleteContact(dupId);
+        deletedIds.push(dupId);
+      } catch {
+        // Log but continue — partial merge is still useful
+        console.warn(`[GHL] Failed to delete duplicate contact ${dupId}`);
+      }
+    }
+
+    // 6. Fetch updated primary
+    const updatedResult = await this.getContact(primaryId);
+
+    return {
+      primaryContact: updatedResult.data.contact,
+      mergedCount: duplicates.length,
+      deletedIds,
+    };
+  }
+
+  /**
+   * Delete a contact by ID.
+   */
+  async deleteContact(contactId: string): Promise<GHLApiResponse<unknown>> {
+    return this.request({
+      method: "DELETE",
+      endpoint: `/contacts/${contactId}`,
+    });
+  }
+
+  /**
+   * Get activity timeline for a contact (notes, tasks, appointments).
+   */
+  async getContactActivity(
+    contactId: string
+  ): Promise<GHLActivityEvent[]> {
+    const [notesResult, tasksResult] = await Promise.all([
+      this.request<{ notes: GHLNote[] }>({
+        method: "GET",
+        endpoint: `/contacts/${contactId}/notes`,
+      }).catch(() => ({ data: { notes: [] }, status: 200, rateLimit: { remaining: null, reset: null, limit: null } })),
+      this.request<{ tasks: GHLTask[] }>({
+        method: "GET",
+        endpoint: `/contacts/${contactId}/tasks`,
+      }).catch(() => ({ data: { tasks: [] }, status: 200, rateLimit: { remaining: null, reset: null, limit: null } })),
+    ]);
+
+    const events: GHLActivityEvent[] = [];
+
+    for (const note of notesResult.data.notes || []) {
+      events.push({
+        type: "note",
+        id: note.id,
+        timestamp: note.dateAdded,
+        data: note,
+      });
+    }
+
+    for (const task of tasksResult.data.tasks || []) {
+      events.push({
+        type: "task",
+        id: task.id,
+        timestamp: task.dateAdded,
+        data: task,
+      });
+    }
+
+    // Sort by timestamp descending (most recent first)
+    events.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+
+    return events;
+  }
+
+  /**
+   * List custom fields for this location.
+   */
+  async getCustomFields(): Promise<GHLApiResponse<{ customFields: GHLCustomField[] }>> {
+    return this.request({
+      method: "GET",
+      endpoint: `/locations/${this.locationId}/customFields`,
+    });
+  }
+
+  /**
+   * Update a single custom field value on a contact.
+   */
+  async updateContactCustomField(
+    contactId: string,
+    fieldId: string,
+    value: string
+  ): Promise<GHLApiResponse<{ contact: GHLContact }>> {
+    return this.updateContact(contactId, {
+      customFields: [{ id: fieldId, value }],
+    });
+  }
+
+  /**
+   * List all tags for this location.
+   */
+  async listTags(): Promise<GHLApiResponse<{ tags: GHLTag[] }>> {
+    return this.request({
+      method: "GET",
+      endpoint: `/locations/${this.locationId}/tags`,
     });
   }
 

--- a/server/services/ghl.service.ts
+++ b/server/services/ghl.service.ts
@@ -134,6 +134,59 @@ export interface GHLLocation {
   email?: string;
 }
 
+export interface GHLContact {
+  id: string;
+  locationId: string;
+  firstName?: string;
+  lastName?: string;
+  name?: string;
+  email?: string;
+  phone?: string;
+  tags?: string[];
+  source?: string;
+  dateAdded?: string;
+  customFields?: Array<{ id: string; value: string }>;
+}
+
+export interface GHLPipeline {
+  id: string;
+  name: string;
+  locationId: string;
+  stages: Array<{
+    id: string;
+    name: string;
+    position: number;
+  }>;
+}
+
+export interface GHLOpportunity {
+  id: string;
+  name: string;
+  pipelineId: string;
+  pipelineStageId: string;
+  status: "open" | "won" | "lost" | "abandoned";
+  monetaryValue?: number;
+  contactId: string;
+  locationId: string;
+  createdAt?: string;
+  updatedAt?: string;
+  customFields?: Array<{ id: string; value: string }>;
+}
+
+export interface GHLCampaign {
+  id: string;
+  name: string;
+  status: string;
+  locationId: string;
+}
+
+export interface GHLWorkflow {
+  id: string;
+  name: string;
+  status: string;
+  locationId: string;
+}
+
 // ========================================
 // TOKEN BUCKET RATE LIMITER
 // ========================================
@@ -716,6 +769,256 @@ export class GHLService {
     console.log(
       `[GHL] Disconnected location ${this.locationId} for user ${this.userId}`
     );
+  }
+
+  // ----------------------------------------
+  // Contact / Lead Management
+  // ----------------------------------------
+
+  /**
+   * Search contacts with optional filters.
+   */
+  async searchContacts(params: {
+    query?: string;
+    limit?: number;
+    offset?: number;
+    filters?: Record<string, string>;
+  }): Promise<GHLApiResponse<{ contacts: GHLContact[]; total: number }>> {
+    const searchParams: Record<string, string> = {
+      locationId: this.locationId,
+      ...(params.query ? { query: params.query } : {}),
+      ...(params.limit ? { limit: String(params.limit) } : {}),
+      ...(params.offset ? { startAfter: String(params.offset) } : {}),
+      ...(params.filters || {}),
+    };
+
+    return this.request({
+      method: "GET",
+      endpoint: "/contacts/",
+      params: searchParams,
+    });
+  }
+
+  /**
+   * Get a single contact by ID.
+   */
+  async getContact(contactId: string): Promise<GHLApiResponse<{ contact: GHLContact }>> {
+    return this.request({
+      method: "GET",
+      endpoint: `/contacts/${contactId}`,
+    });
+  }
+
+  /**
+   * Create a new contact in GHL.
+   */
+  async createContact(data: {
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+    phone?: string;
+    tags?: string[];
+    customFields?: Array<{ id: string; value: string }>;
+    source?: string;
+  }): Promise<GHLApiResponse<{ contact: GHLContact }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/contacts/",
+      data: {
+        ...data,
+        locationId: this.locationId,
+      },
+    });
+  }
+
+  /**
+   * Update an existing contact.
+   */
+  async updateContact(
+    contactId: string,
+    data: {
+      firstName?: string;
+      lastName?: string;
+      email?: string;
+      phone?: string;
+      tags?: string[];
+      customFields?: Array<{ id: string; value: string }>;
+    }
+  ): Promise<GHLApiResponse<{ contact: GHLContact }>> {
+    return this.request({
+      method: "PUT",
+      endpoint: `/contacts/${contactId}`,
+      data,
+    });
+  }
+
+  /**
+   * Add tags to a contact (used for lead routing).
+   */
+  async addContactTags(
+    contactId: string,
+    tags: string[]
+  ): Promise<GHLApiResponse<{ tags: string[] }>> {
+    return this.request({
+      method: "POST",
+      endpoint: `/contacts/${contactId}/tags`,
+      data: { tags },
+    });
+  }
+
+  /**
+   * Remove tags from a contact.
+   */
+  async removeContactTags(
+    contactId: string,
+    tags: string[]
+  ): Promise<GHLApiResponse<unknown>> {
+    return this.request({
+      method: "DELETE",
+      endpoint: `/contacts/${contactId}/tags`,
+      data: { tags },
+    });
+  }
+
+  // ----------------------------------------
+  // Pipeline / Opportunity Management
+  // ----------------------------------------
+
+  /**
+   * List all pipelines for this location.
+   */
+  async listPipelines(): Promise<GHLApiResponse<{ pipelines: GHLPipeline[] }>> {
+    return this.request({
+      method: "GET",
+      endpoint: "/opportunities/pipelines",
+      params: { locationId: this.locationId },
+    });
+  }
+
+  /**
+   * Search opportunities (deals) with filters.
+   */
+  async searchOpportunities(params: {
+    pipelineId?: string;
+    stageId?: string;
+    status?: "open" | "won" | "lost" | "abandoned" | "all";
+    query?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<GHLApiResponse<{ opportunities: GHLOpportunity[]; meta: { total: number } }>> {
+    const searchParams: Record<string, string> = {
+      location_id: this.locationId,
+      ...(params.pipelineId ? { pipeline_id: params.pipelineId } : {}),
+      ...(params.stageId ? { stage_id: params.stageId } : {}),
+      ...(params.status && params.status !== "all" ? { status: params.status } : {}),
+      ...(params.query ? { q: params.query } : {}),
+      ...(params.limit ? { limit: String(params.limit) } : {}),
+      ...(params.offset ? { startAfter: String(params.offset) } : {}),
+    };
+
+    return this.request({
+      method: "GET",
+      endpoint: "/opportunities/search",
+      params: searchParams,
+    });
+  }
+
+  /**
+   * Create a new opportunity (deal/showing request).
+   */
+  async createOpportunity(data: {
+    pipelineId: string;
+    stageId: string;
+    contactId: string;
+    name: string;
+    monetaryValue?: number;
+    status?: "open" | "won" | "lost" | "abandoned";
+    customFields?: Array<{ id: string; value: string }>;
+  }): Promise<GHLApiResponse<{ opportunity: GHLOpportunity }>> {
+    return this.request({
+      method: "POST",
+      endpoint: "/opportunities/",
+      data: {
+        ...data,
+        locationId: this.locationId,
+      },
+    });
+  }
+
+  /**
+   * Update an opportunity (move stage, change status, etc.).
+   */
+  async updateOpportunity(
+    opportunityId: string,
+    data: {
+      stageId?: string;
+      status?: "open" | "won" | "lost" | "abandoned";
+      monetaryValue?: number;
+      name?: string;
+      customFields?: Array<{ id: string; value: string }>;
+    }
+  ): Promise<GHLApiResponse<{ opportunity: GHLOpportunity }>> {
+    return this.request({
+      method: "PUT",
+      endpoint: `/opportunities/${opportunityId}`,
+      data,
+    });
+  }
+
+  // ----------------------------------------
+  // Campaign / Drip Management
+  // ----------------------------------------
+
+  /**
+   * List all campaigns for this location.
+   */
+  async listCampaigns(): Promise<GHLApiResponse<{ campaigns: GHLCampaign[] }>> {
+    return this.request({
+      method: "GET",
+      endpoint: "/campaigns/",
+      params: { locationId: this.locationId },
+    });
+  }
+
+  /**
+   * Add a contact to a campaign (drip sequence).
+   */
+  async addContactToCampaign(
+    campaignId: string,
+    contactId: string
+  ): Promise<GHLApiResponse<unknown>> {
+    return this.request({
+      method: "POST",
+      endpoint: `/campaigns/${campaignId}/contacts/${contactId}`,
+    });
+  }
+
+  /**
+   * Remove a contact from a campaign.
+   */
+  async removeContactFromCampaign(
+    campaignId: string,
+    contactId: string
+  ): Promise<GHLApiResponse<unknown>> {
+    return this.request({
+      method: "DELETE",
+      endpoint: `/campaigns/${campaignId}/contacts/${contactId}`,
+    });
+  }
+
+  // ----------------------------------------
+  // Workflow Triggers
+  // ----------------------------------------
+
+  /**
+   * List available workflows for this location.
+   */
+  async listWorkflows(): Promise<GHLApiResponse<{ workflows: GHLWorkflow[] }>> {
+    return this.request({
+      method: "GET",
+      endpoint: "/workflows/",
+      params: { locationId: this.locationId },
+    });
   }
 
   // ----------------------------------------

--- a/server/services/orgoComputeProvider.ts
+++ b/server/services/orgoComputeProvider.ts
@@ -1,0 +1,266 @@
+/**
+ * Orgo Compute Provider Service
+ *
+ * Bridges Orgo desktop VMs into the agent system as an alternative compute
+ * provider to BrowserBase. When ORGO_API_KEY is set and
+ * COMPUTE_PROVIDER=orgo, this provider is used instead of BrowserBase.
+ *
+ * Session management maps the BrowserBase "session" concept to Orgo
+ * "computer" lifecycle. Browser navigation is handled by launching
+ * Chromium inside the desktop VM via shell commands.
+ *
+ * Env vars:
+ *   COMPUTE_PROVIDER   — 'orgo' | 'browserbase' (default: 'browserbase')
+ *   ORGO_API_KEY       — enables Orgo (required for provider to activate)
+ *   ORGO_API_URL       — Orgo base URL (default: http://localhost:3100)
+ *   ORGO_WORKSPACE_ID  — default workspace
+ */
+
+import { orgoClient, type Computer, type ChatResponse } from '../_core/orgoClient';
+
+// ========================================
+// TYPES
+// ========================================
+
+export type ComputeProviderType = 'orgo' | 'browserbase';
+
+export interface SessionCreateOptions {
+  userId?: number;
+  executionId?: number;
+  specs?: {
+    cpu?: number;
+    ramMb?: number;
+    diskGb?: number;
+    gpu?: boolean;
+  };
+}
+
+export interface SessionInfo {
+  sessionId: string;
+  computerId: string;
+  status: string;
+  createdAt: Date;
+}
+
+export interface AgentLoopOptions {
+  computerId: string;
+  model: string;
+  prompt: string;
+  maxSteps?: number;
+}
+
+// ========================================
+// SESSION REGISTRY
+// Simple in-process map; for production use a distributed store
+// ========================================
+
+const sessionRegistry = new Map<string, SessionInfo>();
+
+function generateSessionId(): string {
+  return `orgo_sess_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+// ========================================
+// PROVIDER CLASS
+// ========================================
+
+export class OrgoComputeProvider {
+  private static instance: OrgoComputeProvider;
+
+  private constructor() {}
+
+  public static getInstance(): OrgoComputeProvider {
+    if (!OrgoComputeProvider.instance) {
+      OrgoComputeProvider.instance = new OrgoComputeProvider();
+    }
+    return OrgoComputeProvider.instance;
+  }
+
+  // ----------------------------------------
+  // Session management
+  // ----------------------------------------
+
+  /**
+   * Create a new compute session backed by an Orgo desktop VM.
+   * The computer is created and started before returning.
+   */
+  public async createSession(opts: SessionCreateOptions = {}): Promise<{
+    sessionId: string;
+    computerId: string;
+  }> {
+    const name = `bb-agent-${opts.userId ?? 'anon'}-${opts.executionId ?? Date.now()}`;
+
+    console.log('[OrgoComputeProvider] Creating session:', name);
+
+    const computer = await orgoClient.createComputer({
+      name,
+      cpu: opts.specs?.cpu,
+      ramMb: opts.specs?.ramMb,
+      diskGb: opts.specs?.diskGb,
+      gpu: opts.specs?.gpu,
+    });
+
+    // Start the computer if it's not already running
+    if (computer.status !== 'running') {
+      await orgoClient.startComputer(computer.id);
+    }
+
+    const sessionId = generateSessionId();
+    const sessionInfo: SessionInfo = {
+      sessionId,
+      computerId: computer.id,
+      status: 'running',
+      createdAt: new Date(),
+    };
+
+    sessionRegistry.set(sessionId, sessionInfo);
+
+    console.log('[OrgoComputeProvider] Session created:', sessionId, '-> computer:', computer.id);
+
+    return { sessionId, computerId: computer.id };
+  }
+
+  /**
+   * Destroy a session and its underlying Orgo computer.
+   */
+  public async destroySession(sessionId: string): Promise<void> {
+    const session = sessionRegistry.get(sessionId);
+    if (!session) {
+      console.warn('[OrgoComputeProvider] destroySession: session not found:', sessionId);
+      return;
+    }
+
+    try {
+      await orgoClient.destroyComputer(session.computerId);
+    } catch (err) {
+      console.error('[OrgoComputeProvider] Failed to destroy computer:', session.computerId, err);
+    }
+
+    sessionRegistry.delete(sessionId);
+    console.log('[OrgoComputeProvider] Session destroyed:', sessionId);
+  }
+
+  /**
+   * Get the current status of a session.
+   */
+  public async getSessionStatus(sessionId: string): Promise<{
+    status: string;
+    computerId: string;
+  }> {
+    const session = sessionRegistry.get(sessionId);
+    if (!session) {
+      return { status: 'not_found', computerId: '' };
+    }
+
+    try {
+      const computer = await orgoClient.getComputer(session.computerId);
+      return { status: computer.status, computerId: computer.id };
+    } catch {
+      return { status: 'unknown', computerId: session.computerId };
+    }
+  }
+
+  // ----------------------------------------
+  // Browser-like actions (maps to Orgo desktop)
+  // ----------------------------------------
+
+  /**
+   * Navigate to a URL by launching Chromium inside the desktop VM.
+   * Uses --no-sandbox and kiosk mode to open the URL in a full-screen browser.
+   */
+  public async navigate(sessionId: string, url: string): Promise<void> {
+    const session = this.requireSession(sessionId);
+
+    console.log('[OrgoComputeProvider] Navigating to:', url);
+
+    // Kill any existing browser instance and open URL in Chromium
+    await orgoClient.bash(session.computerId, [
+      'pkill -f chromium-browser 2>/dev/null || true',
+      'pkill -f google-chrome 2>/dev/null || true',
+      `DISPLAY=:0 chromium-browser --no-sandbox --disable-gpu --start-maximized "${url}" &`,
+      'sleep 2',
+    ].join(' && '));
+  }
+
+  /**
+   * Get a base64-encoded PNG screenshot of the desktop.
+   */
+  public async screenshot(sessionId: string): Promise<string> {
+    const session = this.requireSession(sessionId);
+    const result = await orgoClient.screenshot(session.computerId);
+    return result.data;
+  }
+
+  /**
+   * Click at absolute desktop coordinates.
+   */
+  public async click(sessionId: string, x: number, y: number): Promise<void> {
+    const session = this.requireSession(sessionId);
+    await orgoClient.click(session.computerId, x, y, 'left');
+  }
+
+  /**
+   * Type text into the currently focused element.
+   */
+  public async type(sessionId: string, text: string): Promise<void> {
+    const session = this.requireSession(sessionId);
+    await orgoClient.type(session.computerId, text);
+  }
+
+  // ----------------------------------------
+  // Agent loop integration
+  // ----------------------------------------
+
+  /**
+   * Run the Orgo computer-use agent loop via the OpenAI-compatible
+   * /v1/chat/completions endpoint, which auto-executes tool calls
+   * against the target computer.
+   */
+  public async runAgentLoop(opts: AgentLoopOptions): Promise<ChatResponse> {
+    console.log('[OrgoComputeProvider] Running agent loop on computer:', opts.computerId);
+
+    return orgoClient.chatCompletion({
+      model: opts.model,
+      messages: [
+        {
+          role: 'user',
+          content: opts.prompt,
+        },
+      ],
+      computerId: opts.computerId,
+      autoExecuteTools: true,
+    });
+  }
+
+  // ----------------------------------------
+  // Internal helpers
+  // ----------------------------------------
+
+  private requireSession(sessionId: string): SessionInfo {
+    const session = sessionRegistry.get(sessionId);
+    if (!session) {
+      throw new Error(`OrgoComputeProvider: session not found: ${sessionId}`);
+    }
+    return session;
+  }
+}
+
+// ========================================
+// FACTORY / PROVIDER SELECTION
+// ========================================
+
+/**
+ * Determine which compute provider to use based on env config.
+ * Returns 'orgo' when COMPUTE_PROVIDER=orgo AND ORGO_API_KEY is set.
+ * Falls back to 'browserbase' in all other cases.
+ */
+export function getComputeProvider(): ComputeProviderType {
+  const configured = process.env.COMPUTE_PROVIDER?.toLowerCase();
+  if (configured === 'orgo' && process.env.ORGO_API_KEY) {
+    return 'orgo';
+  }
+  return 'browserbase';
+}
+
+// Export singleton instance
+export const orgoComputeProvider = OrgoComputeProvider.getInstance();


### PR DESCRIPTION
## Summary
- **Full GHL CRM API layer** — 30+ tRPC endpoints covering contacts (CRUD, bulk import/export, merge, tags), pipelines/opportunities, campaigns, workflows, appointments, SMS/email communications
- **Production webhook handlers** — DB sync, SHA-256 dedup, dead letter queue with retry, structured pino logging
- **Frontend CRM screens** — contacts browser, pipeline Kanban board, campaign manager, webhook event log
- **Orgo Clone integration** — self-hosted desktop VM compute provider as alternative to BrowserBase, with full agent tool definitions and session management
- **Drizzle schema** — 4 new tables for webhook processing (contacts, opportunities, events, dead letters)

## Orgo Configuration
Set these env vars to activate Orgo as the compute provider:
```
COMPUTE_PROVIDER=orgo
ORGO_API_URL=http://localhost:3100
ORGO_API_KEY=sk_live_...
ORGO_WORKSPACE_ID=<optional>
```

## Linear Issues
- AI-3461 (parent): GHL/CRM Integration
- AI-5146: Commit & merge CRM endpoints
- AI-5147: Webhook handlers with DB sync
- AI-5148: Bulk contact ops
- AI-5149: Communication endpoints
- AI-5213: Integration tests (Day 2)
- AI-5214: Frontend UI screens

## Test plan
- [ ] pnpm build passes clean
- [ ] GHL OAuth flow connects location
- [ ] Contact CRUD via tRPC endpoints
- [ ] Webhook inbound processing + dedup verification
- [ ] DLQ retry endpoint works
- [ ] Frontend screens render and wire to endpoints
- [ ] Orgo health check returns when configured
- [ ] COMPUTE_PROVIDER=orgo routes agent tools to Orgo
- [ ] Integration tests against GHL sandbox (AI-5213)

🤖 Generated with [Claude Code](https://claude.com/claude-code)