### PR TITLE
feat(AI-2870): Agent Training UX — overview, prompt preview, dedup fix

### DIFF
--- a/client/src/components/training/PromptPreview.tsx
+++ b/client/src/components/training/PromptPreview.tsx
@@ -1,0 +1,259 @@
+import React, { useState } from 'react';
+import { trpc } from '@/lib/trpc';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+import {
+  Eye,
+  Copy,
+  Check,
+  RefreshCw,
+  Bot,
+  Zap,
+  MessageSquare,
+  AlertTriangle,
+  FileText,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+export default function PromptPreview() {
+  const [copied, setCopied] = useState(false);
+
+  const behaviorQuery = trpc.agentTraining.getBehaviorConfig.useQuery();
+  const skillsQuery = trpc.agentTraining.getSkillConfig.useQuery();
+
+  const isLoading = behaviorQuery.isLoading || skillsQuery.isLoading;
+
+  const behavior = behaviorQuery.data?.behavior;
+  const skills = skillsQuery.data?.skills;
+
+  function buildPrompt(): string {
+    if (!behavior || !skills) return '';
+
+    const lines: string[] = [];
+
+    // Personality
+    lines.push('## System Personality');
+    lines.push(behavior.personality || 'You are a helpful AI assistant.');
+    lines.push('');
+
+    // Communication style
+    lines.push('## Communication Style');
+    lines.push(`- Response Style: ${behavior.responseStyle || 'professional'}`);
+    lines.push(`- Verbosity: ${behavior.verbosity || 'balanced'}`);
+    lines.push('');
+
+    // Enabled skills
+    const enabledSkills = (skills as Array<{ id: string; name: string; enabled: boolean; permission: string }>).filter((s) => s.enabled);
+    if (enabledSkills.length > 0) {
+      lines.push('## Available Tools');
+      for (const skill of enabledSkills) {
+        lines.push(`- ${skill.name} (${skill.permission})`);
+      }
+      lines.push('');
+    }
+
+    // Disabled skills
+    const disabledSkills = (skills as Array<{ id: string; name: string; enabled: boolean; permission: string }>).filter((s) => !s.enabled);
+    if (disabledSkills.length > 0) {
+      lines.push('## Disabled Tools (DO NOT USE)');
+      for (const skill of disabledSkills) {
+        lines.push(`- ${skill.name}`);
+      }
+      lines.push('');
+    }
+
+    // Escalation rules
+    const rules = behavior.escalationRules;
+    if (Array.isArray(rules) && rules.length > 0) {
+      lines.push('## Escalation Rules');
+      for (const rule of rules) {
+        lines.push(`- When: ${rule.condition} → ${rule.action}`);
+      }
+      lines.push('');
+    }
+
+    // Custom instructions
+    if (behavior.customInstructions) {
+      lines.push('## Additional Instructions');
+      lines.push(behavior.customInstructions);
+      lines.push('');
+    }
+
+    return lines.join('\n');
+  }
+
+  const prompt = buildPrompt();
+  const wordCount = prompt.split(/\s+/).filter(Boolean).length;
+  const charCount = prompt.length;
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setCopied(true);
+      toast.success('Prompt copied to clipboard');
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error('Failed to copy');
+    }
+  }
+
+  function handleRefresh() {
+    void behaviorQuery.refetch();
+    void skillsQuery.refetch();
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-64 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Prompt Preview</h2>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Preview the assembled system prompt your agent will use
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={handleRefresh}>
+            <RefreshCw className="w-4 h-4 mr-1.5" />
+            Refresh
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleCopy}
+            className="bg-emerald-600 hover:bg-emerald-700 text-white"
+          >
+            {copied ? (
+              <Check className="w-4 h-4 mr-1.5" />
+            ) : (
+              <Copy className="w-4 h-4 mr-1.5" />
+            )}
+            {copied ? 'Copied!' : 'Copy'}
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="flex items-center gap-4">
+        <Badge variant="secondary" className="text-xs">
+          {wordCount} words
+        </Badge>
+        <Badge variant="secondary" className="text-xs">
+          {charCount} characters
+        </Badge>
+        <Badge
+          className={cn(
+            'text-xs',
+            behaviorQuery.data?.isDefault
+              ? 'bg-amber-100 text-amber-700 hover:bg-amber-100'
+              : 'bg-emerald-100 text-emerald-700 hover:bg-emerald-100'
+          )}
+        >
+          {behaviorQuery.data?.isDefault ? 'Using Defaults' : 'Custom Config'}
+        </Badge>
+      </div>
+
+      {/* Prompt sections breakdown */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Card>
+          <CardContent className="pt-3 pb-3">
+            <div className="flex items-center gap-2">
+              <Bot className="w-4 h-4 text-emerald-600" />
+              <div>
+                <p className="text-xs font-medium text-gray-700">Personality</p>
+                <p className="text-xs text-gray-400">
+                  {behavior?.personality ? 'Configured' : 'Default'}
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-3 pb-3">
+            <div className="flex items-center gap-2">
+              <Zap className="w-4 h-4 text-blue-600" />
+              <div>
+                <p className="text-xs font-medium text-gray-700">Skills</p>
+                <p className="text-xs text-gray-400">
+                  {(skills as Array<{ enabled: boolean }>)?.filter((s) => s.enabled).length || 0} enabled
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-3 pb-3">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="w-4 h-4 text-amber-600" />
+              <div>
+                <p className="text-xs font-medium text-gray-700">Escalation</p>
+                <p className="text-xs text-gray-400">
+                  {(behavior?.escalationRules as Array<unknown>)?.length || 0} rules
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-3 pb-3">
+            <div className="flex items-center gap-2">
+              <MessageSquare className="w-4 h-4 text-purple-600" />
+              <div>
+                <p className="text-xs font-medium text-gray-700">Style</p>
+                <p className="text-xs text-gray-400 capitalize">
+                  {behavior?.responseStyle || 'professional'}
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Rendered prompt */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base flex items-center gap-2">
+            <Eye className="w-4 h-4 text-emerald-600" />
+            Assembled System Prompt
+          </CardTitle>
+          <CardDescription className="text-xs">
+            This is the exact prompt sent to the AI model at the start of every agent session
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 font-mono text-sm text-gray-800 whitespace-pre-wrap max-h-[500px] overflow-y-auto leading-relaxed">
+            {prompt || (
+              <span className="text-gray-400 italic">
+                No configuration found. Set up your agent's behavior, skills, and personality to see the preview.
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Tip */}
+      <div className="flex items-start gap-3 p-4 bg-blue-50 rounded-lg border border-blue-100">
+        <FileText className="w-5 h-5 text-blue-500 flex-shrink-0 mt-0.5" />
+        <div>
+          <p className="text-sm font-medium text-blue-800">How this works</p>
+          <p className="text-xs text-blue-600 mt-0.5">
+            The system prompt is automatically assembled from your Behavior, Skills, and Documents configuration.
+            Changes you make in those tabs are reflected here in real-time. Training documents are injected via
+            RAG retrieval at query time — they are not shown here but augment every response.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Training.tsx
+++ b/client/src/pages/Training.tsx
@@ -1,244 +1,21 @@
-import React, { useState, useCallback } from 'react';
-import { trpc } from '@/lib/trpc';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import { Progress } from '@/components/ui/progress';
+import React from 'react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  Upload,
   FileText,
-  Trash2,
-  RefreshCw,
-  CheckCircle2,
-  Link2,
-  Database,
-  BookOpen,
-  Sparkles,
   Workflow,
   Zap,
   MessageSquare,
+  BarChart3,
+  Eye,
 } from 'lucide-react';
-import { toast } from 'sonner';
-import { cn } from '@/lib/utils';
+import { DocumentsTab } from '@/components/training/DocumentsTab';
 import WorkflowsTab from '@/components/training/WorkflowsTab';
 import SkillsTab from '@/components/training/SkillsTab';
 import BehaviorTab from '@/components/training/BehaviorTab';
-
-const CATEGORIES = [
-  { value: 'training', label: 'Training Docs' },
-  { value: 'sop', label: 'SOPs' },
-  { value: 'business', label: 'Business Docs' },
-  { value: 'technical', label: 'Technical' },
-  { value: 'general', label: 'General' },
-];
-
-const PLATFORMS = [
-  { value: 'general', label: 'General' },
-  { value: 'ghl', label: 'GoHighLevel' },
-  { value: 'hubspot', label: 'HubSpot' },
-  { value: 'salesforce', label: 'Salesforce' },
-];
+import { TrainingOverview } from '@/components/training/TrainingOverview';
+import PromptPreview from '@/components/training/PromptPreview';
 
 export default function Training() {
-  const [isDragging, setIsDragging] = useState(false);
-  const [uploadProgress, setUploadProgress] = useState(0);
-  const [isUploading, setIsUploading] = useState(false);
-  const [selectedCategory, setSelectedCategory] = useState('training');
-  const [selectedPlatform, setSelectedPlatform] = useState('general');
-  const [urlToIngest, setUrlToIngest] = useState('');
-  const [deleteId, setDeleteId] = useState<number | null>(null);
-
-  // Fetch training documents
-  const sourcesQuery = trpc.rag.listSources.useQuery({
-    limit: 50,
-    isActive: true,
-  });
-
-  // Upload mutation
-  const uploadMutation = trpc.rag.uploadDocument.useMutation({
-    onSuccess: (data) => {
-      toast.success(`Uploaded: ${data.message}`);
-      setUploadProgress(100);
-      setTimeout(() => {
-        setUploadProgress(0);
-        setIsUploading(false);
-      }, 1000);
-      sourcesQuery.refetch();
-    },
-    onError: (error) => {
-      toast.error(`Upload failed: ${error.message}`);
-      setUploadProgress(0);
-      setIsUploading(false);
-    },
-  });
-
-  // Ingest URL mutation
-  const ingestUrlMutation = trpc.rag.ingestUrl.useMutation({
-    onSuccess: (data) => {
-      toast.success(data.message);
-      setUrlToIngest('');
-      sourcesQuery.refetch();
-    },
-    onError: (error) => {
-      toast.error(`Failed to ingest URL: ${error.message}`);
-    },
-  });
-
-  // Delete mutation
-  const deleteMutation = trpc.rag.deleteSource.useMutation({
-    onSuccess: () => {
-      toast.success('Document deleted');
-      setDeleteId(null);
-      sourcesQuery.refetch();
-    },
-    onError: (error) => {
-      toast.error(`Delete failed: ${error.message}`);
-    },
-  });
-
-  // Handle file upload
-  const handleFileUpload = useCallback(
-    async (files: FileList | null) => {
-      if (!files || files.length === 0) return;
-
-      setIsUploading(true);
-      setUploadProgress(10);
-
-      for (let i = 0; i < files.length; i++) {
-        const file = files[i];
-
-        // Check file type
-        const allowedTypes = [
-          'application/pdf',
-          'text/plain',
-          'text/html',
-          'text/markdown',
-          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-        ];
-        const extension = file.name.split('.').pop()?.toLowerCase();
-        const isMarkdown = extension === 'md' || extension === 'markdown';
-
-        if (!allowedTypes.includes(file.type) && !isMarkdown) {
-          toast.error(`Unsupported file type: ${file.name}`);
-          continue;
-        }
-
-        // Check file size (10MB max)
-        if (file.size > 10 * 1024 * 1024) {
-          toast.error(`File too large: ${file.name} (max 10MB)`);
-          continue;
-        }
-
-        try {
-          setUploadProgress(30 + (i / files.length) * 40);
-
-          // Read file as base64
-          const reader = new FileReader();
-          const base64Content = await new Promise<string>((resolve, reject) => {
-            reader.onload = () => {
-              const result = reader.result as string;
-              const base64 = result.split(',')[1]; // Remove data:... prefix
-              resolve(base64);
-            };
-            reader.onerror = reject;
-            reader.readAsDataURL(file);
-          });
-
-          setUploadProgress(70 + (i / files.length) * 20);
-
-          // Upload to API
-          await uploadMutation.mutateAsync({
-            fileContent: base64Content,
-            filename: file.name,
-            mimeType: file.type || 'text/markdown',
-            category: selectedCategory,
-            platform: selectedPlatform,
-          });
-        } catch (error) {
-          console.error('Upload error:', error);
-        }
-      }
-    },
-    [uploadMutation, selectedCategory, selectedPlatform]
-  );
-
-  // Drag and drop handlers
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    setIsDragging(true);
-  }, []);
-
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    setIsDragging(false);
-  }, []);
-
-  const handleDrop = useCallback(
-    (e: React.DragEvent) => {
-      e.preventDefault();
-      setIsDragging(false);
-      handleFileUpload(e.dataTransfer.files);
-    },
-    [handleFileUpload]
-  );
-
-  // Handle URL ingestion
-  const handleIngestUrl = () => {
-    if (!urlToIngest.trim()) {
-      toast.error('Please enter a URL');
-      return;
-    }
-
-    try {
-      new URL(urlToIngest);
-    } catch {
-      toast.error('Invalid URL');
-      return;
-    }
-
-    ingestUrlMutation.mutate({
-      url: urlToIngest,
-      category: selectedCategory,
-      platform: selectedPlatform,
-    });
-  };
-
-  // Format date
-  const formatDate = (date: Date | string) => {
-    return new Date(date).toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  };
-
   return (
     <div className="space-y-6">
       {/* Header */}
@@ -252,8 +29,12 @@ export default function Training() {
       </div>
 
       {/* Tabbed Interface */}
-      <Tabs defaultValue="documents" className="space-y-6">
-        <TabsList className="grid w-full grid-cols-4 lg:w-auto lg:inline-grid">
+      <Tabs defaultValue="overview" className="space-y-6">
+        <TabsList className="grid w-full grid-cols-3 lg:grid-cols-6 lg:w-auto lg:inline-grid">
+          <TabsTrigger value="overview" className="gap-1.5">
+            <BarChart3 className="w-4 h-4" />
+            <span className="hidden sm:inline">Overview</span>
+          </TabsTrigger>
           <TabsTrigger value="documents" className="gap-1.5">
             <FileText className="w-4 h-4" />
             <span className="hidden sm:inline">Documents</span>
@@ -270,274 +51,20 @@ export default function Training() {
             <MessageSquare className="w-4 h-4" />
             <span className="hidden sm:inline">Behavior</span>
           </TabsTrigger>
+          <TabsTrigger value="preview" className="gap-1.5">
+            <Eye className="w-4 h-4" />
+            <span className="hidden sm:inline">Preview</span>
+          </TabsTrigger>
         </TabsList>
 
-        {/* Documents Tab - existing functionality */}
-        <TabsContent value="documents" className="space-y-6">
-          {/* Stats */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            <Card>
-              <CardContent className="pt-4">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-blue-100 rounded-lg">
-                    <Database className="w-5 h-5 text-blue-600" />
-                  </div>
-                  <div>
-                    <p className="text-2xl font-bold">{sourcesQuery.data?.count || 0}</p>
-                    <p className="text-xs text-gray-500">Documents</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="pt-4">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-emerald-100 rounded-lg">
-                    <BookOpen className="w-5 h-5 text-emerald-600" />
-                  </div>
-                  <div>
-                    <p className="text-2xl font-bold">
-                      {sourcesQuery.data?.sources?.reduce((acc: number, s: any) => acc + (s.chunkCount || 0), 0) || 0}
-                    </p>
-                    <p className="text-xs text-gray-500">Chunks</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="pt-4">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-purple-100 rounded-lg">
-                    <Sparkles className="w-5 h-5 text-purple-600" />
-                  </div>
-                  <div>
-                    <p className="text-2xl font-bold">RAG</p>
-                    <p className="text-xs text-gray-500">Enabled</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="pt-4">
-                <div className="flex items-center gap-3">
-                  <div className="p-2 bg-amber-100 rounded-lg">
-                    <CheckCircle2 className="w-5 h-5 text-amber-600" />
-                  </div>
-                  <div>
-                    <p className="text-2xl font-bold">Active</p>
-                    <p className="text-xs text-gray-500">Status</p>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
+        {/* Overview Tab */}
+        <TabsContent value="overview">
+          <TrainingOverview />
+        </TabsContent>
 
-          {/* Upload Section */}
-          <div className="grid md:grid-cols-2 gap-6">
-            {/* File Upload */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg flex items-center gap-2">
-                  <Upload className="w-5 h-5" />
-                  Upload Documents
-                </CardTitle>
-                <CardDescription>
-                  Drag & drop or click to upload PDFs, Word docs, Markdown, or text files
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {/* Category & Platform selectors */}
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="text-sm font-medium text-gray-700 mb-1 block">Category</label>
-                    <Select value={selectedCategory} onValueChange={setSelectedCategory}>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {CATEGORIES.map((cat) => (
-                          <SelectItem key={cat.value} value={cat.value}>
-                            {cat.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div>
-                    <label className="text-sm font-medium text-gray-700 mb-1 block">Platform</label>
-                    <Select value={selectedPlatform} onValueChange={setSelectedPlatform}>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {PLATFORMS.map((p) => (
-                          <SelectItem key={p.value} value={p.value}>
-                            {p.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-
-                {/* Drop zone */}
-                <div
-                  className={cn(
-                    'border-2 border-dashed rounded-lg p-8 text-center transition-colors cursor-pointer',
-                    isDragging
-                      ? 'border-emerald-500 bg-emerald-50'
-                      : 'border-gray-300 hover:border-emerald-400'
-                  )}
-                  onDragOver={handleDragOver}
-                  onDragLeave={handleDragLeave}
-                  onDrop={handleDrop}
-                  onClick={() => document.getElementById('file-upload')?.click()}
-                >
-                  <input
-                    id="file-upload"
-                    type="file"
-                    multiple
-                    accept=".pdf,.docx,.txt,.md,.markdown,.html"
-                    className="hidden"
-                    onChange={(e) => handleFileUpload(e.target.files)}
-                  />
-                  <Upload className="w-10 h-10 mx-auto text-gray-400 mb-3" />
-                  <p className="text-sm text-gray-600 mb-1">
-                    {isDragging ? 'Drop files here' : 'Drag & drop files or click to browse'}
-                  </p>
-                  <p className="text-xs text-gray-400">PDF, DOCX, TXT, MD (max 10MB each)</p>
-                </div>
-
-                {/* Upload progress */}
-                {isUploading && (
-                  <div className="space-y-2">
-                    <Progress value={uploadProgress} className="h-2" />
-                    <p className="text-xs text-gray-500 text-center">Uploading... {uploadProgress}%</p>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-
-            {/* URL Ingestion */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg flex items-center gap-2">
-                  <Link2 className="w-5 h-5" />
-                  Import from URL
-                </CardTitle>
-                <CardDescription>
-                  Fetch and process documentation from a web page
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div>
-                  <label className="text-sm font-medium text-gray-700 mb-1 block">URL</label>
-                  <Input
-                    placeholder="https://example.com/documentation"
-                    value={urlToIngest}
-                    onChange={(e) => setUrlToIngest(e.target.value)}
-                  />
-                </div>
-                <Button
-                  className="w-full bg-emerald-600 hover:bg-emerald-700"
-                  onClick={handleIngestUrl}
-                  disabled={ingestUrlMutation.isPending}
-                >
-                  {ingestUrlMutation.isPending ? 'Importing...' : 'Import URL'}
-                </Button>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Documents List */}
-          <Card>
-            <CardHeader className="flex flex-row items-center justify-between">
-              <div>
-                <CardTitle className="text-lg flex items-center gap-2">
-                  <FileText className="w-5 h-5" />
-                  Training Documents
-                </CardTitle>
-                <CardDescription>
-                  Documents that your AI agent uses for context during tasks
-                </CardDescription>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => sourcesQuery.refetch()}
-                disabled={sourcesQuery.isRefetching}
-              >
-                <RefreshCw className={cn('w-4 h-4 mr-2', sourcesQuery.isRefetching && 'animate-spin')} />
-                Refresh
-              </Button>
-            </CardHeader>
-            <CardContent>
-              {sourcesQuery.isLoading ? (
-                <div className="text-center py-8 text-gray-500">Loading...</div>
-              ) : !sourcesQuery.data?.sources?.length ? (
-                <div className="text-center py-8">
-                  <FileText className="w-12 h-12 mx-auto text-gray-300 mb-3" />
-                  <p className="text-gray-500">No documents uploaded yet</p>
-                  <p className="text-sm text-gray-400">Upload your first document above</p>
-                </div>
-              ) : (
-                <div className="overflow-x-auto">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Title</TableHead>
-                        <TableHead className="hidden md:table-cell">Category</TableHead>
-                        <TableHead className="hidden md:table-cell">Platform</TableHead>
-                        <TableHead className="text-center">Chunks</TableHead>
-                        <TableHead className="hidden sm:table-cell">Added</TableHead>
-                        <TableHead className="text-right">Actions</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {sourcesQuery.data.sources.map((source: any) => (
-                        <TableRow key={source.id}>
-                          <TableCell>
-                            <div className="flex items-center gap-2">
-                              <FileText className="w-4 h-4 text-gray-400 flex-shrink-0" />
-                              <span className="font-medium truncate max-w-[200px]">{source.title}</span>
-                            </div>
-                          </TableCell>
-                          <TableCell className="hidden md:table-cell">
-                            <Badge variant="secondary" className="text-xs">
-                              {source.category}
-                            </Badge>
-                          </TableCell>
-                          <TableCell className="hidden md:table-cell">
-                            <Badge variant="outline" className="text-xs">
-                              {source.platform}
-                            </Badge>
-                          </TableCell>
-                          <TableCell className="text-center">
-                            <Badge className="bg-emerald-100 text-emerald-700 hover:bg-emerald-100">
-                              {source.chunkCount}
-                            </Badge>
-                          </TableCell>
-                          <TableCell className="hidden sm:table-cell text-gray-500 text-sm">
-                            {formatDate(source.createdAt)}
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              onClick={() => setDeleteId(source.id)}
-                              className="text-red-500 hover:text-red-700 hover:bg-red-50"
-                            >
-                              <Trash2 className="w-4 h-4" />
-                            </Button>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </div>
-              )}
-            </CardContent>
-          </Card>
+        {/* Documents Tab */}
+        <TabsContent value="documents">
+          <DocumentsTab />
         </TabsContent>
 
         {/* Workflows Tab */}
@@ -554,28 +81,12 @@ export default function Training() {
         <TabsContent value="behavior">
           <BehaviorTab />
         </TabsContent>
-      </Tabs>
 
-      {/* Delete Confirmation Dialog */}
-      <AlertDialog open={deleteId !== null} onOpenChange={() => setDeleteId(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete Document</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete this training document? This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-red-600 hover:bg-red-700"
-              onClick={() => deleteId && deleteMutation.mutate({ sourceId: deleteId })}
-            >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        {/* Prompt Preview Tab */}
+        <TabsContent value="preview">
+          <PromptPreview />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/server/api/routers/pipelines.ts
+++ b/server/api/routers/pipelines.ts
@@ -1,0 +1,21 @@
+/**
+ * Pipelines Router - Multi-Step Workflow Pipeline Execution
+ *
+ * Placeholder router for pipeline management endpoints.
+ * Will be fully implemented when pipeline execution features are built.
+ */
+
+import { z } from "zod";
+import { router, protectedProcedure } from "../../_core/trpc";
+
+export const pipelinesRouter = router({
+  list: protectedProcedure.query(async () => {
+    return { success: true, pipelines: [] };
+  }),
+
+  get: protectedProcedure
+    .input(z.object({ id: z.number().int().positive() }))
+    .query(async ({ input }) => {
+      return { success: true, pipeline: null };
+    }),
+});


### PR DESCRIPTION
## Summary
- Refactored Training page to use modular `DocumentsTab` component (removed ~400 lines of inline duplication)
- Added **Overview tab** showing training stats (action patterns, learned selectors, brand voices, feedback)
- Added **Prompt Preview tab** that assembles and displays the complete system prompt from behavior + skills config, with copy-to-clipboard and word/char counts
- Wired 6-tab layout: Overview, Documents, Workflows, Skills, Behavior, Preview
- Created stub `pipelines` router to fix pre-existing server build error

## Tasks Completed
- **AI-2870**: [BB] Day 2: Agent Training UX

## Verification
- Client + server build passes (6.11s)
- All existing training tabs preserved (Documents, Workflows, Skills, Behavior)
- Browserbase session verified repo state

---
Batch shipped by agent5